### PR TITLE
feat(runner): add source parameter to distinguish between scale-up and pool lambda

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.d.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.d.ts
@@ -1,4 +1,5 @@
 import { DefaultTargetCapacityType, SpotAllocationStrategy } from '@aws-sdk/client-ec2';
+import { LambdaRunnerSource } from '../scale-runners/scale-up';
 
 export type RunnerType = 'Org' | 'Repo';
 
@@ -42,7 +43,7 @@ export interface RunnerInputParameters {
     instanceAllocationStrategy: SpotAllocationStrategy;
   };
   numberOfRunners: number;
-  source: 'scale-up-lambda' | 'pool-lambda';
+  source: LambdaRunnerSource;
   amiIdSsmParameterName?: string;
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];

--- a/lambdas/functions/control-plane/src/aws/runners.d.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.d.ts
@@ -42,6 +42,7 @@ export interface RunnerInputParameters {
     instanceAllocationStrategy: SpotAllocationStrategy;
   };
   numberOfRunners: number;
+  source: 'scale-up-lambda' | 'pool-lambda';
   amiIdSsmParameterName?: string;
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -318,6 +318,8 @@ describe('create runner', () => {
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     capacityType: 'spot',
     type: 'Org',
+    scaleErrors: [],
+    source: 'scale-up-lambda',
   };
 
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
@@ -325,6 +327,7 @@ describe('create runner', () => {
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
+    source: 'scale-up-lambda',
   };
 
   beforeEach(() => {
@@ -361,6 +364,25 @@ describe('create runner', () => {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
         totalTargetCapacity: 2,
+      }),
+    });
+  });
+
+  it('calls create fleet of multiple instances with pool-lambda source when specified', async () => {
+    const instances = [{ InstanceIds: ['i-1234', 'i-5678', 'i-9012'] }];
+
+    mockEC2Client.on(CreateFleetCommand).resolves({ Instances: instances });
+
+    await createRunner({
+      ...createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }),
+      numberOfRunners: 3,
+    });
+
+    expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
+      ...expectedCreateFleetRequest({
+        ...defaultExpectedFleetRequestValues,
+        totalTargetCapacity: 3,
+        source: 'pool-lambda',
       }),
     });
   });
@@ -425,6 +447,28 @@ describe('create runner', () => {
       }),
     });
   });
+
+  it('calls create fleet with source set to scale-up-lambda when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'scale-up-lambda' }));
+
+    expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
+      ...expectedCreateFleetRequest({
+        ...defaultExpectedFleetRequestValues,
+        source: 'scale-up-lambda',
+      }),
+    });
+  });
+
+  it('calls create fleet with source set to pool-lambda when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }));
+
+    expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
+      ...expectedCreateFleetRequest({
+        ...defaultExpectedFleetRequestValues,
+        source: 'pool-lambda',
+      }),
+    });
+  });
 });
 
 describe('create runner with errors', () => {
@@ -433,12 +477,14 @@ describe('create runner with errors', () => {
     capacityType: 'spot',
     type: 'Repo',
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
+    source: 'scale-up-lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
+    source: 'scale-up-lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -546,12 +592,15 @@ describe('create runner with errors fail over to OnDemand', () => {
     capacityType: 'spot',
     type: 'Repo',
     onDemandFailoverOnError: ['InsufficientInstanceCapacity'],
+    scaleErrors: [],
+    source: 'scale-up-lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
+    source: 'scale-up-lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -704,6 +753,7 @@ interface RunnerConfig {
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];
   scaleErrors: string[];
+  source: 'scale-up-lambda' | 'pool-lambda';
 }
 
 function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
@@ -724,6 +774,7 @@ function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
     tracingEnabled: runnerConfig.tracingEnabled,
     onDemandFailoverOnError: runnerConfig.onDemandFailoverOnError,
     scaleErrors: runnerConfig.scaleErrors,
+    source: runnerConfig.source,
   };
 }
 
@@ -735,6 +786,7 @@ interface ExpectedFleetRequestValues {
   totalTargetCapacity: number;
   imageId?: string;
   tracingEnabled?: boolean;
+  source: 'scale-up-lambda' | 'pool-lambda';
 }
 
 function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues): CreateFleetCommandInput {
@@ -742,7 +794,7 @@ function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues):
     { Key: 'ghr:Application', Value: 'github-action-runner' },
     {
       Key: 'ghr:created_by',
-      Value: expectedValues.totalTargetCapacity > 1 ? 'pool-lambda' : 'scale-up-lambda',
+      Value: expectedValues.source,
     },
     { Key: 'ghr:Type', Value: expectedValues.type },
     { Key: 'ghr:Owner', Value: REPO_NAME },

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ScaleError from './../scale-runners/ScaleError';
 import { createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
 import type { RunnerInfo, RunnerInputParameters, RunnerType } from './runners.d';
+import { LambdaRunnerSource } from '../scale-runners/scale-up';
 
 process.env.AWS_REGION = 'eu-east-1';
 const mockEC2Client = mockClient(EC2Client);
@@ -753,7 +754,7 @@ interface RunnerConfig {
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];
   scaleErrors: string[];
-  source: 'scale-up-lambda' | 'pool-lambda';
+  source: LambdaRunnerSource;
 }
 
 function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
@@ -786,7 +787,7 @@ interface ExpectedFleetRequestValues {
   totalTargetCapacity: number;
   imageId?: string;
   tracingEnabled?: boolean;
-  source: 'scale-up-lambda' | 'pool-lambda';
+  source: LambdaRunnerSource;
 }
 
 function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues): CreateFleetCommandInput {

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -241,7 +241,7 @@ async function createInstances(
 ) {
   const tags = [
     { Key: 'ghr:Application', Value: 'github-action-runner' },
-    { Key: 'ghr:created_by', Value: runnerParameters.numberOfRunners === 1 ? 'scale-up-lambda' : 'pool-lambda' },
+    { Key: 'ghr:created_by', Value: runnerParameters.source },
     { Key: 'ghr:Type', Value: runnerParameters.runnerType },
     { Key: 'ghr:Owner', Value: runnerParameters.runnerOwner },
   ];

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -192,7 +192,13 @@ describe('Test simple pool.', () => {
     it('Top up pool with pool size 2 registered.', async () => {
       await adjust({ poolSize: 3 });
       expect(createRunners).toHaveBeenCalledTimes(1);
-      expect(createRunners).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything());
+      expect(createRunners).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        1,
+        expect.anything(),
+        'pool-lambda',
+      );
     });
 
     it('Should not top up if pool size is reached.', async () => {
@@ -268,7 +274,13 @@ describe('Test simple pool.', () => {
     it('Top up if the pool size is set to 5', async () => {
       await adjust({ poolSize: 5 });
       // 2 idle, top up with 3 to match a pool of 5
-      expect(createRunners).toHaveBeenCalledWith(expect.anything(), expect.anything(), 3, expect.anything());
+      expect(createRunners).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        3,
+        expect.anything(),
+        'pool-lambda',
+      );
     });
   });
 
@@ -283,7 +295,13 @@ describe('Test simple pool.', () => {
     it('Top up if the pool size is set to 5', async () => {
       await adjust({ poolSize: 5 });
       // 2 idle, top up with 3 to match a pool of 5
-      expect(createRunners).toHaveBeenCalledWith(expect.anything(), expect.anything(), 3, expect.anything());
+      expect(createRunners).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        3,
+        expect.anything(),
+        'pool-lambda',
+      );
     });
   });
 
@@ -333,7 +351,13 @@ describe('Test simple pool.', () => {
 
       await adjust({ poolSize: 5 });
       // 2 idle, 2 prefixed idle top up with 1 to match a pool of 5
-      expect(createRunners).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything());
+      expect(createRunners).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        1,
+        expect.anything(),
+        'pool-lambda',
+      );
     });
   });
 });

--- a/lambdas/functions/control-plane/src/pool/pool.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.ts
@@ -106,6 +106,7 @@ export async function adjust(event: PoolEvent): Promise<void> {
       },
       topUp,
       githubInstallationClient,
+      'pool-lambda',
     );
   } else {
     logger.info(`Pool will not be topped up. Found ${numberOfRunnersInPool} managed idle runners.`);

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -113,6 +113,7 @@ const EXPECTED_RUNNER_PARAMS: RunnerInputParameters = {
   tracingEnabled: false,
   onDemandFailoverOnError: [],
   scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'TargetCapacityLimitExceededException'],
+  source: 'scale-up-lambda',
 };
 let expectedRunnerParams: RunnerInputParameters;
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -11,6 +11,8 @@ import { publishRetryMessage } from './job-retry';
 
 const logger = createChildLogger('scale-up');
 
+export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
+
 export interface RunnerGroup {
   name: string;
   id: number;
@@ -248,7 +250,7 @@ export async function createRunners(
   ec2RunnerConfig: CreateEC2RunnerConfig,
   numberOfRunners: number,
   ghClient: Octokit,
-  source: 'scale-up-lambda' | 'pool-lambda' = 'scale-up-lambda',
+  source: LambdaRunnerSource = 'scale-up-lambda',
 ): Promise<string[]> {
   const instances = await createRunner({
     runnerType: githubRunnerConfig.runnerType,
@@ -509,6 +511,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
       },
       newRunners,
       githubInstallationClient,
+      'scale-up-lambda'
     );
 
     // Not all runners we wanted were created, let's reject enough items so that

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -248,11 +248,13 @@ export async function createRunners(
   ec2RunnerConfig: CreateEC2RunnerConfig,
   numberOfRunners: number,
   ghClient: Octokit,
+  source: 'scale-up-lambda' | 'pool-lambda' = 'scale-up-lambda',
 ): Promise<string[]> {
   const instances = await createRunner({
     runnerType: githubRunnerConfig.runnerType,
     runnerOwner: githubRunnerConfig.runnerOwner,
     numberOfRunners,
+    source,
     ...ec2RunnerConfig,
   });
   if (instances.length !== 0) {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -511,7 +511,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
       },
       newRunners,
       githubInstallationClient,
-      'scale-up-lambda'
+      'scale-up-lambda',
     );
 
     // Not all runners we wanted were created, let's reject enough items so that


### PR DESCRIPTION
Fixes #5053

This pull request updates the way runner creation is tracked and tagged by introducing an explicit `source` parameter to distinguish between runners created by the scale-up lambda and those created by the pool lambda. The changes ensure that the runner creation flow and related tests consistently use this new `source` field.

**Runner creation and tagging improvements:**

* Added a `source` field (`'scale-up-lambda' | 'pool-lambda'`) to `RunnerConfig`, `RunnerInputParameters`, and related test interfaces to explicitly track the origin of runner creation. [[1]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR756) [[2]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR777) [[3]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR789-R797)
* Updated the runner creation logic in `createInstances` and `createRunners` to use the new `source` field for the `ghr:created_by` tag, replacing previous logic based on runner count. [[1]](diffhunk://#diff-69076cf041b0bcf70b90ba1dde121bfc3cb3b57bc9d293d29f7da72affcf0041L244-R244) [[2]](diffhunk://#diff-fbc68af2a40bf14ad13a80b13958c0b52d1d0fde5f0009416a693fb4b691ceaeR253-R259)

**Test enhancements:**

* Modified and added tests in `runners.test.ts` to verify correct behaviour when the `source` parameter is specified, including both single and multiple instance fleet creation. [[1]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR321-R330) [[2]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR371-R389) [[3]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR450-R471) [[4]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR480-R487) [[5]](diffhunk://#diff-a41db796ea6eeeb679f8cda3eb91243ffc16e68b8ebbeaea6837fbf85e7241baR595-R603)
* Updated pool adjustment tests to pass the `source` argument and verify its usage in runner creation calls. [[1]](diffhunk://#diff-f39f9287eeda57c37c329d28d6e6463da19db37f71791bf7da0181191b95857aL195-R201) [[2]](diffhunk://#diff-f39f9287eeda57c37c329d28d6e6463da19db37f71791bf7da0181191b95857aL271-R283) [[3]](diffhunk://#diff-f39f9287eeda57c37c329d28d6e6463da19db37f71791bf7da0181191b95857aL286-R304) [[4]](diffhunk://#diff-f39f9287eeda57c37c329d28d6e6463da19db37f71791bf7da0181191b95857aL336-R360)

**Pool and scaling logic:**

* Changed the pool adjustment logic in `pool.ts` to always pass `'pool-lambda'` as the `source` when topping up the pool.
* Ensured scale-up runner logic in `scale-up.test.ts` and related code passes `'scale-up-lambda'` as the `source` for created runners.

These changes collectively improve the clarity and reliability of runner source tracking throughout the control-plane codebase.