### PR TITLE
Improve example/ubuntu user-data.sh (shellcheck fixes + use apt to install docker)

### DIFF
--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -16,8 +16,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     unzip
 
 USER_NAME=${runner_run_as}
-useradd -m -s /bin/bash $USER_NAME
-USER_ID=$(id -ru $USER_NAME)
+useradd -m -s /bin/bash "$USER_NAME"
+USER_ID=$(id -ru "$USER_NAME")
 
 # uncomment following line to be able to debug and login as the user via ssm
 # echo -e "test1234\ntest1234" | passwd $USER_NAME
@@ -47,27 +47,27 @@ WantedBy=default.target
 
 EOF
 
-echo export XDG_RUNTIME_DIR=/run/user/$USER_ID >>/home/$USER_NAME/.profile
+echo "export XDG_RUNTIME_DIR=/run/user/$USER_ID" >> "/home/$USER_NAME/.profile"
 
 systemctl daemon-reload
 systemctl enable user@UID.service
 systemctl start user@UID.service
 
 curl -fsSL https://get.docker.com/rootless >>/opt/rootless.sh && chmod 755 /opt/rootless.sh
-su -l $USER_NAME -c /opt/rootless.sh
-echo export DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock >>/home/$USER_NAME/.profile
-echo export PATH=/home/$USER_NAME/bin:$PATH >>/home/$USER_NAME/.profile
+su -l "$USER_NAME" -c /opt/rootless.sh
+echo "export DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock" >> "/home/$USER_NAME/.profile"
+echo "export PATH=/home/$USER_NAME/bin:$PATH" >> "/home/$USER_NAME/.profile"
 
 # Run docker service by default
-loginctl enable-linger $USER_NAME
-su -l $USER_NAME -c "systemctl --user enable docker"
+loginctl enable-linger "$USER_NAME"
+su -l "$USER_NAME" -c "systemctl --user enable docker"
 
 ${install_runner}
 
 # config runner for rootless docker
 cd /opt/actions-runner/
-echo DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock >>.env
-echo PATH=/home/$USER_NAME/bin:$PATH >>.env
+echo "DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock" >> .env
+echo "PATH=/home/$USER_NAME/bin:$PATH" >> .env
 
 ${post_install}
 

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -64,6 +64,9 @@ ${install_runner}
 
 ${post_install}
 
-cd /opt/actions-runner
+trap "{ echo 'failed to change directory'; exit 255; }" SIGINT SIGTERM ERR EXIT
+pushd /opt/actions-runner || exit
 
 ${start_runner}
+
+popd || exit

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -15,9 +15,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     unzip
 
-USER_NAME=runners
+USER_NAME=${runner_run_as}
 useradd -m -s /bin/bash $USER_NAME
 USER_ID=$(id -ru $USER_NAME)
+
+# uncomment following line to be able to debug and login as the user via ssm
+# echo -e "test1234\ntest1234" | passwd $USER_NAME
 
 # install and configure cloudwatch logging agent
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -47,16 +47,20 @@ WantedBy=default.target
 
 EOF
 
-echo "export XDG_RUNTIME_DIR=/run/user/$USER_ID" >> "/home/$USER_NAME/.profile"
-
 systemctl daemon-reload
 systemctl enable user@UID.service
 systemctl start user@UID.service
 
 curl -fsSL https://get.docker.com/rootless >>/opt/rootless.sh && chmod 755 /opt/rootless.sh
 su -l "$USER_NAME" -c /opt/rootless.sh
-echo "export DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock" >> "/home/$USER_NAME/.profile"
-echo "export PATH=/home/$USER_NAME/bin:$PATH" >> "/home/$USER_NAME/.profile"
+
+{
+  echo
+  echo "export XDG_RUNTIME_DIR=/run/user/$USER_ID"
+  echo "export DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock"
+  echo "export PATH=/home/$USER_NAME/bin:$PATH"
+  echo
+} >> "/home/$USER_NAME/.profile"
 
 # Run docker service by default
 loginctl enable-linger "$USER_NAME"
@@ -65,9 +69,13 @@ su -l "$USER_NAME" -c "systemctl --user enable docker"
 ${install_runner}
 
 # config runner for rootless docker
-cd /opt/actions-runner/
-echo "DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock" >> .env
-echo "PATH=/home/$USER_NAME/bin:$PATH" >> .env
+{
+  echo
+  echo "XDG_RUNTIME_DIR=/run/user/$USER_ID"
+  echo "DOCKER_HOST=unix:///run/user/$USER_ID/docker.sock"
+  echo "PATH=/home/$USER_NAME/bin:$PATH"
+  echo
+} >> /opt/actions-runner/.env
 
 ${post_install}
 

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -120,6 +120,7 @@ resource "aws_launch_template" "runner" {
       S3_LOCATION_RUNNER_DISTRIBUTION = var.s3_location_runner_binaries
       RUNNER_ARCHITECTURE             = var.runner_architecture
     })
+    runner_run_as   = var.runner_run_as
     post_install    = var.userdata_post_install
     start_runner    = templatefile(local.userdata_start_runner[var.runner_os], {})
     ghes_url        = var.ghes_url


### PR DESCRIPTION
This builds further on #1817 and therefore also contains that change.

This PR resolves some shellcheck issues in `user-data.sh`. As well it takes the same approach to install Docker like now being done in the packer ami build script for `ubuntu-focal`.

The `user-data.sh` still install docker as rootless as was done in the original example.

cc: @gjkamstra