### PR TITLE
feat(webhook): use priority field as tiebreaker in matcher dispatch

### DIFF
--- a/lambdas/functions/webhook/src/runners/dispatch.test.ts
+++ b/lambdas/functions/webhook/src/runners/dispatch.test.ts
@@ -153,6 +153,54 @@ describe('Dispatcher', () => {
       });
     });
 
+    it('should dispatch to lowest priority pool when multiple pools match the same labels', async () => {
+      config = await createConfig(undefined, [
+        {
+          ...runnerConfig[0],
+          id: 'large-ondemand',
+          matcherConfig: {
+            labelMatchers: [['self-hosted', 'linux', 'x64', 'large', 'ondemand']],
+            exactMatch: true,
+            priority: 100,
+          },
+        },
+        {
+          ...runnerConfig[0],
+          id: 'medium-spot',
+          matcherConfig: {
+            labelMatchers: [['self-hosted', 'linux', 'x64', 'medium', 'spot']],
+            exactMatch: true,
+            priority: 5,
+          },
+        },
+        {
+          ...runnerConfig[0],
+          id: 'small-spot',
+          matcherConfig: {
+            labelMatchers: [['self-hosted', 'linux', 'x64', 'small', 'spot']],
+            exactMatch: true,
+            priority: 1,
+          },
+        },
+      ]);
+
+      // Job requests only the common subset — all pools match
+      const event = {
+        ...workFlowJobEvent,
+        workflow_job: {
+          ...workFlowJobEvent.workflow_job,
+          labels: ['self-hosted', 'linux', 'x64'],
+        },
+      } as unknown as WorkflowJobEvent;
+      const resp = await dispatch(event, 'workflow_job', config);
+      expect(resp.statusCode).toBe(201);
+      expect(sendActionRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queueId: 'small-spot',
+        }),
+      );
+    });
+
     it('should not accept jobs where not all labels are supported (single matcher).', async () => {
       config = await createConfig(undefined, [
         {

--- a/lambdas/functions/webhook/src/runners/dispatch.ts
+++ b/lambdas/functions/webhook/src/runners/dispatch.ts
@@ -42,9 +42,12 @@ async function handleWorkflowJob(
       `Job ID: ${body.workflow_job.id}, Job Name: ${body.workflow_job.name}, ` +
       `Run ID: ${body.workflow_job.run_id}, Labels: ${JSON.stringify(body.workflow_job.labels)}`,
   );
-  // sort the queuesConfig by order of matcher config exact match, with all true matches lined up ahead.
+  // Sort: exact-match first, then by ascending priority (lower = preferred/cheaper).
   matcherConfig.sort((a, b) => {
-    return a.matcherConfig.exactMatch === b.matcherConfig.exactMatch ? 0 : a.matcherConfig.exactMatch ? -1 : 1;
+    if (a.matcherConfig.exactMatch !== b.matcherConfig.exactMatch) {
+      return a.matcherConfig.exactMatch ? -1 : 1;
+    }
+    return (a.matcherConfig.priority ?? 999) - (b.matcherConfig.priority ?? 999);
   });
   for (const queue of matcherConfig) {
     if (canRunJob(body.workflow_job.labels, queue.matcherConfig.labelMatchers, queue.matcherConfig.exactMatch)) {

--- a/lambdas/functions/webhook/src/sqs/index.ts
+++ b/lambdas/functions/webhook/src/sqs/index.ts
@@ -17,6 +17,7 @@ export interface ActionRequestMessage {
 export interface MatcherConfig {
   labelMatchers: string[][];
   exactMatch: boolean;
+  priority?: number;
 }
 
 export type RunnerConfig = RunnerMatcherConfig[];


### PR DESCRIPTION
## Problem

When multiple runner pools match the same job labels via `exactMatch: true` (subset matching), dispatch order is non-deterministic. A workflow requesting `[self-hosted, linux, x64]` can land on any pool whose labels contain that subset — including an expensive 16 vCPU on-demand pool when a cheap 2 vCPU spot pool would suffice.

See #5128 for the full discussion and concrete examples.

## Fix

The Terraform variable `runner_matcher_config` already supports an optional `priority` field (default 999) and pre-sorts the config before writing to SSM. However the Lambda re-sorts only by `exactMatch`, discarding the priority ordering. This PR adds `priority` as a secondary sort key:

```typescript
matcherConfig.sort((a, b) => {
  if (a.matcherConfig.exactMatch !== b.matcherConfig.exactMatch) {
    return a.matcherConfig.exactMatch ? -1 : 1;
  }
  return (a.matcherConfig.priority ?? 999) - (b.matcherConfig.priority ?? 999);
});
```

The assumption is that when a workflow omits specific labels (e.g. uses just `[self-hosted, linux, x64]` instead of `[self-hosted, linux, x64, large, ondemand]`), the omission is intentional — the requester does not care which specific pool handles the job. The `priority` field lets the operator decide which pool should be preferred for these ambiguous requests.

## Changes

- `lambdas/functions/webhook/src/sqs/index.ts` — add optional `priority` field to `MatcherConfig`
- `lambdas/functions/webhook/src/runners/dispatch.ts` — sort by priority as tiebreaker
- `lambdas/functions/webhook/src/runners/dispatch.test.ts` — test: multiple pools match common subset, lowest priority wins

## Backwards compatible

- `priority` is optional, defaults to 999
- Existing configs without priority behave identically (all sort equal, first match wins as before)
- The Terraform variable already defines `priority = optional(number, 999)` — no Terraform changes needed

Refs: #5128