### PR TITLE
fix(install-runner.sh): support Debian

### DIFF
--- a/modules/runners/templates/install-runner.sh
+++ b/modules/runners/templates/install-runner.sh
@@ -45,8 +45,8 @@ rm -rf $file_name
 os_id=$(awk -F= '/^ID=/{print $2}' /etc/os-release)
 echo OS: $os_id
 
-# Install libicu on non-ubuntu
-if [[ ! "$os_id" =~ ^ubuntu.* ]]; then
+# Install libicu on non-ubuntu, non-debian
+if [[ ! "$os_id" =~ ^(ubuntu|debian).* ]]; then
   max_attempts=5
   attempt_count=0
   success=false
@@ -63,8 +63,8 @@ if [[ ! "$os_id" =~ ^ubuntu.* ]]; then
   done
 fi
 
-# Install dependencies for ubuntu
-if [[ "$os_id" =~ ^ubuntu.* ]]; then
+# Install dependencies for ubuntu and debian
+if [[ "$os_id" =~ ^(ubuntu|debian).* ]]; then
     echo "Installing dependencies"
     ./bin/installdependencies.sh
 fi


### PR DESCRIPTION
Currently, when using the Debian OS, the existing `install-runner.sh` script will take an additional 25s during start up as the script attempts to install `libicu` via `dnf`

This PR adds support for the `debian` OS which is listed as a supported OS in the GitHub docs: https://docs.github.com/en/actions/reference/runners/self-hosted-runners#linux