### PR TITLE
fix(webhook): Fix publish events to EventBridge

### DIFF
--- a/lambdas/functions/webhook/src/webhook/index.ts
+++ b/lambdas/functions/webhook/src/webhook/index.ts
@@ -21,7 +21,7 @@ export async function publishForRunners(
 
   const checkBodySizeResult = checkBodySize(body, headers);
 
-  const { event, eventType } = readEvent(headers, body, ['workflow_job']);
+  const { event, eventType } = readWorkflowJobEvent(headers, body);
   logger.info(`Github event ${event.action} accepted for ${event.repository.full_name}`);
   if (checkBodySizeResult.sizeExceeded) {
     // We only warn for large event, when moving the event bridge we can only can accept events up to 256KB
@@ -39,9 +39,11 @@ export async function publishOnEventBridge(
 
   await verifySignature(headers, body, config.webhookSecret);
 
-  const checkBodySizeResult = checkBodySize(body, headers);
+  // Check for supported event types allowed to send to event bridge
+  const eventType = headers['x-github-event'] as string;
+  checkEventIsSupported(eventType, config.allowedEvents);
 
-  const { eventType } = readEvent(headers, body, config.allowedEvents);
+  const checkBodySizeResult = checkBodySize(body, headers);
 
   logger.info(
     `Github event ${headers['x-github-event'] as string} accepted for ` +
@@ -126,13 +128,13 @@ function checkEventIsSupported(eventType: string, allowedEvents: string[]): void
   }
 }
 
-function readEvent(
+// Reads the workflow_job event from the request body and headers, and logs relevant information for monitoring and debugging purposes.
+function readWorkflowJobEvent(
   headers: IncomingHttpHeaders,
   body: string,
-  allowedEvents: string[],
 ): { event: WorkflowJobEvent; eventType: string } {
   const eventType = headers['x-github-event'] as string;
-  checkEventIsSupported(eventType, allowedEvents);
+  checkEventIsSupported(eventType, ['workflow_job']);
 
   const event = JSON.parse(body) as WorkflowJobEvent;
   logger.appendPersistentKeys({

--- a/lambdas/functions/webhook/src/webhook/index.ts
+++ b/lambdas/functions/webhook/src/webhook/index.ts
@@ -43,6 +43,11 @@ export async function publishOnEventBridge(
   const eventType = headers['x-github-event'] as string;
   checkEventIsSupported(eventType, config.allowedEvents);
 
+  // If workflow_job event, read the event and log relevant information for monitoring and debugging purposes.
+  if (eventType === 'workflow_job') {
+    readWorkflowJobEvent(headers, body);
+  }
+
   const checkBodySizeResult = checkBodySize(body, headers);
 
   logger.info(


### PR DESCRIPTION
## Description

Rollback changes introduced on #5030. The webhook lambda in the EventBridge mode is not supporting other events beside `workflow_job`. 

## Related Issues

This PR fixes #5142.
