### PR TITLE
fix(runner): handle long prefixes in pool scheduler and IAM resource names

### DIFF
--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -1,3 +1,11 @@
+locals {
+  pool_name_prefix = (
+    length("${var.config.prefix}-pool") <= 38
+    ? "${var.config.prefix}-pool"
+    : "${substr("${var.config.prefix}-pool", 0, 29)}-${substr(md5("${var.config.prefix}-pool"), 0, 8)}"
+  )
+}
+
 resource "aws_lambda_function" "pool" {
 
   s3_bucket                      = var.config.lambda.s3_bucket != null ? var.config.lambda.s3_bucket : null
@@ -157,7 +165,7 @@ resource "aws_iam_role_policy" "pool_xray" {
 }
 
 resource "aws_scheduler_schedule_group" "pool" {
-  name_prefix = "${var.config.prefix}-pool"
+  name_prefix = local.pool_name_prefix
 
   tags = var.config.tags
 }
@@ -188,7 +196,7 @@ data "aws_iam_policy_document" "scheduler" {
 }
 
 resource "aws_iam_role" "scheduler" {
-  name_prefix = "${var.config.prefix}-pool"
+  name_prefix = local.pool_name_prefix
 
   path                 = var.config.role_path
   permissions_boundary = var.config.role_permissions_boundary


### PR DESCRIPTION
The pool module's `aws_scheduler_schedule_group` and `aws_iam_role` for the scheduler both use `name_prefix`, which has a 38-character limit (64 max name minus 26 for Terraform's random suffix). When the module prefix is long — for example a multi-runner prefix like `self-hosted-linux-ubuntu2404-x64-2cpu-8gb` — the combined `${prefix}-pool` exceeds 38 characters and Terraform fails.

For long prefixes, the name is now truncated with an md5 hash suffix to stay within limits, matching the existing pattern used elsewhere in the module. Existing deployments with short prefixes see no resource changes.