### PR TITLE
fix(ssm): ignore_changes for insecure_value/version on github_app SSM params

### DIFF
--- a/modules/ssm/ssm.tf
+++ b/modules/ssm/ssm.tf
@@ -5,6 +5,16 @@ resource "aws_ssm_parameter" "github_app_id" {
   value  = var.github_app.id
   key_id = local.kms_key_arn
   tags   = var.tags
+
+  # The AWS provider exposes `insecure_value` as a computed/optional attribute and
+  # surfaces a "+ insecure_value = (known after apply)" diff on every plan for
+  # SecureString params (the API never returns it). `version` similarly drifts to
+  # "(known after apply)" because the provider treats it as recomputed. Neither
+  # actually changes anything on apply — ignore them to silence perpetual no-op
+  # drift for consumers of this module.
+  lifecycle {
+    ignore_changes = [insecure_value, version]
+  }
 }
 
 resource "aws_ssm_parameter" "github_app_key_base64" {
@@ -14,6 +24,10 @@ resource "aws_ssm_parameter" "github_app_key_base64" {
   value  = var.github_app.key_base64
   key_id = local.kms_key_arn
   tags   = var.tags
+
+  lifecycle {
+    ignore_changes = [insecure_value, version]
+  }
 }
 
 resource "aws_ssm_parameter" "github_app_webhook_secret" {
@@ -23,4 +37,8 @@ resource "aws_ssm_parameter" "github_app_webhook_secret" {
   value  = var.github_app.webhook_secret
   key_id = local.kms_key_arn
   tags   = var.tags
+
+  lifecycle {
+    ignore_changes = [insecure_value, version]
+  }
 }


### PR DESCRIPTION
## Problem

Every consumer of the `ssm` submodule sees perpetual no-op drift in `terraform plan` for the three github_app SSM parameters:

```
~ resource "aws_ssm_parameter" "github_app_id" {
    + insecure_value  = (known after apply)
    ~ version         = 1 -> (known after apply)
    ...
}
```

Same for `github_app_key_base64` and `github_app_webhook_secret`. The diff appears every plan, the apply does nothing meaningful, and the diff returns next plan.

### Why this happens

- The `aws_ssm_parameter` resource in the AWS provider exposes `insecure_value` as a computed/optional attribute (it's the plaintext alternative to `value`, mutually exclusive). For `SecureString` params the API never returns it, so the provider perpetually wants to "set" it to known-after-apply.
- The provider similarly treats `version` as recomputed each plan even when nothing changed.

The result is harmless but noisy — three lines of perpetual drift on every plan for every consumer of this module.

## Fix

Add `lifecycle { ignore_changes = [insecure_value, version] }` to the three SSM parameter resources in `modules/ssm/ssm.tf`. This silences the no-op drift without affecting:

- Actual secret rotation: changing `var.github_app.id` / `.key_base64` / `.webhook_secret` still updates `value`, which still triggers an update.
- Encryption: the SecureString type and `key_id` (KMS key) are unchanged.
- The SSM-pull-mode path: gated by `count = var.github_app.X_ssm != null ? 0 : 1`, unaffected.

## Verification

Tested on a downstream consumer using this module at `5.16.3`. Before the patch: 3 SSM parameter changes appear on every plan. After applying the patch (locally pinned), those changes are absent.

## Notes

- Strictly a no-op drift suppression — no functional change, no breaking change for existing consumers.
- I did not run `pre-commit run --all-files` or the lambda test suite for this PR since the change is isolated to a single `.tf` file with no logic changes; happy to run them if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)