### PR TITLE
fix(lambda): return batch failures on unhandled errors instead of dropping messages

### DIFF
--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -218,9 +218,10 @@ describe('Test scale up lambda wrapper.', () => {
       vi.mocked(scaleUp).mockRejectedValue(new Error('Generic error'));
 
       const result = await scaleUpHandler(multiRecordEvent, context);
-      expect(result).toEqual({
-        batchItemFailures: [{ itemIdentifier: 'message-0' }, { itemIdentifier: 'message-1' }],
-      });
+      expect(result.batchItemFailures).toHaveLength(2);
+      expect(result.batchItemFailures).toEqual(
+        expect.arrayContaining([{ itemIdentifier: 'message-0' }, { itemIdentifier: 'message-1' }]),
+      );
     });
 
     it('Should log error with retry message when scaleUp throws non-ScaleError', async () => {

--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -97,10 +97,13 @@ describe('Test scale up lambda wrapper.', () => {
     await expect(scaleUpHandler(sqsEvent, context)).resolves.not.toThrow();
   });
 
-  it('Non scale should resolve.', async () => {
+  it('Non scale error should return message as batch failure for retry.', async () => {
     const error = new Error('Non scale should resolve.');
     vi.mocked(scaleUp).mockRejectedValue(error);
-    await expect(scaleUpHandler(sqsEvent, context)).resolves.not.toThrow();
+    const result = await scaleUpHandler(sqsEvent, context);
+    expect(result).toEqual({
+      batchItemFailures: [{ itemIdentifier: sqsRecord.messageId }],
+    });
   });
 
   it('Scale should create a batch failure message', async () => {
@@ -208,14 +211,31 @@ describe('Test scale up lambda wrapper.', () => {
       await scaleUpHandler(multiRecordEvent, context);
     });
 
-    it('Should return all failed messages when scaleUp throws non-ScaleError', async () => {
+    it('Should return all messages as batch failures when scaleUp throws non-ScaleError', async () => {
       const records = createMultipleRecords(2);
       const multiRecordEvent: SQSEvent = { Records: records };
 
       vi.mocked(scaleUp).mockRejectedValue(new Error('Generic error'));
 
       const result = await scaleUpHandler(multiRecordEvent, context);
-      expect(result).toEqual({ batchItemFailures: [] });
+      expect(result).toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-0' }, { itemIdentifier: 'message-1' }],
+      });
+    });
+
+    it('Should log error with retry message when scaleUp throws non-ScaleError', async () => {
+      const records = createMultipleRecords(3);
+      const multiRecordEvent: SQSEvent = { Records: records };
+      const error = new Error('GitHub API timeout');
+
+      vi.mocked(scaleUp).mockRejectedValue(error);
+      const logSpy = vi.spyOn(logger, 'error');
+
+      await scaleUpHandler(multiRecordEvent, context);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('returning batch for retry'),
+        expect.objectContaining({ error }),
+      );
     });
 
     it('Should throw when scaleUp throws ScaleError', async () => {

--- a/lambdas/functions/control-plane/src/lambda.ts
+++ b/lambdas/functions/control-plane/src/lambda.ts
@@ -55,9 +55,11 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
       batchItemFailures.push(...e.toBatchItemFailures(sqsMessages));
       logger.warn(`${e.detailedMessage} A retry will be attempted via SQS.`, { error: e });
     } else {
-      logger.error(`Error processing batch (size: ${sqsMessages.length}): ${(e as Error).message}, ignoring batch`, {
-        error: e,
-      });
+      logger.error(
+        `Error processing batch (size: ${sqsMessages.length}): ${(e as Error).message}, returning batch for retry`,
+        { error: e },
+      );
+      batchItemFailures.push(...sqsMessages.map(({ messageId }) => ({ itemIdentifier: messageId })));
     }
 
     return { batchItemFailures };


### PR DESCRIPTION
## Problem

The `scaleUpHandler` catch block returns empty `batchItemFailures` for non-`ScaleError` exceptions. This tells SQS that all messages were processed successfully, causing them to be permanently deleted. The corresponding `workflow_job` events are silently lost — no EC2 instances are launched, no retry occurs, and affected jobs remain `queued` in GitHub until they time out (24 hours).

Any transient error (GitHub API 404, rate limit, network timeout) that isn't a `ScaleError` triggers this path.

## Fix

Return all message IDs as `batchItemFailures` when an unhandled exception occurs. SQS will retry delivery according to the queue's visibility timeout. The redrive policy / `maxReceiveCount` moves persistently-failing messages to the DLQ, preventing infinite retries.

```typescript
} else {
  logger.error(
    `Error processing batch (size: ${sqsMessages.length}): ${(e as Error).message}, returning batch for retry`,
    { error: e },
  );
  batchItemFailures.push(...sqsMessages.map(({ messageId }) => ({ itemIdentifier: messageId })));
}
```

## Changes

- `lambdas/functions/control-plane/src/lambda.ts` — return all messages as batch failures on non-ScaleError
- `lambdas/functions/control-plane/src/lambda.test.ts` — update tests to assert new behavior + add log message test

## Impact

- Non-ScaleError exceptions → messages retried via SQS (previously: silently dropped)
- ScaleError path → unchanged
- DLQ catches persistently-failing messages (no infinite retry loop)

Fixes #5024
Also fixes #5105
