### PR TITLE
chore: add concurrent workflow rules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '25 19 * * 2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
     - cron: '25 19 * * 2'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,10 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -8,6 +8,10 @@ on:
       - 'lambdas/**'
       - '.github/workflows/lambda.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # for actions/checkout and repository analysis
 

--- a/.github/workflows/ovs.yml
+++ b/.github/workflows/ovs.yml
@@ -5,6 +5,10 @@ on:
   merge_group:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -8,6 +8,11 @@ on:
       - "images/**"
       - ".github/workflows/packer-build.yml"
       - "module/runners/templates/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - v1
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -5,6 +5,11 @@ on:
       - opened
       - edited
       - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # for actions/checkout
   pull-requests: read # for amannn/action-semantic-pull-request to check PR details

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions: {}
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "30 1 * * *"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 jobs:
   stale:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     paths: ["**/*.tf", "**/*.hcl", ".github/workflows/terraform.yml"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,6 +6,10 @@ on:
       - "**/*.md"
       - ".github/workflows/update-docs.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - '.github/workflows/*.ya?ml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,3 +12,6 @@ rules:
   dangerous-triggers:
     ignore:
       - semantic-check.yml:2
+  concurrency-limits:
+    ignore:
+      - release.yml


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to add concurrency controls. The main goal is to prevent multiple runs of the same workflow from executing simultaneously on the same branch or ref, which helps reduce unnecessary resource usage and ensures that only the latest workflow run is active. Most workflows now use a concurrency group based on the workflow name and branch/ref, with `cancel-in-progress` set to `true` so that in-progress runs are canceled when a new run is triggered. Two workflows (`release.yml` and `stale.yml`) use a different concurrency configuration.

Concurrency configuration added to workflows:

**General concurrency improvements**
* Added `concurrency` blocks to `.github/workflows/codeql.yml`, `.github/workflows/dependency-review.yml`, `.github/workflows/lambda.yml`, `.github/workflows/ossf-scorecard.yml`, `.github/workflows/ovs.yml`, `.github/workflows/packer-build.yml`, `.github/workflows/semantic-check.yml`, `.github/workflows/terraform.yml`, `.github/workflows/update-docs.yml`, and `.github/workflows/zizmor.yml` to group runs by workflow name and branch/ref and cancel in-progress runs (`cancel-in-progress: true`). [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R13-R16) [[2]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R12-R15) [[3]](diffhunk://#diff-b0732b88b9e5a3df48561602571a10179d2b28cbb21ba8032025932bc9606426R11-R14) [[4]](diffhunk://#diff-0f32dffa00fbb4b53f979f3524fd4f69451050cda001ae563ed49e27e702da7bR10-R13) [[5]](diffhunk://#diff-0efa76244190040e37ac26bd58a2e1c1155c0de92da9ddf72276d5354c5c0bf8R8-R11) [[6]](diffhunk://#diff-7d0fae1f42bb015ceff53b783c22a632e3c0aa2a62f4bf6cf3b71cf5c8d8cda1R11-R15) [[7]](diffhunk://#diff-9d577d2550fe414a048906bc0af8ff9188d21f432e41be311e49b3a910fe9ac4R8-R12) [[8]](diffhunk://#diff-10eac00f40a120814e0c56ca5bf5a61c8b335acbdeb977b72207606aa3daea4dR9-R12) [[9]](diffhunk://#diff-6cb924cb587613a1d83384b44ca0c806ccf512202b3f29f529fc6825cef21de2R9-R12) [[10]](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7R13-R16)

**Special concurrency configuration**
* For `.github/workflows/release.yml`, added a concurrency group by workflow name and branch/ref, but set `cancel-in-progress: false` to allow multiple runs to proceed.
* For `.github/workflows/stale.yml`, added a concurrency group by workflow name only, with `cancel-in-progress: false`.