### PR TITLE
fix: Safer chown call in runner scripts for custom AMIs

### DIFF
--- a/modules/runners/templates/install-runner.sh
+++ b/modules/runners/templates/install-runner.sh
@@ -70,5 +70,5 @@ if [[ "$os_id" =~ ^ubuntu.* ]]; then
 fi
 
 echo "Set file ownership of action runner"
-chown -R "$user_name":"$user_name" .
+chown -R "$user_name":"$user_name" /opt/actions-runner
 chown -R "$user_name":"$user_name" /opt/hostedtoolcache

--- a/modules/runners/templates/start-runner.sh
+++ b/modules/runners/templates/start-runner.sh
@@ -190,7 +190,7 @@ if [[ "$run_as" == "root" ]]; then
   export RUNNER_ALLOW_RUNASROOT=1
 fi
 
-chown -R $run_as .
+chown -R $run_as /opt/actions-runner
 
 info_arch=$(uname -p)
 info_os=$( ( lsb_release -ds || cat /etc/*release || uname -om ) 2>/dev/null | head -n1 | cut -d "=" -f2- | tr -d '"')


### PR DESCRIPTION
Updated the install-runner and start-runner scripts to call `chown` on explicit path instead of just using the current directory. 

The current script will work for most users, however, this change will make it more safer and avoid risk of unintended changes. For example, if the `cd /opt/actions-runner` call in the template file (`images/start-runner.sh`) is missed, the script will change owner of the root directory (`/`) instead. 