### PR TITLE
docs(configuration): fix formatting of default AMI list

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,7 @@ This module also allows you to run agents from a prebuilt AMI to gain faster sta
 ## AMI Configuration
 
 By default, the module will automatically select appropriate AMI images:
+
 - For Linux x64: Amazon Linux 2023 x86_64
 - For Linux ARM64: Amazon Linux 2023 ARM64
 - For Windows: Windows Server 2022 English Full ECS Optimized


### PR DESCRIPTION
This fixes the formatting of the default AMI list in the configuration docs. See https://github-aws-runners.github.io/terraform-aws-github-runner/configuration/#ami-configuration.

Without this newline mkdocs does not render the list properly:
<img width="1903" height="572" alt="image" src="https://github.com/user-attachments/assets/950c1a64-8adb-42c9-856c-1c38cc89f160" />
