### PR TITLE
feat(lambdas): add batch SSM parameter fetching to reduce API calls

### DIFF
--- a/lambdas/functions/ami-housekeeper/src/ami.test.ts
+++ b/lambdas/functions/ami-housekeeper/src/ami.test.ts
@@ -10,15 +10,17 @@ import {
 import {
   DescribeParametersCommand,
   DescribeParametersCommandOutput,
-  GetParametersCommand,
   SSMClient,
 } from '@aws-sdk/client-ssm';
+import { getParameters } from '@aws-github-runner/aws-ssm-util';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest/vitest';
 
 import { AmiCleanupOptions, amiCleanup, defaultAmiCleanupOptions } from './ami';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { fail } from 'assert';
+
+vi.mock('@aws-github-runner/aws-ssm-util');
 
 process.env.AWS_REGION = 'eu-east-1';
 const deleteAmisOlderThenDays = 30;
@@ -83,23 +85,12 @@ describe("delete AMI's", () => {
     mockSSMClient.reset();
 
     mockSSMClient.on(DescribeParametersCommand).resolves(ssmParameters);
-    mockSSMClient.on(GetParametersCommand).resolves({
-      Parameters: [
-        {
-          Name: 'ami-id/ami-ssm0001',
-          Type: 'String',
-          Value: 'ami-ssm0001',
-          Version: 1,
-        },
-        {
-          Name: 'ami-id/ami-ssm0002',
-          Type: 'String',
-          Value: 'ami-ssm0002',
-          Version: 1,
-        },
-      ],
-      InvalidParameters: [],
-    });
+    vi.mocked(getParameters).mockResolvedValue(
+      new Map([
+        ['ami-id/ami-ssm0001', 'ami-ssm0001'],
+        ['ami-id/ami-ssm0002', 'ami-ssm0002'],
+      ]),
+    );
 
     mockEC2Client.on(DescribeLaunchTemplatesCommand).resolves({
       LaunchTemplates: [
@@ -144,11 +135,7 @@ describe("delete AMI's", () => {
     expect(mockEC2Client).toHaveReceivedCommand(DescribeLaunchTemplatesCommand);
     expect(mockEC2Client).toHaveReceivedCommand(DescribeLaunchTemplateVersionsCommand);
     expect(mockSSMClient).toHaveReceivedCommand(DescribeParametersCommand);
-    expect(mockSSMClient).toHaveReceivedCommandTimes(GetParametersCommand, 1);
-    expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-      Names: ['ami-id/ami-ssm0001', 'ami-id/ami-ssm0002'],
-      WithDecryption: true,
-    });
+    expect(getParameters).toHaveBeenCalledWith(['ami-id/ami-ssm0001', 'ami-id/ami-ssm0002']);
   });
 
   it('should NOT delete instances in use.', async () => {
@@ -484,17 +471,9 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand).resolves({
-        Parameters: [
-          {
-            Name: '/github-runner/config/ami_id',
-            Type: 'String',
-            Value: 'ami-underscore0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
-      });
+      vi.mocked(getParameters).mockResolvedValue(
+        new Map([['/github-runner/config/ami_id', 'ami-underscore0001']]),
+      );
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -503,10 +482,7 @@ describe("delete AMI's", () => {
 
       // AMI should not be deleted because it's referenced in SSM
       expect(mockEC2Client).not.toHaveReceivedCommand(DeregisterImageCommand);
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/github-runner/config/ami_id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/github-runner/config/ami_id']);
       expect(mockSSMClient).not.toHaveReceivedCommand(DescribeParametersCommand);
     });
 
@@ -521,17 +497,9 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand).resolves({
-        Parameters: [
-          {
-            Name: '/github-runner/config/ami-id',
-            Type: 'String',
-            Value: 'ami-hyphen0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
-      });
+      vi.mocked(getParameters).mockResolvedValue(
+        new Map([['/github-runner/config/ami-id', 'ami-hyphen0001']]),
+      );
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -540,10 +508,7 @@ describe("delete AMI's", () => {
 
       // AMI should not be deleted because it's referenced in SSM
       expect(mockEC2Client).not.toHaveReceivedCommand(DeregisterImageCommand);
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/github-runner/config/ami-id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/github-runner/config/ami-id']);
       expect(mockSSMClient).not.toHaveReceivedCommand(DescribeParametersCommand);
     });
 
@@ -568,17 +533,9 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand).resolves({
-        Parameters: [
-          {
-            Name: '/some/path/ami-id',
-            Type: 'String',
-            Value: 'ami-wildcard0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
-      });
+      vi.mocked(getParameters).mockResolvedValue(
+        new Map([['/some/path/ami-id', 'ami-wildcard0001']]),
+      );
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -590,10 +547,7 @@ describe("delete AMI's", () => {
       expect(mockSSMClient).toHaveReceivedCommandWith(DescribeParametersCommand, {
         ParameterFilters: [{ Key: 'Name', Option: 'Contains', Values: ['ami-id'] }],
       });
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/some/path/ami-id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/some/path/ami-id']);
     });
 
     it('handles wildcard SSM parameter patterns (*ami_id)', async () => {
@@ -617,17 +571,9 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand).resolves({
-        Parameters: [
-          {
-            Name: '/github-runner/config/ami_id',
-            Type: 'String',
-            Value: 'ami-wildcard-underscore0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
-      });
+      vi.mocked(getParameters).mockResolvedValue(
+        new Map([['/github-runner/config/ami_id', 'ami-wildcard-underscore0001']]),
+      );
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -639,10 +585,7 @@ describe("delete AMI's", () => {
       expect(mockSSMClient).toHaveReceivedCommandWith(DescribeParametersCommand, {
         ParameterFilters: [{ Key: 'Name', Option: 'Contains', Values: ['ami_id'] }],
       });
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/github-runner/config/ami_id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/github-runner/config/ami_id']);
     });
 
     it('handles mixed explicit names and wildcard patterns', async () => {
@@ -664,17 +607,9 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand, { Names: ['/explicit/ami_id'], WithDecryption: true }).resolves({
-        Parameters: [
-          {
-            Name: '/explicit/ami_id',
-            Type: 'String',
-            Value: 'ami-explicit0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
-      });
+      vi.mocked(getParameters)
+        .mockResolvedValueOnce(new Map([['/explicit/ami_id', 'ami-explicit0001']]))
+        .mockResolvedValueOnce(new Map([['/discovered/ami-id', 'ami-wildcard0001']]));
 
       mockSSMClient.on(DescribeParametersCommand).resolves({
         Parameters: [
@@ -684,18 +619,6 @@ describe("delete AMI's", () => {
             Version: 1,
           },
         ],
-      });
-
-      mockSSMClient.on(GetParametersCommand, { Names: ['/discovered/ami-id'], WithDecryption: true }).resolves({
-        Parameters: [
-          {
-            Name: '/discovered/ami-id',
-            Type: 'String',
-            Value: 'ami-wildcard0001',
-            Version: 1,
-          },
-        ],
-        InvalidParameters: [],
       });
 
       await amiCleanup({
@@ -709,17 +632,11 @@ describe("delete AMI's", () => {
         ImageId: 'ami-unused0001',
       });
 
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/explicit/ami_id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/explicit/ami_id']);
       expect(mockSSMClient).toHaveReceivedCommandWith(DescribeParametersCommand, {
         ParameterFilters: [{ Key: 'Name', Option: 'Contains', Values: ['ami-id'] }],
       });
-      expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
-        Names: ['/discovered/ami-id'],
-        WithDecryption: true,
-      });
+      expect(getParameters).toHaveBeenCalledWith(['/discovered/ami-id']);
     });
 
     it('handles SSM parameter fetch failures gracefully', async () => {
@@ -733,7 +650,7 @@ describe("delete AMI's", () => {
         ],
       });
 
-      mockSSMClient.on(GetParametersCommand).rejects(new Error('ParameterNotFound'));
+      vi.mocked(getParameters).mockRejectedValue(new Error('ParameterNotFound'));
 
       // Should not throw and should delete the AMI since SSM reference failed
       await amiCleanup({
@@ -791,7 +708,7 @@ describe("delete AMI's", () => {
         ImageId: 'ami-no-ssm0001',
       });
       expect(mockSSMClient).not.toHaveReceivedCommand(DescribeParametersCommand);
-      expect(mockSSMClient).not.toHaveReceivedCommand(GetParametersCommand);
+      expect(getParameters).not.toHaveBeenCalled();
     });
   });
 });

--- a/lambdas/functions/ami-housekeeper/src/ami.test.ts
+++ b/lambdas/functions/ami-housekeeper/src/ami.test.ts
@@ -7,11 +7,7 @@ import {
   EC2Client,
   Image,
 } from '@aws-sdk/client-ec2';
-import {
-  DescribeParametersCommand,
-  DescribeParametersCommandOutput,
-  SSMClient,
-} from '@aws-sdk/client-ssm';
+import { DescribeParametersCommand, DescribeParametersCommandOutput, SSMClient } from '@aws-sdk/client-ssm';
 import { getParameters } from '@aws-github-runner/aws-ssm-util';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest/vitest';
@@ -471,9 +467,7 @@ describe("delete AMI's", () => {
         ],
       });
 
-      vi.mocked(getParameters).mockResolvedValue(
-        new Map([['/github-runner/config/ami_id', 'ami-underscore0001']]),
-      );
+      vi.mocked(getParameters).mockResolvedValue(new Map([['/github-runner/config/ami_id', 'ami-underscore0001']]));
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -497,9 +491,7 @@ describe("delete AMI's", () => {
         ],
       });
 
-      vi.mocked(getParameters).mockResolvedValue(
-        new Map([['/github-runner/config/ami-id', 'ami-hyphen0001']]),
-      );
+      vi.mocked(getParameters).mockResolvedValue(new Map([['/github-runner/config/ami-id', 'ami-hyphen0001']]));
 
       await amiCleanup({
         minimumDaysOld: 0,
@@ -533,9 +525,7 @@ describe("delete AMI's", () => {
         ],
       });
 
-      vi.mocked(getParameters).mockResolvedValue(
-        new Map([['/some/path/ami-id', 'ami-wildcard0001']]),
-      );
+      vi.mocked(getParameters).mockResolvedValue(new Map([['/some/path/ami-id', 'ami-wildcard0001']]));
 
       await amiCleanup({
         minimumDaysOld: 0,

--- a/lambdas/functions/ami-housekeeper/src/ami.ts
+++ b/lambdas/functions/ami-housekeeper/src/ami.ts
@@ -203,9 +203,7 @@ async function resolveSsmParameterValues(names: string[]): Promise<(string | und
     // Log warnings for parameters that couldn't be resolved
     for (const name of names) {
       if (!parameterMap.has(name)) {
-        logger.warn(
-          `Failed to resolve image id from SSM parameter ${name}: Parameter not found or access denied`,
-        );
+        logger.warn(`Failed to resolve image id from SSM parameter ${name}: Parameter not found or access denied`);
       }
     }
 

--- a/lambdas/functions/ami-housekeeper/src/ami.ts
+++ b/lambdas/functions/ami-housekeeper/src/ami.ts
@@ -8,9 +8,10 @@ import {
   Filter,
   Image,
 } from '@aws-sdk/client-ec2';
-import { GetParametersCommand, SSMClient, DescribeParametersCommand } from '@aws-sdk/client-ssm';
+import { SSMClient, DescribeParametersCommand } from '@aws-sdk/client-ssm';
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
+import { getParameters } from '@aws-github-runner/aws-ssm-util';
 
 const logger = createChildLogger('ami');
 
@@ -184,56 +185,37 @@ async function deleteSnapshot(options: AmiCleanupOptions, amiDetails: Image, ec2
 }
 
 /**
- * Resolves the values of multiple SSM parameters by their names in batched API calls.
+ * Resolves the values of multiple SSM parameters by their names.
+ * Delegates batching to the shared `getParameters` utility.
  * Doesn't fail on errors, but warns instead, as this process is best-effort.
  *
  * @param names - Array of SSM parameter names to resolve
- * @param ssmClient - Configured SSM client for making API calls
- * @returns Array of parameter values (may contain undefined for missing/failed parameters)
+ * @returns Array of parameter values in the same order as input (undefined for missing/failed parameters)
  */
-async function resolveSsmParameterValues(names: string[], ssmClient: SSMClient): Promise<(string | undefined)[]> {
+async function resolveSsmParameterValues(names: string[]): Promise<(string | undefined)[]> {
   if (names.length === 0) {
     return [];
   }
 
-  const results = new Map<string, string | undefined>();
+  try {
+    const parameterMap = await getParameters(names);
 
-  // AWS SSM GetParameters API has a limit of 10 parameters per call
-  const chunkSize = 10;
-  for (let i = 0; i < names.length; i += chunkSize) {
-    const chunk = names.slice(i, i + chunkSize);
-    try {
-      const response = await ssmClient.send(
-        new GetParametersCommand({
-          Names: chunk,
-          WithDecryption: true,
-        }),
-      );
-
-      for (const param of response.Parameters ?? []) {
-        if (param.Name) {
-          results.set(param.Name, param.Value);
-        }
-      }
-
-      // Log warnings for invalid parameters
-      for (const invalidParam of response.InvalidParameters ?? []) {
+    // Log warnings for parameters that couldn't be resolved
+    for (const name of names) {
+      if (!parameterMap.has(name)) {
         logger.warn(
-          `Failed to resolve image id from SSM parameter ${invalidParam}: Parameter not found or access denied`,
+          `Failed to resolve image id from SSM parameter ${name}: Parameter not found or access denied`,
         );
-        results.set(invalidParam, undefined);
-      }
-    } catch (error: unknown) {
-      logger.warn(`Failed to resolve image ids from SSM parameters ${chunk.join(', ')}`, { error });
-      // Mark all parameters in this chunk as undefined
-      for (const name of chunk) {
-        results.set(name, undefined);
       }
     }
-  }
 
-  // Return values in the same order as input names
-  return names.map((name) => results.get(name));
+    // Return values in the same order as input names
+    return names.map((name) => parameterMap.get(name));
+  } catch (error: unknown) {
+    logger.warn(`Failed to resolve image ids from SSM parameters ${names.join(', ')}`, { error });
+    // Mark all parameters as undefined on failure
+    return names.map(() => undefined);
+  }
 }
 
 /**
@@ -307,7 +289,7 @@ async function getAmisReferedInSSM(options: AmiCleanupOptions): Promise<(string 
   const wildcardPatterns = options.ssmParameterNames.filter((n) => n.startsWith('*'));
 
   // Batch fetch explicit parameter values in chunks of 10 (AWS API limit)
-  const explicitValuesPromise = resolveSsmParameterValues(explicitNames, ssmClient);
+  const explicitValuesPromise = resolveSsmParameterValues(explicitNames);
 
   // Handle wildcard patterns by first discovering matching parameters, then
   // fetching their values
@@ -332,7 +314,7 @@ async function getAmisReferedInSSM(options: AmiCleanupOptions): Promise<(string 
           .map((param) => param.Name)
           .filter((name): name is string => name !== undefined);
 
-        return resolveSsmParameterValues(discoveredNames, ssmClient);
+        return resolveSsmParameterValues(discoveredNames);
       } catch (e) {
         logger.warn('Failed to describe SSM parameters using wildcard patterns', { error: e });
         return [];

--- a/lambdas/functions/control-plane/src/github/auth.test.ts
+++ b/lambdas/functions/control-plane/src/github/auth.test.ts
@@ -2,7 +2,7 @@ import { createAppAuth } from '@octokit/auth-app';
 import { StrategyOptions } from '@octokit/auth-app/dist-types/types';
 import { request } from '@octokit/request';
 import { RequestInterface, RequestParameters } from '@octokit/types';
-import { getParameter } from '@aws-github-runner/aws-ssm-util';
+import { getParameters } from '@aws-github-runner/aws-ssm-util';
 import { generateKeyPairSync } from 'node:crypto';
 import * as nock from 'nock';
 
@@ -27,7 +27,7 @@ const GITHUB_APP_ID = '1';
 const PARAMETER_GITHUB_APP_ID_NAME = `/actions-runner/${ENVIRONMENT}/github_app_id`;
 const PARAMETER_GITHUB_APP_KEY_BASE64_NAME = `/actions-runner/${ENVIRONMENT}/github_app_key_base64`;
 
-const mockedGet = vi.mocked(getParameter);
+const mockedGetParameters = vi.mocked(getParameters);
 
 beforeEach(() => {
   vi.resetModules();
@@ -78,9 +78,32 @@ describe('Test createGithubAppAuth', () => {
     process.env.ENVIRONMENT = ENVIRONMENT;
   });
 
+  it('Throws early when PARAMETER_GITHUB_APP_ID_NAME is not set', async () => {
+    delete process.env.PARAMETER_GITHUB_APP_ID_NAME;
+
+    await expect(createGithubAppAuth(installationId)).rejects.toThrow(
+      'Environment variable PARAMETER_GITHUB_APP_ID_NAME is not set',
+    );
+    expect(mockedGetParameters).not.toHaveBeenCalled();
+  });
+
+  it('Throws early when PARAMETER_GITHUB_APP_KEY_BASE64_NAME is not set', async () => {
+    delete process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME;
+
+    await expect(createGithubAppAuth(installationId)).rejects.toThrow(
+      'Environment variable PARAMETER_GITHUB_APP_KEY_BASE64_NAME is not set',
+    );
+    expect(mockedGetParameters).not.toHaveBeenCalled();
+  });
+
   it('Creates auth object with createJwt callback including jti claim', async () => {
     // Arrange
-    mockedGet.mockResolvedValueOnce(GITHUB_APP_ID).mockResolvedValueOnce(b64);
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64],
+      ]),
+    );
 
     const mockedAuth = vi.fn();
     mockedAuth.mockResolvedValue({ token });
@@ -108,7 +131,12 @@ describe('Test createGithubAppAuth', () => {
     });
     const b64Key = Buffer.from(privateKey as string).toString('base64');
 
-    mockedGet.mockResolvedValueOnce(GITHUB_APP_ID).mockResolvedValueOnce(b64Key);
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64Key],
+      ]),
+    );
 
     let capturedCreateJwt: (appId: string | number, timeDifference?: number) => Promise<{ jwt: string }>;
     mockedCreatAppAuth.mockImplementation((opts: StrategyOptions) => {
@@ -137,9 +165,17 @@ describe('Test createGithubAppAuth', () => {
     expect(payload).toHaveProperty('iss');
   });
 
-  it('Creates auth object for public GitHub', async () => {
+  it('Creates auth object with line breaks in SSH key.', async () => {
     // Arrange
-    mockedGet.mockResolvedValueOnce(GITHUB_APP_ID).mockResolvedValueOnce(b64);
+    const b64PrivateKeyWithLineBreaks = Buffer.from(decryptedValue + '\n' + decryptedValue, 'binary').toString(
+      'base64',
+    );
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64PrivateKeyWithLineBreaks],
+      ]),
+    );
 
     const mockedAuth = vi.fn();
     mockedAuth.mockResolvedValue({ token });
@@ -150,8 +186,31 @@ describe('Test createGithubAppAuth', () => {
     const result = await createGithubAppAuth(installationId);
 
     // Assert
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_ID_NAME);
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_KEY_BASE64_NAME);
+    expect(getParameters).toBeCalledWith([PARAMETER_GITHUB_APP_ID_NAME, PARAMETER_GITHUB_APP_KEY_BASE64_NAME]);
+    expect(mockedCreatAppAuth).toBeCalledTimes(1);
+    expect(mockedAuth).toBeCalledWith({ type: authType });
+    expect(result.token).toBe(token);
+  });
+
+  it('Creates auth object for public GitHub', async () => {
+    // Arrange
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64],
+      ]),
+    );
+
+    const mockedAuth = vi.fn();
+    mockedAuth.mockResolvedValue({ token });
+    const mockWithHook = Object.assign(mockedAuth, { hook: vi.fn() });
+    mockedCreatAppAuth.mockReturnValue(mockWithHook);
+
+    // Act
+    const result = await createGithubAppAuth(installationId);
+
+    // Assert
+    expect(getParameters).toBeCalledWith([PARAMETER_GITHUB_APP_ID_NAME, PARAMETER_GITHUB_APP_KEY_BASE64_NAME]);
 
     expect(mockedCreatAppAuth).toBeCalledTimes(1);
     const callArgs = mockedCreatAppAuth.mock.calls[0][0] as Record<string, unknown>;
@@ -171,7 +230,12 @@ describe('Test createGithubAppAuth', () => {
       () => mockedRequestInterface as RequestInterface<object & RequestParameters>,
     );
 
-    mockedGet.mockResolvedValueOnce(GITHUB_APP_ID).mockResolvedValueOnce(b64);
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64],
+      ]),
+    );
     const mockedAuth = vi.fn();
     mockedAuth.mockResolvedValue({ token });
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -183,8 +247,7 @@ describe('Test createGithubAppAuth', () => {
     const result = await createGithubAppAuth(installationId, githubServerUrl);
 
     // Assert
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_ID_NAME);
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_KEY_BASE64_NAME);
+    expect(getParameters).toBeCalledWith([PARAMETER_GITHUB_APP_ID_NAME, PARAMETER_GITHUB_APP_KEY_BASE64_NAME]);
 
     expect(mockedCreatAppAuth).toBeCalledTimes(1);
     const callArgs = mockedCreatAppAuth.mock.calls[0][0] as Record<string, unknown>;
@@ -207,7 +270,12 @@ describe('Test createGithubAppAuth', () => {
 
     const installationId = undefined;
 
-    mockedGet.mockResolvedValueOnce(GITHUB_APP_ID).mockResolvedValueOnce(b64);
+    mockedGetParameters.mockResolvedValueOnce(
+      new Map([
+        [PARAMETER_GITHUB_APP_ID_NAME, GITHUB_APP_ID],
+        [PARAMETER_GITHUB_APP_KEY_BASE64_NAME, b64],
+      ]),
+    );
     const mockedAuth = vi.fn();
     mockedAuth.mockResolvedValue({ token });
     const mockWithHook = Object.assign(mockedAuth, { hook: vi.fn() });
@@ -217,8 +285,7 @@ describe('Test createGithubAppAuth', () => {
     const result = await createGithubAppAuth(installationId, githubServerUrl);
 
     // Assert
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_ID_NAME);
-    expect(getParameter).toBeCalledWith(PARAMETER_GITHUB_APP_KEY_BASE64_NAME);
+    expect(getParameters).toBeCalledWith([PARAMETER_GITHUB_APP_ID_NAME, PARAMETER_GITHUB_APP_KEY_BASE64_NAME]);
 
     expect(mockedCreatAppAuth).toBeCalledTimes(1);
     const callArgs = mockedCreatAppAuth.mock.calls[0][0] as Record<string, unknown>;

--- a/lambdas/functions/control-plane/src/github/auth.ts
+++ b/lambdas/functions/control-plane/src/github/auth.ts
@@ -91,18 +91,25 @@ function signJwt(payload: Record<string, unknown>, privateKey: string): string {
 }
 
 async function createAuth(installationId: number | undefined, ghesApiUrl: string): Promise<AuthInterface> {
+  const appIdParamName = process.env.PARAMETER_GITHUB_APP_ID_NAME;
+  const appKeyParamName = process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME;
+  if (!appIdParamName) {
+    throw new Error('Environment variable PARAMETER_GITHUB_APP_ID_NAME is not set');
+  }
+  if (!appKeyParamName) {
+    throw new Error('Environment variable PARAMETER_GITHUB_APP_KEY_BASE64_NAME is not set');
+  }
+
   // Batch fetch both App ID and Private Key in a single SSM API call
-  const paramNames = [process.env.PARAMETER_GITHUB_APP_ID_NAME, process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME];
+  const paramNames = [appIdParamName, appKeyParamName];
   const params = await getParameters(paramNames);
-
-  const appIdValue = params.get(process.env.PARAMETER_GITHUB_APP_ID_NAME);
-  const privateKeyBase64 = params.get(process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME);
-
+  const appIdValue = params.get(appIdParamName);
+  const privateKeyBase64 = params.get(appKeyParamName);
   if (!appIdValue) {
-    throw new Error(`Parameter ${process.env.PARAMETER_GITHUB_APP_ID_NAME} not found`);
+    throw new Error(`Parameter ${appIdParamName} not found`);
   }
   if (!privateKeyBase64) {
-    throw new Error(`Parameter ${process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME} not found`);
+    throw new Error(`Parameter ${appKeyParamName} not found`);
   }
 
   const appId = parseInt(appIdValue);

--- a/lambdas/functions/control-plane/src/github/auth.ts
+++ b/lambdas/functions/control-plane/src/github/auth.ts
@@ -116,9 +116,7 @@ async function createAuth(installationId: number | undefined, ghesApiUrl: string
   // replace literal \n characters with new lines to allow the key to be stored as a
   // single line variable. This logic should match how the GitHub Terraform provider
   // processes private keys to retain compatibility between the projects
-  const privateKey = Buffer.from(privateKeyBase64, 'base64')
-    .toString()
-    .replace('/[\\n]/g', String.fromCharCode(10));
+  const privateKey = Buffer.from(privateKeyBase64, 'base64').toString().replace('/[\\n]/g', String.fromCharCode(10));
 
   // Use a custom createJwt callback to include a jti (JWT ID) claim in every token.
   // Without this, concurrent Lambda invocations generating JWTs within the same second

--- a/lambdas/functions/control-plane/src/github/auth.ts
+++ b/lambdas/functions/control-plane/src/github/auth.ts
@@ -22,7 +22,7 @@ import { Octokit } from '@octokit/rest';
 import { retry } from '@octokit/plugin-retry';
 import { throttling } from '@octokit/plugin-throttling';
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
-import { getParameter } from '@aws-github-runner/aws-ssm-util';
+import { getParameters } from '@aws-github-runner/aws-ssm-util';
 import { EndpointDefaults } from '@octokit/types';
 
 const logger = createChildLogger('gh-auth');
@@ -91,11 +91,25 @@ function signJwt(payload: Record<string, unknown>, privateKey: string): string {
 }
 
 async function createAuth(installationId: number | undefined, ghesApiUrl: string): Promise<AuthInterface> {
-  const appId = parseInt(await getParameter(process.env.PARAMETER_GITHUB_APP_ID_NAME));
+  // Batch fetch both App ID and Private Key in a single SSM API call
+  const paramNames = [process.env.PARAMETER_GITHUB_APP_ID_NAME, process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME];
+  const params = await getParameters(paramNames);
+
+  const appIdValue = params.get(process.env.PARAMETER_GITHUB_APP_ID_NAME);
+  const privateKeyBase64 = params.get(process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME);
+
+  if (!appIdValue) {
+    throw new Error(`Parameter ${process.env.PARAMETER_GITHUB_APP_ID_NAME} not found`);
+  }
+  if (!privateKeyBase64) {
+    throw new Error(`Parameter ${process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME} not found`);
+  }
+
+  const appId = parseInt(appIdValue);
   // replace literal \n characters with new lines to allow the key to be stored as a
   // single line variable. This logic should match how the GitHub Terraform provider
   // processes private keys to retain compatibility between the projects
-  const privateKey = Buffer.from(await getParameter(process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME), 'base64')
+  const privateKey = Buffer.from(privateKeyBase64, 'base64')
     .toString()
     .replace('/[\\n]/g', String.fromCharCode(10));
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -132,8 +132,6 @@ async function getGithubRunnerRegistrationToken(githubRunnerConfig: CreateGitHub
           repo: githubRunnerConfig.runnerOwner.split('/')[1],
         });
 
-  const appId = parseInt(await getParameter(process.env.PARAMETER_GITHUB_APP_ID_NAME));
-  logger.info('App id from SSM', { appId: appId });
   return registrationToken.data.token;
 }
 

--- a/lambdas/libs/aws-ssm-util/src/index.test.ts
+++ b/lambdas/libs/aws-ssm-util/src/index.test.ts
@@ -1,6 +1,7 @@
 import {
   GetParameterCommand,
   GetParameterCommandOutput,
+  GetParametersCommand,
   PutParameterCommand,
   PutParameterCommandOutput,
   SSMClient,
@@ -9,7 +10,7 @@ import 'aws-sdk-client-mock-jest/vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import nock from 'nock';
 
-import { getParameter, putParameter, SSM_ADVANCED_TIER_THRESHOLD } from '.';
+import { getParameter, getParameters, putParameter, SSM_ADVANCED_TIER_THRESHOLD } from '.';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mockSSMClient = mockClient(SSMClient);
@@ -164,5 +165,92 @@ describe('Test getParameter and putParameter', () => {
       Type: 'String',
       Tier: expectedTier,
     });
+  });
+});
+
+describe('Test getParameters (batch)', () => {
+  beforeEach(() => {
+    mockSSMClient.reset();
+  });
+
+  it('returns multiple parameters in a single call', async () => {
+    mockSSMClient.on(GetParametersCommand).resolves({
+      Parameters: [
+        { Name: '/app/param1', Value: 'value1' },
+        { Name: '/app/param2', Value: 'value2' },
+      ],
+    });
+
+    const result = await getParameters(['/app/param1', '/app/param2']);
+
+    expect(result).toEqual(
+      new Map([
+        ['/app/param1', 'value1'],
+        ['/app/param2', 'value2'],
+      ]),
+    );
+    expect(mockSSMClient).toHaveReceivedCommandWith(GetParametersCommand, {
+      Names: ['/app/param1', '/app/param2'],
+      WithDecryption: true,
+    });
+  });
+
+  it('returns empty map for empty input', async () => {
+    const result = await getParameters([]);
+
+    expect(result).toEqual(new Map());
+    expect(mockSSMClient).not.toHaveReceivedCommand(GetParametersCommand);
+  });
+
+  it('chunks requests when more than 10 parameters', async () => {
+    const names = Array.from({ length: 12 }, (_, i) => `/app/param${i}`);
+
+    mockSSMClient
+      .on(GetParametersCommand, { Names: names.slice(0, 10), WithDecryption: true })
+      .resolves({
+        Parameters: names.slice(0, 10).map((name) => ({ Name: name, Value: `val-${name}` })),
+      })
+      .on(GetParametersCommand, { Names: names.slice(10), WithDecryption: true })
+      .resolves({
+        Parameters: names.slice(10).map((name) => ({ Name: name, Value: `val-${name}` })),
+      });
+
+    const result = await getParameters(names);
+
+    expect(result.size).toBe(12);
+    expect(mockSSMClient).toHaveReceivedCommandTimes(GetParametersCommand, 2);
+    for (const name of names) {
+      expect(result.get(name)).toBe(`val-${name}`);
+    }
+  });
+
+  it('omits parameters with missing Name or Value', async () => {
+    mockSSMClient.on(GetParametersCommand).resolves({
+      Parameters: [
+        { Name: '/app/good', Value: 'value' },
+        { Name: '/app/no-value', Value: undefined },
+        { Name: undefined, Value: 'orphan' },
+      ],
+    });
+
+    const result = await getParameters(['/app/good', '/app/no-value']);
+
+    expect(result).toEqual(new Map([['/app/good', 'value']]));
+  });
+
+  it('propagates errors from SSM API', async () => {
+    mockSSMClient.on(GetParametersCommand).rejects(new Error('AccessDenied'));
+
+    await expect(getParameters(['/app/param1'])).rejects.toThrow('AccessDenied');
+  });
+
+  it('handles response with empty Parameters array', async () => {
+    mockSSMClient.on(GetParametersCommand).resolves({
+      Parameters: [],
+    });
+
+    const result = await getParameters(['/app/missing']);
+
+    expect(result).toEqual(new Map());
   });
 });

--- a/lambdas/libs/aws-ssm-util/src/index.ts
+++ b/lambdas/libs/aws-ssm-util/src/index.ts
@@ -17,6 +17,32 @@ export async function getParameter(parameter_name: string): Promise<string> {
   return result;
 }
 
+/**
+ * Retrieves multiple parameters from AWS Systems Manager Parameter Store.
+ *
+ * This function uses the AWS SSM {@link GetParametersCommand} API to fetch the values
+ * for the provided parameter names. Requests are automatically chunked into batches
+ * of up to 10 names per call to comply with the AWS GetParameters API limit.
+ *
+ * Each successfully retrieved parameter is added to the returned {@link Map}, where:
+ * - The map key is the full parameter name as stored in Parameter Store.
+ * - The map value is the decrypted string value of the parameter.
+ *
+ * Parameter names that are not found in Parameter Store (or that cannot be returned
+ * by the API) are silently omitted from the resulting map. They will not appear as
+ * keys in the returned {@link Map}.
+ *
+ * @param parameter_names - An array of parameter names to retrieve from SSM Parameter Store.
+ *   If the array is empty, an empty {@link Map} is returned without calling the AWS API.
+ *
+ * @returns A {@link Map} where each key is a parameter name and each value is the
+ *   corresponding decrypted string value for that parameter. Only parameters that
+ *   are successfully retrieved and have both a `Name` and a `Value` are included.
+ *
+ * @throws Error Propagates any error thrown by the underlying AWS SDK client,
+ *   such as network errors, AWS service errors (e.g., access denied, throttling),
+ *   or configuration issues (e.g., missing region or credentials).
+ */
 export async function getParameters(parameter_names: string[]): Promise<Map<string, string>> {
   if (parameter_names.length === 0) {
     return new Map();

--- a/modules/runners/job-retry/policies/lambda.json
+++ b/modules/runners/job-retry/policies/lambda.json
@@ -4,7 +4,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ssm:GetParameter"
+        "ssm:GetParameter",
+        "ssm:GetParameters"
       ],
       "Resource": [
         "${github_app_key_base64_arn}",

--- a/modules/runners/policies/lambda-scale-down.json
+++ b/modules/runners/policies/lambda-scale-down.json
@@ -46,7 +46,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ssm:GetParameter"
+        "ssm:GetParameter",
+        "ssm:GetParameters"
       ],
       "Resource": [
         "${github_app_key_base64_arn}",

--- a/modules/runners/policies/lambda-scale-up.json
+++ b/modules/runners/policies/lambda-scale-up.json
@@ -30,7 +30,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+                "ssm:GetParameters"
             ],
             "Resource": [
                 "${github_app_key_base64_arn}",

--- a/modules/runners/pool/policies/lambda-pool.json
+++ b/modules/runners/pool/policies/lambda-pool.json
@@ -51,7 +51,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+                "ssm:GetParameters"
             ],
             "Resource": [
                 "${github_app_key_base64_arn}",

--- a/modules/webhook/policies/lambda-ssm.json
+++ b/modules/webhook/policies/lambda-ssm.json
@@ -3,7 +3,7 @@
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": ["ssm:GetParameter"],
+      "Action": ["ssm:GetParameter", "ssm:GetParameters"],
       "Resource": ${resource_arns}
     }
   ]


### PR DESCRIPTION
This PR intends to reduce SSM AWS API calls by doing the following:

Add `getParameters()` function to aws-ssm-util that fetches multiple SSM parameters in a single API call with automatic chunking (max 10 per call per AWS API limits).

Apply batch fetching to:
- auth.ts: fetch App ID and Private Key in one call (2 calls → 1)
- ConfigLoader.ts: fetch multiple matcher config paths in one call
- ami.ts: batch resolve SSM parameter values for AMI lookups

Also remove redundant appId SSM fetch in scale-up.ts that was only used for logging.