### PR TITLE
fix: not try to tag spot requests when on-demand is set

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -206,18 +206,21 @@ resource "aws_launch_template" "runner" {
     )
   }
 
-  tag_specifications {
-    resource_type = "spot-instances-request"
-    tags = merge(
-      local.tags,
-      {
-        "Name" = format("%s", local.name_runner)
-      },
-      {
-        "ghr:runner_name_prefix" = var.runner_name_prefix
-      },
-      var.runner_ec2_tags
-    )
+  dynamic "tag_specifications" {
+    for_each = var.instance_target_capacity_type == "spot" ? 1 : 0
+    content {
+      resource_type = "spot-instances-request"
+      tags = merge(
+        local.tags,
+        {
+          "Name" = format("%s", local.name_runner)
+        },
+        {
+          "ghr:runner_name_prefix" = var.runner_name_prefix
+        },
+        var.runner_ec2_tags
+      )
+    }
   }
 
   tag_specifications {

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -207,7 +207,7 @@ resource "aws_launch_template" "runner" {
   }
 
   dynamic "tag_specifications" {
-    for_each = var.instance_target_capacity_type == "spot" ? 1 : 0
+    for_each = var.instance_target_capacity_type == "spot" ? [1] : [] # Include the block only if the value is "spot"
     content {
       resource_type = "spot-instances-request"
       tags = merge(


### PR DESCRIPTION
fix #4561
