### PR TITLE
fix: retry SQS messages when GitHub API fails after EC2 instance creation

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/ScaleError.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/ScaleError.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ActionRequestMessageSQS } from './scale-up';
-import ScaleError from './ScaleError';
+import ScaleError, { GHHttpError } from './ScaleError';
 
 describe('ScaleError', () => {
   describe('detailedMessage', () => {
@@ -71,6 +71,90 @@ describe('ScaleError', () => {
       const failures = error.toBatchItemFailures([]);
 
       expect(failures).toEqual([]);
+    });
+  });
+});
+
+describe('GHHttpError', () => {
+  describe('constructor', () => {
+    it('should set name, message, and status', () => {
+      const error = new GHHttpError('Validation Failed', 422);
+
+      expect(error.name).toBe('GHHttpError');
+      expect(error.message).toBe('Validation Failed');
+      expect(error.status).toBe(422);
+    });
+
+    it('should be an instance of ScaleError', () => {
+      const error = new GHHttpError('Not Found', 404);
+
+      expect(error).toBeInstanceOf(ScaleError);
+      expect(error).toBeInstanceOf(GHHttpError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('detailedMessage', () => {
+    it.each([
+      { message: 'Validation Failed', status: 422, expected: 'GitHub API HTTP error (status 422): Validation Failed' },
+      { message: 'Bad credentials', status: 401, expected: 'GitHub API HTTP error (status 401): Bad credentials' },
+      { message: 'Not Found', status: 404, expected: 'GitHub API HTTP error (status 404): Not Found' },
+      {
+        message: 'Internal Server Error',
+        status: 500,
+        expected: 'GitHub API HTTP error (status 500): Internal Server Error',
+      },
+    ])('should format message for status $status', ({ message, status, expected }) => {
+      const error = new GHHttpError(message, status);
+
+      expect(error.detailedMessage).toBe(expected);
+    });
+  });
+
+  describe('toBatchItemFailures', () => {
+    const mockMessages: ActionRequestMessageSQS[] = [
+      { messageId: 'msg-1', id: 1, eventType: 'workflow_job' },
+      { messageId: 'msg-2', id: 2, eventType: 'workflow_job' },
+      { messageId: 'msg-3', id: 3, eventType: 'workflow_job' },
+    ];
+
+    it('should retry ALL messages regardless of status', () => {
+      const error = new GHHttpError('Validation Failed', 422);
+      const failures = error.toBatchItemFailures(mockMessages);
+
+      expect(failures).toEqual([{ itemIdentifier: 'msg-1' }, { itemIdentifier: 'msg-2' }, { itemIdentifier: 'msg-3' }]);
+    });
+
+    it('should retry the single message when only one is provided', () => {
+      const error = new GHHttpError('Bad credentials', 401);
+      const failures = error.toBatchItemFailures([mockMessages[0]]);
+
+      expect(failures).toEqual([{ itemIdentifier: 'msg-1' }]);
+    });
+
+    it('should return empty array for empty messages', () => {
+      const error = new GHHttpError('Server Error', 500);
+      const failures = error.toBatchItemFailures([]);
+
+      expect(failures).toEqual([]);
+    });
+
+    it('should retry all messages unlike ScaleError which retries only failedInstanceCount', () => {
+      const messages: ActionRequestMessageSQS[] = [
+        { messageId: 'msg-1', id: 1, eventType: 'workflow_job' },
+        { messageId: 'msg-2', id: 2, eventType: 'workflow_job' },
+        { messageId: 'msg-3', id: 3, eventType: 'workflow_job' },
+        { messageId: 'msg-4', id: 4, eventType: 'workflow_job' },
+        { messageId: 'msg-5', id: 5, eventType: 'workflow_job' },
+      ];
+
+      // ScaleError with failedInstanceCount=1 retries only 1 message
+      const scaleError = new ScaleError(1);
+      expect(scaleError.toBatchItemFailures(messages)).toHaveLength(1);
+
+      // GHHttpError retries ALL messages
+      const ghError = new GHHttpError('error', 422);
+      expect(ghError.toBatchItemFailures(messages)).toHaveLength(5);
     });
   });
 });


### PR DESCRIPTION
Closes #5024

When createStartRunnerConfig fails with a GitHub HTTP error (e.g., 401, 404, 422) after EC2 instances have already been created, the SQS messages are consumed and permanently deleted. The workflow jobs are silently lost — runners can't register, and jobs remain queued in GitHub until they time out (24 hours).

This change introduces GHHttpError, a subclass of ScaleError, that catches Octokit HttpError exceptions in createStartRunnerConfig and wraps them. Because GHHttpError extends ScaleError, the existing ScaleError catch in scaleUpHandler handles it via polymorphism — no changes needed in lambda.ts. Unlike ScaleError (which retries only failedInstanceCount messages), GHHttpError overrides toBatchItemFailures() to retry all messages, since the GitHub API failure affects every instance in the batch.