### PR TITLE
fix(scale-up): prevent negative TotalTargetCapacity when runners exceed maximum

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -228,6 +228,24 @@ describe('scaleUp with GHES', () => {
       expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
     });
 
+    it('does not create runners when current runners exceed maximum (race condition)', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '5';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      // Simulate race condition where pool lambda created more runners than max
+      mockListRunners.mockImplementation(async () =>
+        Array.from({ length: 10 }, (_, i) => ({
+          instanceId: `i-${i}`,
+          launchTime: new Date(),
+          type: 'Org',
+          owner: TEST_DATA_SINGLE.repositoryOwner,
+        })),
+      );
+      await scaleUpModule.scaleUp(TEST_DATA);
+      // Should not attempt to create runners (would be negative without fix)
+      expect(createRunner).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+    });
+
     it('does create a runner if maximum is set to -1', async () => {
       process.env.RUNNERS_MAXIMUM_COUNT = '-1';
       process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -438,12 +438,14 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
     });
 
     // Calculate how many runners we want to create.
+    // Use Math.max(0, ...) to ensure we never attempt to create a negative number of runners,
+    // which can happen when currentRunners exceeds maximumRunners due to pool/scale-up race conditions.
     const newRunners =
       maximumRunners === -1
         ? // If we don't have an upper limit, scale up by the number of new jobs.
           scaleUp
         : // Otherwise, we do have a limit, so work out if `scaleUp` would exceed it.
-          Math.min(scaleUp, maximumRunners - currentRunners);
+          Math.max(0, Math.min(scaleUp, maximumRunners - currentRunners));
 
     const missingInstanceCount = Math.max(0, scaleUp - newRunners);
 


### PR DESCRIPTION
## Problem

When pool and scale-up lambdas run concurrently, `currentRunners` can temporarily exceed `maximumRunners`. This causes the calculation `maximumRunners - currentRunners` to produce a negative value, which is then passed to the EC2 CreateFleet API.

### Error observed in CloudWatch logs:
```
InvalidTargetCapacitySpecification: TotalTargetCapacity should not be negative.
```

### Root cause:
The scale-up lambda calculates:
```typescript
const newRunners = Math.min(scaleUp, maximumRunners - currentRunners);
```

When `currentRunners > maximumRunners` (e.g., 55 runners with max 50), this produces:
```
newRunners = Math.min(1, 50 - 55) = Math.min(1, -5) = -5
```

This negative value is passed to `CreateFleet` API which rejects it.

## Solution

Wrap the calculation with `Math.max(0, ...)` to ensure we never attempt to create a negative number of runners:

```typescript
const newRunners = Math.max(0, Math.min(scaleUp, maximumRunners - currentRunners));
```

## Changes

- **scale-up.ts**: Added `Math.max(0, ...)` guard to prevent negative runner count
- **scale-up.test.ts**: Added test case for race condition scenario

## Testing

- Added unit test that simulates 10 current runners with max of 5
- Verified no `createRunner` call is made in this scenario
- All existing tests pass
