### PR TITLE
fix(runners): Remove scheduled task for runner initialization

### DIFF
--- a/images/windows-core-2022/windows-provisioner.ps1
+++ b/images/windows-core-2022/windows-provisioner.ps1
@@ -45,8 +45,4 @@ Expand-Archive -Path actions-runner.zip -DestinationPath .
 Write-Host "Delete zip file"
 Remove-Item actions-runner.zip
 
-$action = New-ScheduledTaskAction -WorkingDirectory "C:\actions-runner" -Execute "PowerShell.exe" -Argument "-File C:\start-runner.ps1"
-$trigger = New-ScheduledTaskTrigger -AtStartup
-Register-ScheduledTask -TaskName "runnerinit" -Action $action -Trigger $trigger -User System -RunLevel Highest -Force
-
 C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule


### PR DESCRIPTION
# Note: Runner startup is handled by user-data script at instance launch
# Removed scheduled task to prevent duplicate runner registration