### PR TITLE
fix(lambda): return partial CreateFleet instances instead of discarding them

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -820,9 +820,9 @@ describe('create runner with errors', () => {
   it('returns partial instances on recognized scale error instead of throwing', async () => {
     createFleetMockWithErrors(['UnfulfillableCapacity'], ['i-partial']);
 
-    await expect(
-      createRunner({ ...createRunnerConfig(defaultRunnerConfig), numberOfRunners: 3 }),
-    ).resolves.toEqual(['i-partial']);
+    await expect(createRunner({ ...createRunnerConfig(defaultRunnerConfig), numberOfRunners: 3 })).resolves.toEqual([
+      'i-partial',
+    ]);
     expect(mockEC2Client).toHaveReceivedCommandWith(
       CreateFleetCommand,
       expectedCreateFleetRequest({ ...defaultExpectedFleetRequestValues, totalTargetCapacity: 3 }),

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -783,13 +783,15 @@ describe('create runner with errors', () => {
   it('test ScaleError with multiple error.', async () => {
     createFleetMockWithErrors(['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'NotMappedError']);
 
-    await expect(createRunner(createRunnerConfig(defaultRunnerConfig))).rejects.toMatchObject({
+    await expect(
+      createRunner({ ...createRunnerConfig(defaultRunnerConfig), numberOfRunners: 3 }),
+    ).rejects.toMatchObject({
       name: 'ScaleError',
-      failedInstanceCount: 1, // numberOfRunners when zero instances created
+      failedInstanceCount: 3, // numberOfRunners when zero instances created
     });
     expect(mockEC2Client).toHaveReceivedCommandWith(
       CreateFleetCommand,
-      expectedCreateFleetRequest(defaultExpectedFleetRequestValues),
+      expectedCreateFleetRequest({ ...defaultExpectedFleetRequestValues, totalTargetCapacity: 3 }),
     );
     expect(mockSSMClient).not.toHaveReceivedCommand(PutParameterCommand);
   });
@@ -818,10 +820,12 @@ describe('create runner with errors', () => {
   it('returns partial instances on recognized scale error instead of throwing', async () => {
     createFleetMockWithErrors(['UnfulfillableCapacity'], ['i-partial']);
 
-    await expect(createRunner(createRunnerConfig(defaultRunnerConfig))).resolves.toEqual(['i-partial']);
+    await expect(
+      createRunner({ ...createRunnerConfig(defaultRunnerConfig), numberOfRunners: 3 }),
+    ).resolves.toEqual(['i-partial']);
     expect(mockEC2Client).toHaveReceivedCommandWith(
       CreateFleetCommand,
-      expectedCreateFleetRequest(defaultExpectedFleetRequestValues),
+      expectedCreateFleetRequest({ ...defaultExpectedFleetRequestValues, totalTargetCapacity: 3 }),
     );
   });
 

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -785,7 +785,7 @@ describe('create runner with errors', () => {
 
     await expect(createRunner(createRunnerConfig(defaultRunnerConfig))).rejects.toMatchObject({
       name: 'ScaleError',
-      failedInstanceCount: 2,
+      failedInstanceCount: 1, // numberOfRunners when zero instances created
     });
     expect(mockEC2Client).toHaveReceivedCommandWith(
       CreateFleetCommand,
@@ -809,6 +809,16 @@ describe('create runner with errors', () => {
     createFleetMockWithErrors(['NonMappedError'], ['i-123']);
 
     await expect(createRunner(createRunnerConfig(defaultRunnerConfig))).resolves.toEqual(['i-123']);
+    expect(mockEC2Client).toHaveReceivedCommandWith(
+      CreateFleetCommand,
+      expectedCreateFleetRequest(defaultExpectedFleetRequestValues),
+    );
+  });
+
+  it('returns partial instances on recognized scale error instead of throwing', async () => {
+    createFleetMockWithErrors(['UnfulfillableCapacity'], ['i-partial']);
+
+    await expect(createRunner(createRunnerConfig(defaultRunnerConfig))).resolves.toEqual(['i-partial']);
     expect(mockEC2Client).toHaveReceivedCommandWith(
       CreateFleetCommand,
       expectedCreateFleetRequest(defaultExpectedFleetRequestValues),
@@ -962,12 +972,14 @@ describe('create runner with errors fail over to OnDemand', () => {
     // fallback to on demand for UnfulfillableCapacity but InsufficientInstanceCapacity is thrown
     createFleetMockWithWithOnDemandFallback(['UnfulfillableCapacity'], instancesIds);
 
+    // Partial success: 1 instance created, unrecognized error for the rest.
+    // Returns partial instances instead of throwing to prevent orphans.
     await expect(
       createRunner({
         ...createRunnerConfig(defaultRunnerConfig),
         numberOfRunners: 2,
       }),
-    ).rejects.toBeInstanceOf(Error);
+    ).resolves.toEqual(['i-123']);
 
     expect(mockEC2Client).toHaveReceivedCommandTimes(CreateFleetCommand, 1);
 

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -319,8 +319,8 @@ async function processFleetResult(
     if (instances.length > 0) {
       logger.warn(
         `Partial fleet success: ${instances.length}/${runnerParameters.numberOfRunners} instances created. ` +
-          `Returning partial results; caller will retry the shortfall via SQS.`,
-        { data: fleet.Errors },
+          `Returning partial results; unfulfilled requests remain for retry.`,
+        { data: fleet.Errors, created: instances.length, requested: runnerParameters.numberOfRunners },
       );
       return instances;
     }
@@ -333,7 +333,7 @@ async function processFleetResult(
     logger.warn(
       `Partial fleet success: ${instances.length}/${runnerParameters.numberOfRunners} instances created. ` +
         `Error not recognized as scaling error; returning partial results.`,
-      { data: fleet.Errors },
+      { data: fleet.Errors, created: instances.length, requested: runnerParameters.numberOfRunners },
     );
     return instances;
   }

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -316,9 +316,26 @@ async function processFleetResult(
 
   const failedCount = countScaleErrors(errors, scaleErrors);
   if (failedCount > 0) {
-    logger.warn('Create fleet failed, ScaleError will be thrown to trigger retry for ephemeral runners.');
+    if (instances.length > 0) {
+      logger.warn(
+        `Partial fleet success: ${instances.length}/${runnerParameters.numberOfRunners} instances created. ` +
+          `Returning partial results; caller will retry the shortfall via SQS.`,
+        { data: fleet.Errors },
+      );
+      return instances;
+    }
+    logger.warn('Create fleet failed with zero instances, ScaleError will be thrown to trigger retry.');
     logger.debug('Create fleet failed.', { data: fleet.Errors });
-    throw new ScaleError(failedCount);
+    throw new ScaleError(runnerParameters.numberOfRunners);
+  }
+
+  if (instances.length > 0) {
+    logger.warn(
+      `Partial fleet success: ${instances.length}/${runnerParameters.numberOfRunners} instances created. ` +
+        `Error not recognized as scaling error; returning partial results.`,
+      { data: fleet.Errors },
+    );
+    return instances;
   }
 
   logger.warn('Create fleet failed, error not recognized as scaling error.', { data: fleet.Errors });


### PR DESCRIPTION
## Problem

When `CreateFleet` returns partial success (e.g. "6 of 8 instances created" plus errors), `processFleetResult` throws `ScaleError` and discards the successfully-created instance IDs. Those instances boot with no JIT config written to SSM — they are orphaned until the scale-down Lambda reaps them.

The caller (`scaleUp`) already handles count mismatch by marking unfulfilled messages as batch failures for SQS retry. But it never gets the chance because the throw short-circuits the entire flow.

**Impact observed at batch_size ≥ 5:** ~9% of jobs stuck permanently in burst tests — instances are launched, waste resources, but never pick up work.

## Fix

Return partial instances when at least one was created. Only throw `ScaleError` when zero instances were created:

```typescript
if (failedCount > 0 && instances.length > 0) {
  logger.warn(`Partial fleet success: ${instances.length}/${numberOfRunners} created. Returning partial results.`);
  return instances;
}
if (failedCount > 0) {
  throw new ScaleError(runnerParameters.numberOfRunners);
}
```

Same logic for unrecognized errors — if instances exist, return them.

## Changes

- `lambdas/functions/control-plane/src/aws/runners.ts` — return partial instances, only throw on zero
- `lambdas/functions/control-plane/src/aws/runners.test.ts` — new test for partial success with recognized error, updated existing tests for new ScaleError semantics

## Behavior change summary

| Scenario | Before | After |
|---|---|---|
| Partial success + recognized error | Throws ScaleError (orphans instances) | Returns instances, caller retries shortfall |
| Partial success + unrecognized error | Throws Error (orphans instances) | Returns instances, caller retries shortfall |
| Zero instances + recognized error | Throws ScaleError(errorCount) | Throws ScaleError(numberOfRunners) |
| Zero instances + unrecognized error | Throws Error | Throws Error (unchanged) |
| On-demand failover path | Returns combined | Returns combined (unchanged) |

Related to #5024