### PR TITLE
feat: support centralised webhook proxy in multi-account deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,9 +48,16 @@ data "aws_iam_policy_document" "deny_insecure_transport" {
   }
 }
 
+data "aws_iam_policy_document" "build_queue_policy" {
+  source_policy_documents = compact([
+    data.aws_iam_policy_document.deny_insecure_transport.json,
+    var.sqs_build_queue_extra_policy_json,
+  ])
+}
+
 resource "aws_sqs_queue_policy" "build_queue_policy" {
   queue_url = aws_sqs_queue.queued_builds.id
-  policy    = data.aws_iam_policy_document.deny_insecure_transport.json
+  policy    = data.aws_iam_policy_document.build_queue_policy.json
 }
 
 resource "aws_sqs_queue" "queued_builds" {
@@ -97,6 +104,7 @@ module "ssm" {
 
 module "webhook" {
   source = "./modules/webhook"
+  count  = var.create_webhook_module ? 1 : 0
 
   ssm_paths = {
     root    = local.ssm_root_path

--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -32,16 +32,16 @@ output "binaries_syncer_map" {
 }
 
 output "webhook" {
-  value = {
-    gateway          = module.webhook.gateway
-    lambda           = module.webhook.lambda
-    lambda_log_group = module.webhook.lambda_log_group
-    lambda_role      = module.webhook.role
-    endpoint         = "${module.webhook.gateway.api_endpoint}/${module.webhook.endpoint_relative_path}"
-    webhook          = module.webhook.webhook
-    dispatcher       = var.eventbridge.enable ? module.webhook.dispatcher : null
-    eventbridge      = var.eventbridge.enable ? module.webhook.eventbridge : null
-  }
+  value = var.create_webhook_module ? {
+    gateway          = module.webhook[0].gateway
+    lambda           = module.webhook[0].lambda
+    lambda_log_group = module.webhook[0].lambda_log_group
+    lambda_role      = module.webhook[0].role
+    endpoint         = "${module.webhook[0].gateway.api_endpoint}/${module.webhook[0].endpoint_relative_path}"
+    webhook          = module.webhook[0].webhook
+    dispatcher       = var.eventbridge.enable ? module.webhook[0].dispatcher : null
+    eventbridge      = var.eventbridge.enable ? module.webhook[0].eventbridge : null
+  } : null
 }
 
 output "ssm_parameters" {
@@ -66,4 +66,14 @@ output "instance_termination_handler" {
     lambda_log_group = module.instance_termination_watcher[0].spot_termination_handler.lambda_log_group
     lambda_role      = module.instance_termination_watcher[0].spot_termination_handler.lambda_role
   } : null
+}
+
+output "queues" {
+  description = "SQS build queues per runner type."
+  value = {
+    for key in keys(var.multi_runner_config) : key => {
+      build_queue_arn = aws_sqs_queue.queued_builds[key].arn
+      build_queue_url = aws_sqs_queue.queued_builds[key].url
+    }
+  }
 }

--- a/modules/multi-runner/queues.tf
+++ b/modules/multi-runner/queues.tf
@@ -45,10 +45,19 @@ resource "aws_sqs_queue" "queued_builds" {
   tags = var.tags
 }
 
+data "aws_iam_policy_document" "build_queue_policy" {
+  for_each = var.multi_runner_config
+
+  source_policy_documents = compact([
+    data.aws_iam_policy_document.deny_insecure_transport.json,
+    var.sqs_build_queue_extra_policy_json,
+  ])
+}
+
 resource "aws_sqs_queue_policy" "build_queue_policy" {
   for_each  = var.multi_runner_config
   queue_url = aws_sqs_queue.queued_builds[each.key].id
-  policy    = data.aws_iam_policy_document.deny_insecure_transport.json
+  policy    = data.aws_iam_policy_document.build_queue_policy[each.key].json
 }
 
 resource "aws_sqs_queue" "queued_builds_dlq" {

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -770,3 +770,15 @@ variable "parameter_store_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "sqs_build_queue_extra_policy_json" {
+  description = "Optional additional SQS policy statements (JSON) merged into the build queue policy for all runner types. Useful for cross-account access, e.g. allowing an SNS topic from another account to send messages."
+  type        = string
+  default     = null
+}
+
+variable "create_webhook_module" {
+  description = "Set to false to skip deploying the webhook Lambda and API Gateway. Use when webhook delivery is handled externally (e.g. a centralised proxy in another account)."
+  type        = bool
+  default     = true
+}

--- a/modules/multi-runner/webhook.tf
+++ b/modules/multi-runner/webhook.tf
@@ -1,5 +1,6 @@
 module "webhook" {
   source                              = "../webhook"
+  count                               = var.create_webhook_module ? 1 : 0
   prefix                              = var.prefix
   tags                                = local.tags
   kms_key_arn                         = var.kms_key_arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,16 +31,16 @@ output "binaries_syncer" {
 }
 
 output "webhook" {
-  value = {
-    gateway          = module.webhook.gateway
-    lambda           = module.webhook.lambda
-    lambda_log_group = module.webhook.lambda_log_group
-    lambda_role      = module.webhook.role
-    endpoint         = "${module.webhook.gateway.api_endpoint}/${module.webhook.endpoint_relative_path}"
-    webhook          = module.webhook.webhook
-    dispatcher       = var.eventbridge.enable ? module.webhook.dispatcher : null
-    eventbridge      = var.eventbridge.enable ? module.webhook.eventbridge : null
-  }
+  value = var.create_webhook_module ? {
+    gateway          = module.webhook[0].gateway
+    lambda           = module.webhook[0].lambda
+    lambda_log_group = module.webhook[0].lambda_log_group
+    lambda_role      = module.webhook[0].role
+    endpoint         = "${module.webhook[0].gateway.api_endpoint}/${module.webhook[0].endpoint_relative_path}"
+    webhook          = module.webhook[0].webhook
+    dispatcher       = var.eventbridge.enable ? module.webhook[0].dispatcher : null
+    eventbridge      = var.eventbridge.enable ? module.webhook[0].eventbridge : null
+  } : null
 }
 
 output "ssm_parameters" {
@@ -56,6 +56,7 @@ output "queues" {
   description = "SQS queues."
   value = {
     build_queue_arn     = aws_sqs_queue.queued_builds.arn
+    build_queue_url     = aws_sqs_queue.queued_builds.url
     build_queue_dlq_arn = var.redrive_build_queue.enabled ? aws_sqs_queue.queued_builds_dlq[0].arn : null
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,18 @@ variable "aws_region" {
   type        = string
 }
 
+variable "sqs_build_queue_extra_policy_json" {
+  description = "Optional additional SQS policy statements (JSON) merged into the build queue policy. Useful for cross-account access, e.g. allowing an SNS topic from another account to send messages."
+  type        = string
+  default     = null
+}
+
+variable "create_webhook_module" {
+  description = "Set to false to skip deploying the webhook Lambda and API Gateway. Use when webhook delivery is handled externally (e.g. a centralised proxy in another account)."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_id" {
   description = "The VPC for security groups of the action runners."
   type        = string


### PR DESCRIPTION
## Description

  When deploying runners with a centralised webhook proxy in a separate AWS account (e.g. an account that validates and authorises webhook events before routing them to target accounts), three gaps force consumers to work around the module:

  1. **SQS queue policy drift** — the module exclusively owns the build queue policy (`DenyInsecureTransport` only). Adding cross-account `sqs:SendMessage` requires overriding the whole policy, duplicating `DenyInsecureTransport` and causing permanent Terraform drift.

  2. **Queue URL not exposed** — `aws_sqs_queue_policy` requires the queue URL, but the `queues` output only exposed the ARN, forcing consumers to reconstruct the URL by string-splitting.

  3. **Webhook always deployed** — the webhook Lambda and API Gateway are always created even when an external proxy handles webhook delivery.

  ### Changes (root module + `modules/multi-runner`)

  - **`sqs_build_queue_extra_policy_json`** (default: `null`): optional policy JSON merged into the build queue policy via `source_policy_documents`.
  No-op when unset.
  - **`build_queue_url`** added to the root `queues` output; new **`queues`** output added to `modules/multi-runner` exposing ARN + URL per runner key.
  - **`create_webhook_module`** (default: `true`): set to `false` to skip the webhook Lambda and API Gateway. The `webhook` output becomes `null` when disabled.
