### PR TITLE
fix: remove progress and control codes from log output

### DIFF
--- a/modules/runners/templates/install-runner.sh
+++ b/modules/runners/templates/install-runner.sh
@@ -25,16 +25,16 @@ mkdir -p actions-runner && cd actions-runner
 
 if [[ -n "$RUNNER_TARBALL_URL" ]]; then
   echo "Downloading the GH Action runner from $RUNNER_TARBALL_URL to $file_name"
-  curl -o $file_name -L "$RUNNER_TARBALL_URL"
+  curl -s -o $file_name -L "$RUNNER_TARBALL_URL"
 else
   echo "Retrieving TOKEN from AWS API"
-  token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 180")
+  token="$(curl -s -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 180")"
 
-  region=$(curl -f -H "X-aws-ec2-metadata-token: $token" -v http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+  region="$(curl -s -f -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)"
   echo "Retrieved REGION from AWS API ($region)"
 
   echo "Downloading the GH Action runner from s3 bucket $s3_location"
-  aws s3 cp "$s3_location" "$file_name" --region "$region"
+  aws s3 cp "$s3_location" "$file_name" --region "$region" --no-progress
 fi
 
 echo "Un-tar action runner"


### PR DESCRIPTION
This commit removes some not very useful output from the `/var/log/user-data.log` output that looks like this:

```
1 file(s) remaining ^MCompleted 6.2 MiB/214.5 MiB (22.3 MiB/s) with 1
file(s) remaining ^MCompleted 6.5 MiB/214.5 MiB (23.1 MiB/s) with 1
file(s) remaining ^MCompleted 6.8 MiB/214.5 MiB (23.9 MiB/s) with 1
file(s) remaining
```

This goes on for potentially several _screens_ worth of log output.

It also removes a similar progress bar output from the IMDS token fetching, and as a bonus side effect, prevents the token itself from being persisted to the logs.

Finally, quotes are added around some of the values returned by curl to prevent bash from splitting it if there's whitespace in the return value and subsequent unintentional behaviour.