### PR TITLE
test: find vitest setup file by absolute path

### DIFF
--- a/lambdas/functions/ami-housekeeper/vitest.config.ts
+++ b/lambdas/functions/ami-housekeeper/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],

--- a/lambdas/functions/control-plane/vitest.config.ts
+++ b/lambdas/functions/control-plane/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],

--- a/lambdas/functions/gh-agent-syncer/vitest.config.ts
+++ b/lambdas/functions/gh-agent-syncer/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],

--- a/lambdas/functions/termination-watcher/vitest.config.ts
+++ b/lambdas/functions/termination-watcher/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],

--- a/lambdas/functions/webhook/vitest.config.ts
+++ b/lambdas/functions/webhook/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],

--- a/lambdas/libs/aws-ssm-util/vitest.config.ts
+++ b/lambdas/libs/aws-ssm-util/vitest.config.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'path';
+
 import { mergeConfig } from 'vitest/config';
 import defaultConfig from '../../vitest.base.config';
 
 export default mergeConfig(defaultConfig, {
   test: {
-    setupFiles: ['../../aws-vitest-setup.ts'],
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts'],


### PR DESCRIPTION
I've been struggling with running the tests in Neovim. I was getting

```console
FAIL  functions/control-plane/src/github/client.test.ts [ functions/control-plane/src/github/client.test.ts ]
Error: Failed to load url <root>/../aws-vitest-setup.ts (resolved id: <root>/.../aws-vitest-setup.ts). Does the file exist?
```

(but with absolute paths)

Turns out this was because the tests couldn't be run using `yarn vitest --config-file=lambdas/... path/to/test.test.ts`.

When we resolve the paths using `node:path.resolve()` then this works.
