### PR TITLE
fix(logging): update log_class to log_group_class in CloudWatch agent configuration

### DIFF
--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -33,11 +33,12 @@ locals {
       }
     ]
   )
+  # CloudWatch agent collect_list schema expects log_group_class, not log_class
   logfiles = var.enable_cloudwatch_agent ? [for l in local.runner_log_files : {
     "log_group_name" : l.prefix_log_group ? "/github-self-hosted-runners/${var.prefix}/${l.log_group_name}" : "/${l.log_group_name}"
     "log_stream_name" : l.log_stream_name
     "file_path" : l.file_path
-    "log_class" : l.log_class
+    "log_group_class" : l.log_class
   }] : []
 
   loggroups_names = distinct([for l in local.logfiles : l.log_group_name])
@@ -45,7 +46,7 @@ locals {
   # This maintains the same order as loggroups_names for use with count
   loggroups_classes = [
     for name in local.loggroups_names : [
-      for l in local.logfiles : l.log_class
+      for l in local.logfiles : l.log_group_class
       if l.log_group_name == name
     ][0]
   ]


### PR DESCRIPTION
### Description
CloudWatch agent config stored in SSM used log_class inside each collect_list entry. The agent’s JSON schema only allows log_group_class there, so validation failed with “Additional property log_class is not allowed” and runner user-data exited before the GitHub runner started ([issue #5065](https://github.com/github-aws-runners/terraform-aws-github-runner/issues/5065)).

This PR maps the Terraform log_class value to log_group_class in the serialized logfiles blob passed to cloudwatch_config.json, and updates loggroups_classes to read log_group_class from local.logfiles so aws_cloudwatch_log_group behavior stays aligned.

## Test Plan
- `terraform validate` from repo root
- `pre-commit run --all-files` (or `tflint` on `modules/runners`)
<!--
  Please describe how you tested these changes. This helps reviewers understand
  the scope and confidence level of the change. Examples:

  - Ran `terraform plan` against an existing deployment
  - Added/updated unit tests (link to test file or describe coverage)
  - Deployed to a test environment and triggered a workflow run
  - Validated with `terraform validate` and `tflint`
-->

## Related Issues

Fixes [#5065](https://github.com/github-aws-runners/terraform-aws-github-runner/issues/5065)
