### PR TITLE
fix: update-docs.yml github actions condition

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,6 +17,7 @@ jobs:
   docs:
     name: Auto update terraform docs
     runs-on: ubuntu-latest
+    if: github.repository == 'github-aws-runners/terraform-aws-github-runner'
     permissions:
       contents: write # for terraform-docs/gh-actions to commit documentation updates
       pull-requests: write # for peter-evans/create-pull-request to create PRs with doc updates
@@ -68,6 +69,7 @@ jobs:
     name: Deploy documentation to GitHub Pages
     needs: [docs]
     runs-on: ubuntu-latest
+    if: github.repository == 'github-aws-runners/terraform-aws-github-runner'
     permissions:
       contents: write # for actions/checkout and mkdocs gh-deploy to push to gh-pages branch
     steps:


### PR DESCRIPTION
Hi,

The idea in this PR is for `update-docs.yml` to make a conditional decision if it's running on the parent repo or not.   If it's not then skip building docs.

Explanation:   

Currently there are over 700 forks of the terraform-aws-github-runner repository. We're maintaining a git fork and rebasing from upstream on a certain schedule. When rebasing, it always pulls in `update-docs.yml` and that file rebuilds the docs and commits them.   The automatic extra commit is incorrect and must be deleted because we're keeping careful track of all git commits in the history.   You might suggest "rebasing" isn't the best idea, and it should be "merging". But "rebasing" keeps a nice linear git history.  

If any git repository syncs their fork on a regular basis, it pulls in the docs from upstream, so it's not necessary to have additional commit messages about building docs again.

If a particular fork really chooses to be "independent" and branch off on their own without merging or rebasing from upstream, they can manually modify `update-docs.yml` to refer to their own repository specifically.   In the majority case, where forks are frequently synchronizing with the parent repo, by any method, they will get their docs refreshed during that process. So all cases may be dealt with correctly.  

Ultimately, when there are so many git forks, which are often syncing with upstream rather than being permanent separate forks, it can cause problems to "automatically" commit code.