### PR TITLE
fix(syncer): add default filter with empty prefix due to changes in AWS Provi…

### DIFF
--- a/modules/runner-binaries-syncer/main.tf
+++ b/modules/runner-binaries-syncer/main.tf
@@ -22,6 +22,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_config" {
     id     = "lifecycle_config"
     status = "Enabled"
 
+    filter {
+      prefix = ""
+    }
+
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
     }


### PR DESCRIPTION
…der 5.90.0

In 5.90.0 of the AWS provider they are now providing the warning below. This PR keeps the same functionality while getting rid of the warning.

```
No attribute specified when one (and only one) of [rule[0].prefix.<.filter] is required

This will be an error in a future version of the provider
```