### PR TITLE
chore: lock .github to enforce admin approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,9 +7,9 @@
 # admins
 CODEOWNERS @github-aws-runners/terraform-aws-github-runner-admins
 LICENSE* @github-aws-runners/terraform-aws-github-runner-admins
+.github/* @github-aws-runners/terraform-aws-github-runner-admins
 
 # maintainers - protect potential interface changes by maintainer team
-.github/** @github-aws-runners/terraform-aws-github-runner-maintainers
 /*.* @github-aws-runners/terraform-aws-github-runner-maintainers
 /policies/** @github-aws-runners/terraform-aws-github-runner-maintainers
 /modules/multi-runner/** @github-aws-runners/terraform-aws-github-runner-maintainers


### PR DESCRIPTION
## Description

Force approval for changes on files in `.github` to admin team. Rest mostly maintainers controled.