### PR TITLE
chore: fix typo in variables.tf

### DIFF
--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -596,7 +596,7 @@ variable "pool_lambda_reserved_concurrent_executions" {
 }
 
 variable "ssm_paths" {
-  description = "The root path used in SSM to store configuration and secreets."
+  description = "The root path used in SSM to store configuration and secrets."
   type = object({
     root    = optional(string, "github-action-runners")
     app     = optional(string, "app")


### PR DESCRIPTION
This only fixes a small typo in variables.tf.