### PR TITLE
fix: add SSM AMI parameter permissions and environment-based naming

### DIFF
--- a/examples/multi-runner/main.tf
+++ b/examples/multi-runner/main.tf
@@ -28,7 +28,7 @@ locals {
   aws_region  = var.aws_region
 
   # create map only with amazon linux 2023 x64 and arm64 to overwrite the default
-  al2023_arm64_name = "/${var.environment}/examples/multi-runner/aws-github-runners/ami/amazon-linux-2023-arm64"
+  al2023_arm64_name = "/${local.environment}/examples/multi-runner/aws-github-runners/ami/amazon-linux-2023-arm64"
   ssm_ami_arns = {
     "linux-x64" = data.aws_ssm_parameter.al2023_x64.arn
     # construct the arn to avoid terraform count errors

--- a/examples/multi-runner/main.tf
+++ b/examples/multi-runner/main.tf
@@ -28,7 +28,7 @@ locals {
   aws_region  = var.aws_region
 
   # create map only with amazon linux 2023 x64 and arm64 to overwrite the default
-  al2023_arm64_name = "/examples/multi-runner/aws-github-runners/ami/amazon-linux-2023-arm64"
+  al2023_arm64_name = "/${var.environment}/examples/multi-runner/aws-github-runners/ami/amazon-linux-2023-arm64"
   ssm_ami_arns = {
     "linux-x64" = data.aws_ssm_parameter.al2023_x64.arn
     # construct the arn to avoid terraform count errors

--- a/modules/runners/policies/lambda-scale-up.json
+++ b/modules/runners/policies/lambda-scale-up.json
@@ -35,7 +35,8 @@
             "Resource": [
                 "${github_app_key_base64_arn}",
                 "${github_app_id_arn}",
-                "${ssm_config_path}/*"
+                "${ssm_config_path}/*",
+                "${ssm_ami_id_parameter_arn}"
             ]
         },
         {


### PR DESCRIPTION

This pull request introduces environment-specific configuration improvements and updates IAM policy resources to support new SSM parameters. The main changes focus on making resource naming more flexible and ensuring the Lambda scale-up policy has access to the necessary SSM parameters.

Configuration improvements:

* Updated the `al2023_arm64_name` local in `examples/multi-runner/main.tf` to include the environment variable, making AMI name paths environment-specific for better isolation and flexibility.

IAM policy updates:

* Added `${ssm_ami_id_parameter_arn}` to the resource list in `modules/runners/policies/lambda-scale-up.json`, allowing Lambda scale-up operations to access the new SSM parameter for AMI IDs. This solve errors related handling batches