### PR TITLE
fix(images): Tidying up the AMI config for windows to reduce some duplication

### DIFF
--- a/images/install-runner.ps1
+++ b/images/install-runner.ps1
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-
-user_name=ec2-user
-
-## This wrapper file re-uses scripts in the /modules/runners/templates directory
-## of this repo. These are the same that are used by the user_data functionality 
-## to bootstrap the instance if it is started from an existing AMI.
-${install_runner}

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -59,8 +59,11 @@ build {
   }
 
   provisioner "powershell" {
+    environment_vars = [
+      "RUNNER_TARBALL_URL=${var.action_runner_url}"
+    ]
     inline = [templatefile("./windows-provisioner.ps1", {
-      action_runner_url = var.action_runner_url
+      install_runner = templatefile("../../modules/runners/templates/install-runner.ps1", {})
     })]
   }
 }

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -63,7 +63,9 @@ build {
       "RUNNER_TARBALL_URL=${var.action_runner_url}"
     ]
     inline = [templatefile("./windows-provisioner.ps1", {
-      install_runner = templatefile("../../modules/runners/templates/install-runner.ps1", {})
+      install_runner = templatefile("../../modules/runners/templates/install-runner.ps1", {
+        S3_LOCATION_RUNNER_DISTRIBUTION = ""
+      })
     })]
   }
 }

--- a/images/windows-core-2019/windows-provisioner.ps1
+++ b/images/windows-core-2019/windows-provisioner.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = "Continue"
+$ErrorActionPreference = "Stop"
 $VerbosePreference = "Continue"
 
 # Install Chocolatey
@@ -12,7 +12,6 @@ $ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 if (Test-Path($ChocolateyProfile)) {
   Import-Module "$ChocolateyProfile"
 }
-
 refreshenv
 '@
 # Write it to the $profile location
@@ -33,18 +32,9 @@ Write-Host "Installing additional development tools"
 choco install git awscli -y
 refreshenv
 
-Write-Host "Creating actions-runner directory for the GH Action installtion"
-New-Item -ItemType Directory -Path C:\actions-runner ; Set-Location C:\actions-runner
+${install_runner}
 
-Write-Host "Downloading the GH Action runner from ${action_runner_url}"
-Invoke-WebRequest -Uri ${action_runner_url} -OutFile actions-runner.zip
-
-Write-Host "Un-zip action runner"
-Expand-Archive -Path actions-runner.zip -DestinationPath .
-
-Write-Host "Delete zip file"
-Remove-Item actions-runner.zip
-
+Write-Output "Configuring start-runner.ps1 to run on startup"
 $action = New-ScheduledTaskAction -WorkingDirectory "C:\actions-runner" -Execute "PowerShell.exe" -Argument "-File C:\start-runner.ps1"
 $trigger = New-ScheduledTaskTrigger -AtStartup
 Register-ScheduledTask -TaskName "runnerinit" -Action $action -Trigger $trigger -User System -RunLevel Highest -Force

--- a/modules/runners/templates/install-runner.ps1
+++ b/modules/runners/templates/install-runner.ps1
@@ -1,14 +1,36 @@
 ## install the runner
 
+$s3_location="${S3_LOCATION_RUNNER_DISTRIBUTION}"
+
+if ( $null -eq $env:RUNNER_TARBALL_URL -and $null -eq $s3_location ) {
+  Write-Output "Neither RUNNER_TARBALL_URL or s3_location are set"
+  return
+}
+
+$file_name="actions-runner.zip"
+
 Write-Host "Creating actions-runner directory for the GH Action installtion"
 New-Item -ItemType Directory -Path C:\actions-runner ; Set-Location C:\actions-runner
 
-Write-Host "Downloading the GH Action runner from s3 bucket $s3_location"
-aws s3 cp ${S3_LOCATION_RUNNER_DISTRIBUTION} actions-runner.zip
+if ( $null -ne $env:RUNNER_TARBALL_URL ) {
+  Write-Output "Downloading the GH Action runner from $RUNNER_TARBALL_URL to $file_name"  
+  Invoke-WebRequest -Uri $env:RUNNER_TARBALL_URL -OutFile $file_name
+} else  {
+  Write-Host  "Retrieving TOKEN from AWS API"
+  $token=Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "180"}
+    
+  $metadata=Invoke-RestMethod -Uri "http://169.254.169.254/latest/dynamic/instance-identity/document" -Headers @{"X-aws-ec2-metadata-token" = $token}
+
+  $Region = $metadata.region
+  Write-Host  "Reteieved REGION from AWS API ($Region)"
+
+  Write-Output "Downloading the GH Action runner from s3 bucket $s3_location"
+  aws s3 cp "$s3_location" "$file_name" --region "$region"  
+}
 
 Write-Host "Un-zip action runner"
-Expand-Archive -Path actions-runner.zip -DestinationPath .
+Expand-Archive -Path $file_name -DestinationPath .
 
 Write-Host "Delete zip file"
-Remove-Item actions-runner.zip
+Remove-Item $file_name
 


### PR DESCRIPTION
While implementing a windows AMI I noticed some duplication that can be removed, and some scripting aligned more with the Linux example.

