### PR TITLE
fix: only tag spot requests if no on-demand fallback

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -206,6 +206,10 @@ resource "aws_launch_template" "runner" {
     )
   }
 
+  # We avoid including the "spot-instances-request" tag_specifications block when on_demand_failover_for_errors is defined,
+  # because when using on-demand fallback, the spot instance request resource is not created and thus the tags would not apply.
+  # Additionally, tagging spot requests via the CreateFleetCommand in the Lambda function does not work as expected,
+  # so we rely on Terraform to manage these tags only when spot is exclusively used without on-demand failover.
   dynamic "tag_specifications" {
     for_each = var.instance_target_capacity_type == "spot" && var.enable_on_demand_failover_for_errors == null ? [1] : [] # Include the block only if the value is "spot" and on_demand_failover_for_errors is not enabled
     content {

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -207,7 +207,7 @@ resource "aws_launch_template" "runner" {
   }
 
   dynamic "tag_specifications" {
-    for_each = var.instance_target_capacity_type == "spot" ? [1] : [] # Include the block only if the value is "spot"
+    for_each = var.instance_target_capacity_type == "spot" && var.enable_on_demand_failover_for_errors == null ? [1] : [] # Include the block only if the value is "spot" and on_demand_failover_for_errors is not enabled
     content {
       resource_type = "spot-instances-request"
       tags = merge(

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -211,7 +211,7 @@ resource "aws_launch_template" "runner" {
   # Additionally, tagging spot requests via the CreateFleetCommand in the Lambda function does not work as expected,
   # so we rely on Terraform to manage these tags only when spot is exclusively used without on-demand failover.
   dynamic "tag_specifications" {
-    for_each = var.instance_target_capacity_type == "spot" && var.enable_on_demand_failover_for_errors == null ? [1] : [] # Include the block only if the value is "spot" and on_demand_failover_for_errors is not enabled
+    for_each = var.instance_target_capacity_type == "spot" && length(var.enable_on_demand_failover_for_errors) == 0 ? [1] : [] # Include the block only if the value is "spot" and on_demand_failover_for_errors is not enabled
     content {
       resource_type = "spot-instances-request"
       tags = merge(


### PR DESCRIPTION
Hi,

This PR prevents tagging spot instance requests when an on-demand fallback is configured.

It addresses [my comment on this issue](https://github.com/github-aws-runners/terraform-aws-github-runner/issues/4561#issuecomment-2875651681).

The previous fix was working only if the `instance_target_capacity_type` is set to `on-demand` but not in case of on-demand fallback from a spot request.

This approach isn’t ideal but I didn’t find a cleaner way to cancel the tagging directly in `lambdas/functions/control-plane/src/aws/runners.ts` when the on-demand fallback is triggered.