### PR TITLE
Improve example/ubuntu runner run as user data template

### DIFF
--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -15,9 +15,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     unzip
 
-USER_NAME=runners
+USER_NAME=${runner_run_as}
 useradd -m -s /bin/bash $USER_NAME
 USER_ID=$(id -ru $USER_NAME)
+
+# uncomment following line to be able to debug and login as the user via ssm
+# echo -e "test1234\ntest1234" | passwd $USER_NAME
 
 # install and configure cloudwatch logging agent
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -120,6 +120,7 @@ resource "aws_launch_template" "runner" {
       S3_LOCATION_RUNNER_DISTRIBUTION = var.s3_location_runner_binaries
       RUNNER_ARCHITECTURE             = var.runner_architecture
     })
+    runner_run_as   = var.runner_run_as
     post_install    = var.userdata_post_install
     start_runner    = templatefile(local.userdata_start_runner[var.runner_os], {})
     ghes_url        = var.ghes_url


### PR DESCRIPTION
This prevents issues by not aligning the `runner_run_as` variable in terraform with the `USERNAME` used in the `user-data.sh` template.

While upgrading from an older release things have changed and misalignment in the `user-data.sh` template and Terraform `main.tf` occurred in our project. Took a while to figure out and debug finding those changes and updates in the example.

This fix should prevent it for future consumers. Now terraform will fail if the user did not define the `runner_run_as` variable in the `user-data.sh` template, which is more transparent and applies the fail fast fail cheap principle. So as opposed to waiting an debugging the runner when it comes online it will now fail when applying terraform.

cc @gjkamstra