### PR TITLE
feat: support RUNNER_TARBALL_URL in Windows install script

### DIFF
--- a/modules/runners/templates/install-runner.ps1
+++ b/modules/runners/templates/install-runner.ps1
@@ -1,14 +1,25 @@
 ## install the runner
 
+$s3_location = "${S3_LOCATION_RUNNER_DISTRIBUTION}"
+
+if ([string]::IsNullOrEmpty($env:RUNNER_TARBALL_URL) -and [string]::IsNullOrEmpty($s3_location)) {
+  Write-Error "Neither RUNNER_TARBALL_URL or s3_location are set"
+  exit 1
+}
+
 Write-Host "Creating actions-runner directory for the GH Action installation"
 New-Item -ItemType Directory -Path C:\actions-runner ; Set-Location C:\actions-runner
 
-Write-Host "Downloading the GH Action runner from s3 bucket $s3_location"
-aws s3 cp ${S3_LOCATION_RUNNER_DISTRIBUTION} actions-runner.zip
+if (-not [string]::IsNullOrEmpty($env:RUNNER_TARBALL_URL)) {
+  Write-Host "Downloading the GH Action runner from $env:RUNNER_TARBALL_URL"
+  Invoke-WebRequest -Uri $env:RUNNER_TARBALL_URL -OutFile actions-runner.zip -UseBasicParsing
+} else {
+  Write-Host "Downloading the GH Action runner from s3 bucket $s3_location"
+  aws s3 cp $s3_location actions-runner.zip
+}
 
 Write-Host "Un-zip action runner"
 Expand-Archive -Path actions-runner.zip -DestinationPath .
 
 Write-Host "Delete zip file"
 Remove-Item actions-runner.zip
-


### PR DESCRIPTION
## Description

Add support for `RUNNER_TARBALL_URL` as an alternative download source in the Windows runner install script (install-runner.ps1), matching the existing behavior in the Linux install-runner.sh.

When `RUNNER_TARBALL_URL` is set, the runner zip is downloaded directly from that URL via `Invoke-WebRequest` instead of from S3. If neither `RUNNER_TARBALL_URL` nor the S3 location is configured, the script exits with an error.

This enables Windows runners to be provisioned with a custom runner binary URL, which is useful for air-gapped environments or when using a local artifact cache.

## Test Plan

- Reviewed parity with the Linux install-runner.sh logic
- Validated PowerShell syntax
- Deployed to a test environment and triggered a Windows runner workflow with `RUNNER_TARBALL_URL` set
- Verified fallback to S3 download when `RUNNER_TARBALL_URL` is unset

## Related Issues

<!-- Link any related issues, e.g. Fixes #123, Closes #456 -->