### PR TITLE
chore(ci): update .github/workflows/update-docs.yml to use latest actions/cache

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache


### PR DESCRIPTION
Hi all!

GitHub will be deprecating older versions of `actions/cache` on March 1st, including version `4.0.2` which is used in `.github/workflows/update-docs.yml`. 

This is a quick PR to get that workflow updated to the newest version.

See [GitHub's notice](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) and the [full list of deprecated versions](https://github.com/actions/cache/discussions/1510) for more info.