### PR TITLE
fix: scale down log level

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
@@ -130,7 +130,7 @@ async function removeRunner(ec2runner: RunnerInfo, ghRunnerIds: number[]): Promi
 
       if (statuses.every((status) => status == 204)) {
         await terminateRunner(ec2runner.instanceId);
-        logger.debug(`AWS runner instance '${ec2runner.instanceId}' is terminated and GitHub runner is de-registered.`);
+        logger.info(`AWS runner instance '${ec2runner.instanceId}' is terminated and GitHub runner is de-registered.`);
       } else {
         logger.error(`Failed to de-register GitHub runner: ${statuses}`);
       }


### PR DESCRIPTION
This log is very important to check how many instances are being destroyed because idle for a while. This is also consistent with other logs (else conditions). We've lost time because we though this info was present in info but it was not.

This could have helped us understood that ~646 instances were being destroyed in 2 hours timeframe. So making this MR as it could help others too.