### PR TITLE
fix(lambda): fail-open isJobQueued — assume queued on API errors

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -1563,6 +1563,16 @@ describe('scaleUp with GHES', () => {
         }),
       );
     });
+
+    it('Should not fail-open for unsupported event types', async () => {
+      // An unsupported event can never become answerable, so fail-open must not
+      // swallow it — otherwise every check_run event silently scales up a runner.
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      const messages = createTestMessages(1).map((m) => ({ ...m, eventType: 'check_run' as const }));
+
+      await expect(scaleUpModule.scaleUp(messages)).rejects.toThrow('Event check_run is not supported');
+      expect(createRunner).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -1549,6 +1549,20 @@ describe('scaleUp with GHES', () => {
         }),
       );
     });
+
+    it('Should assume job is queued when isJobQueued throws (fail-open)', async () => {
+      mockOctokit.actions.getJobForWorkflowRun.mockRejectedValue(new Error('GitHub API 502'));
+
+      const messages = createTestMessages(2);
+      await scaleUpModule.scaleUp(messages);
+
+      // All messages processed despite API error — fail-open prevents job drops
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+        }),
+      );
+    });
   });
 });
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -600,10 +600,17 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
         },
       });
 
-      if (enableJobQueuedCheck && !(await isJobQueued(githubInstallationClient, message))) {
-        messageLogger.info('No runner will be created, job is not queued.');
-
-        continue;
+      if (enableJobQueuedCheck) {
+        let jobQueued = true;
+        try {
+          jobQueued = await isJobQueued(githubInstallationClient, message);
+        } catch (e) {
+          messageLogger.warn('isJobQueued check failed, assuming job is still queued (fail-open)', { error: e });
+        }
+        if (!jobQueued) {
+          messageLogger.info('No runner will be created, job is not queued.');
+          continue;
+        }
       }
 
       scaleUp++;

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -242,6 +242,16 @@ export async function getInstallationId(
   return resolveInstallationId(githubAppClient, enableOrgLevel, payload);
 }
 
+// Raised when the queued-check is asked about an event type it cannot interpret.
+// Distinct from an API failure: no amount of retrying makes a check_run event
+// answerable, so callers must not treat this as a transient fault.
+export class UnsupportedEventError extends Error {
+  constructor(eventType: string) {
+    super(`Event ${eventType} is not supported`);
+    this.name = 'UnsupportedEventError';
+  }
+}
+
 export async function isJobQueued(githubInstallationClient: Octokit, payload: ActionRequestMessage): Promise<boolean> {
   let isQueued = false;
   if (payload.eventType === 'workflow_job') {
@@ -254,7 +264,7 @@ export async function isJobQueued(githubInstallationClient: Octokit, payload: Ac
     isQueued = jobForWorkflowRun.data.status === 'queued';
     logger.debug(`The job ${payload.id} is${isQueued ? ' ' : 'not'} queued`);
   } else {
-    throw Error(`Event ${payload.eventType} is not supported`);
+    throw new UnsupportedEventError(payload.eventType);
   }
   return isQueued;
 }
@@ -605,6 +615,11 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
         try {
           jobQueued = await isJobQueued(githubInstallationClient, message);
         } catch (e) {
+          // An unsupported event type is not a transient fault — the check can never
+          // succeed for it, so let it propagate rather than silently scaling up.
+          if (e instanceof UnsupportedEventError) {
+            throw e;
+          }
           const err = e as Error & { status?: number };
           messageLogger.warn('isJobQueued check failed, assuming job is still queued (fail-open)', {
             error: err.message,

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -605,7 +605,11 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
         try {
           jobQueued = await isJobQueued(githubInstallationClient, message);
         } catch (e) {
-          messageLogger.warn('isJobQueued check failed, assuming job is still queued (fail-open)', { error: e });
+          const err = e as Error & { status?: number };
+          messageLogger.warn('isJobQueued check failed, assuming job is still queued (fail-open)', {
+            error: err.message,
+            status: err.status,
+          });
         }
         if (!jobQueued) {
           messageLogger.info('No runner will be created, job is not queued.');


### PR DESCRIPTION
## Problem

When `enable_job_queued_check = true` (default), the `isJobQueued` call has no error handling. If `getJobForWorkflowRun` throws (404, rate limit, 502), the error propagates up through `scaleUp` and hits the generic catch in `scaleUpHandler` — causing the batch to fail.

This is especially problematic in combination with the race condition described in #5026: when SQS delivers messages in multiple batches due to concurrency limits, GitHub API errors during the second batch cause jobs to be silently dropped.

## Fix

Wrap the `isJobQueued` check in a try/catch. On any error, assume the job is still queued (fail-open) and log a warning. The worst case is creating a runner for a job that has already been handled — the runner will self-terminate when no job is available.

```typescript
if (enableJobQueuedCheck) {
  let jobQueued = true;
  try {
    jobQueued = await isJobQueued(githubInstallationClient, message);
  } catch (e) {
    messageLogger.warn('isJobQueued check failed, assuming job is still queued (fail-open)', { error: e });
  }
  if (!jobQueued) {
    messageLogger.info('No runner will be created, job is not queued.');
    continue;
  }
}
```

## Changes

- `lambdas/functions/control-plane/src/scale-runners/scale-up.ts` — try/catch around isJobQueued
- `lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts` — test: API error → runner still created

## Risk

Low — fail-open is strictly more resilient than fail-closed for job dispatch. The extra runner (if the job was already handled) self-terminates with no work.

Fixes #5026