### PR TITLE
fix(job-retry): wait for IAM policy before creating SQS event source mapping

### DIFF
--- a/modules/runners/job-retry/main.tf
+++ b/modules/runners/job-retry/main.tf
@@ -48,6 +48,8 @@ resource "aws_lambda_event_source_mapping" "job_retry" {
   function_name                      = module.job_retry.lambda.function.arn
   batch_size                         = var.config.lambda_event_source_mapping_batch_size
   maximum_batching_window_in_seconds = var.config.lambda_event_source_mapping_maximum_batching_window_in_seconds
+
+  depends_on = [aws_iam_role_policy.job_retry]
 }
 
 resource "aws_lambda_permission" "job_retry" {


### PR DESCRIPTION
Fixes #5097

## Summary

- add an explicit dependency from the job-retry event source mapping to the retry Lambda IAM policy
- ensure the event source mapping is created only after the retry Lambda role has the required SQS permissions

## Problem

When `job_retry` is enabled, Terraform creates the retry queue, retry Lambda, retry role, retry IAM policy, and event source mapping in the same apply.

The retry IAM policy already contains the correct queue permissions, but the event source mapping did not explicitly depend on that policy resource. As a result, AWS could validate the Lambda execution role before the policy was attached and reject the mapping with:

```text
InvalidParameterValueException: The function execution role does not have permissions to call ReceiveMessage on SQS
```

In my case this was consistently reproducible. Apply failed every time before this change.

## Change

This PR adds:

```hcl
depends_on = [aws_iam_role_policy.job_retry]
```

to `aws_lambda_event_source_mapping.job_retry` in `modules/runners/job-retry/main.tf`.

## Result

With this change in place, I was able to apply the same configuration successfully without the event source mapping errors.

## Why this is safe

- no permission set is changed
- no runtime behavior is changed after successful apply
- this only makes the intended creation order explicit