### PR TITLE
fix: start-runner.ps1 set username

### DIFF
--- a/images/windows-core-2019/windows-provisioner.ps1
+++ b/images/windows-core-2019/windows-provisioner.ps1
@@ -22,16 +22,19 @@ Set-Content -Path "$PsHome\Microsoft.PowerShell_profile.ps1" -Value $ChocoProfil
 
 refreshenv
 
-Write-Host "Installing cloudwatch agent..."
+Write-Host "Installing cloudwatch agent, part 1"
 Invoke-WebRequest -Uri https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile C:\amazon-cloudwatch-agent.msi
-$cloudwatchParams = '/i', 'C:\amazon-cloudwatch-agent.msi', '/qn', '/L*v', 'C:\CloudwatchInstall.log'
-Start-Process "msiexec.exe" $cloudwatchParams -Wait -NoNewWindow
-Remove-Item C:\amazon-cloudwatch-agent.msi
 
 # Install dependent tools
 Write-Host "Installing additional development tools"
 choco install git awscli -y
 refreshenv
+
+Write-Host "Installing cloudwatch agent, part 2"
+# Delayed part 2 to ensure the download from part 1 completed and was written to disk
+$cloudwatchParams = '/i', 'C:\amazon-cloudwatch-agent.msi', '/qn', '/L*v', 'C:\CloudwatchInstall.log'
+Start-Process "msiexec.exe" $cloudwatchParams -Wait -NoNewWindow
+Remove-Item C:\amazon-cloudwatch-agent.msi
 
 Write-Host "Creating actions-runner directory for the GH Action installation"
 New-Item -ItemType Directory -Path C:\actions-runner ; Set-Location C:\actions-runner

--- a/images/windows-core-2022/windows-provisioner.ps1
+++ b/images/windows-core-2022/windows-provisioner.ps1
@@ -22,16 +22,19 @@ Set-Content -Path "$PsHome\Microsoft.PowerShell_profile.ps1" -Value $ChocoProfil
 
 refreshenv
 
-Write-Host "Installing cloudwatch agent..."
+Write-Host "Installing cloudwatch agent, part 1"
 Invoke-WebRequest -Uri https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile C:\amazon-cloudwatch-agent.msi
-$cloudwatchParams = '/i', 'C:\amazon-cloudwatch-agent.msi', '/qn', '/L*v', 'C:\CloudwatchInstall.log'
-Start-Process "msiexec.exe" $cloudwatchParams -Wait -NoNewWindow
-Remove-Item C:\amazon-cloudwatch-agent.msi
 
 # Install dependent tools
 Write-Host "Installing additional development tools"
 choco install git awscli -y
 refreshenv
+
+Write-Host "Installing cloudwatch agent, part 2"
+# Delayed part 2 to ensure the download from part 1 completed and was written to disk
+$cloudwatchParams = '/i', 'C:\amazon-cloudwatch-agent.msi', '/qn', '/L*v', 'C:\CloudwatchInstall.log'
+Start-Process "msiexec.exe" $cloudwatchParams -Wait -NoNewWindow
+Remove-Item C:\amazon-cloudwatch-agent.msi
 
 Write-Host "Creating actions-runner directory for the GH Action installation"
 New-Item -ItemType Directory -Path C:\actions-runner ; Set-Location C:\actions-runner

--- a/modules/runners/templates/start-runner.sh
+++ b/modules/runners/templates/start-runner.sh
@@ -254,6 +254,8 @@ if [[ "$enable_jit_config" == "false" || $agent_mode != "ephemeral" ]]; then
   else
       extra_flags=""
   fi
+  # Note: the double dollar signs are an artifact of Terraform since a single dollar sign and bracket would be
+  # interpreted by the template
   sudo --preserve-env=RUNNER_ALLOW_RUNASROOT -u "$run_as" -- ./config.sh $${extra_flags} --unattended --name "$runner_name_prefix$instance_id" --work "_work" $${config}
 
   # Tag instance with GitHub runner agent ID for non-JIT runners


### PR DESCRIPTION
This is to facilitate discussion of issue #4712 

Usually the username on windows comes from `runner_run_as: Administrator`. Recently that has broken and it's always `System`.

In `start-runner.ps1` move everything back inside a "Register-ScheduledTask" so the username can be set.   This fixes the issue.

However, `start-runner.ps1` also included a relatively new section:

```
Write-Host "Terminating instance"
aws ec2 terminate-instances --instance-ids "$InstanceId" --region "$Region"
```

By removing it, instances fail to terminate. How did this work before?  ( in 2023)  Why is it necessary to terminate instance from `start-runner.ps1` instead of how it used to work before?    

By removing `terminate-instances`, the instances continue to run, which is obviously not the desired result.  

Where should `terminate-instances` be placed, or can the earlier solution handle that task.

