### PR TITLE
fix(examples): disable background apt services in multi-runner user-data

### DIFF
--- a/examples/multi-runner/templates/user-data.sh
+++ b/examples/multi-runner/templates/user-data.sh
@@ -12,6 +12,17 @@ set +x
 set -x
 %{ endif }
 
+# Ubuntu's unattended-upgrades and apt-daily services start in the background
+# shortly after boot and can hold /var/lib/dpkg/lock-frontend. The runner
+# installer (install_runner.sh → installdependencies.sh) also needs apt-get;
+# a lock conflict causes dependency installation to fail.
+systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+systemctl mask unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+  echo "Waiting for dpkg lock to be released..."
+  sleep 5
+done
+
 ${pre_install}
 
 # Install AWS CLI


### PR DESCRIPTION
Ubuntu's \`unattended-upgrades\`, \`apt-daily.service\`, and \`apt-daily-upgrade.service\` start in the background shortly after a fresh instance boots and can hold \`/var/lib/dpkg/lock-frontend\`. The runner installer (\`install_runner.sh\` → \`installdependencies.sh\`) runs \`apt-get\` to install .NET Core dependencies; if a background service holds the lock at that moment the install fails:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 5381 (apt-get)
Can't install dotnet core dependencies.
```

Without \`set -e\`, the runner starts with missing dependencies. With \`set -e\` (a common hardening practice), the entire user-data script exits — the runner is never installed or registered, and queued jobs wait indefinitely until job-retry exhausts its attempts.

This PR stops and masks those services before any \`apt-get\` operations, then waits for any in-flight lock holder to release.