### PR TITLE
feat: Add workflow URL to EC2 instance tags

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.d.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.d.ts
@@ -43,4 +43,5 @@ export interface RunnerInputParameters {
   amiIdSsmParameterName?: string;
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];
+  workflowUrl?: string;
 }

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -244,6 +244,10 @@ async function createInstances(
     tags.push({ Key: 'ghr:trace_id', Value: traceId! });
   }
 
+  if (runnerParameters.workflowUrl) {
+    tags.push({ Key: 'ghr:workflow_url', Value: runnerParameters.workflowUrl });
+  }
+
   let fleet: CreateFleetResult;
   try {
     // see for spec https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html

--- a/lambdas/functions/webhook/src/runners/dispatch.ts
+++ b/lambdas/functions/webhook/src/runners/dispatch.ts
@@ -37,7 +37,7 @@ async function handleWorkflowJob(
     });
     for (const queue of matcherConfig) {
       if (canRunJob(body.workflow_job.labels, queue.matcherConfig.labelMatchers, queue.matcherConfig.exactMatch)) {
-        await sendActionRequest({
+        const actionRequest = {
           id: body.workflow_job.id,
           repositoryName: body.repository.name,
           repositoryOwner: body.repository.owner.login,
@@ -45,7 +45,11 @@ async function handleWorkflowJob(
           installationId: body.installation?.id ?? 0,
           queueId: queue.id,
           repoOwnerType: body.repository.owner.type,
-        });
+          workflowUrl: body.workflow_job.run_url,
+        };
+        logger.info(`Action request: ${JSON.stringify(actionRequest)}`);
+        await sendActionRequest(actionRequest);
+
         logger.info(`Successfully dispatched job for ${body.repository.full_name} to the queue ${queue.id}`);
         return {
           statusCode: 201,

--- a/lambdas/functions/webhook/src/sqs/index.ts
+++ b/lambdas/functions/webhook/src/sqs/index.ts
@@ -12,6 +12,7 @@ export interface ActionRequestMessage {
   installationId: number;
   queueId: string;
   repoOwnerType: string;
+  workflowUrl?: string;
 }
 
 export interface MatcherConfig {


### PR DESCRIPTION
Add the `workflow_url` to the instance tags so that it's easier to identify which build is being run by the instance.

The property is passed along from the webhook lambda, as part of the SQS event.