### PR TITLE
fix: retry all SQS messages on unhandled errors instead of silently dropping them

### DIFF
--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -215,7 +215,9 @@ describe('Test scale up lambda wrapper.', () => {
       vi.mocked(scaleUp).mockRejectedValue(new Error('Generic error'));
 
       const result = await scaleUpHandler(multiRecordEvent, context);
-      expect(result).toEqual({ batchItemFailures: [] });
+      expect(result).toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-0' }, { itemIdentifier: 'message-1' }],
+      });
     });
 
     it('Should throw when scaleUp throws ScaleError', async () => {

--- a/lambdas/functions/control-plane/src/lambda.ts
+++ b/lambdas/functions/control-plane/src/lambda.ts
@@ -55,9 +55,11 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
       batchItemFailures.push(...e.toBatchItemFailures(sqsMessages));
       logger.warn(`${e.detailedMessage} A retry will be attempted via SQS.`, { error: e });
     } else {
-      logger.error(`Error processing batch (size: ${sqsMessages.length}): ${(e as Error).message}, ignoring batch`, {
-        error: e,
-      });
+      batchItemFailures.push(...sqsMessages.map(({ messageId }) => ({ itemIdentifier: messageId })));
+      logger.error(
+        `Error processing batch (size: ${sqsMessages.length}): ${(e as Error).message}, all messages will be retried via SQS.`,
+        { error: e },
+      );
     }
 
     return { batchItemFailures };


### PR DESCRIPTION
## Description

When the scale-up lambda encounters an unhandled error (e.g. SSM ThrottlingException during registration token creation), the catch block returned an empty batchItemFailures array. With ReportBatchItemFailures enabled, this tells SQS that all messages were processed successfully, permanently deleting them from the queue.

This causes queued GitHub Actions jobs to be silently lost — they never get a runner and remain stuck in 'queued' state indefinitely.

The fix returns all message IDs as batch item failures on unhandled errors, so SQS retries them after the visibility timeout.

## Test Plan

<!--
Fixed via unit tests
-->

## Related Issues

We ran into issues with our runners in https://github.com/island-is/island.is