### PR TITLE
fix: prevent unnecessary updates when cpu_options is unset

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -160,9 +160,12 @@ resource "aws_launch_template" "runner" {
     }
   }
 
-  cpu_options {
-    core_count       = var.cpu_options != null ? var.cpu_options.core_count : null
-    threads_per_core = var.cpu_options != null ? var.cpu_options.threads_per_core : null
+  dynamic "cpu_options" {
+    for_each = var.cpu_options != null ? [var.cpu_options] : []
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+    }
   }
 
   monitoring {


### PR DESCRIPTION
This PR will replace:

```hcl
cpu_options {
  core_count       = var.cpu_options != null ? var.cpu_options.core_count : null
  threads_per_core = var.cpu_options != null ? var.cpu_options.threads_per_core : null
}
```

with:

```hcl
dynamic "cpu_options" {
  for_each = var.cpu_options != null ? [var.cpu_options] : []
  content {
    core_count       = try(cpu_options.value.core_count, null)
    threads_per_core = try(cpu_options.value.threads_per_core, null)
  }
}
```

This way, if `cpu_options` is not set, Terraform will **not force a resource update every time**.

This issue was introduced in PR #4789 


<img width="346" height="94" alt="image" src="https://github.com/user-attachments/assets/5a3ca60d-7300-4957-91c3-ff87c2cd5b62" />
