### PR TITLE
fix(ci): restore persist-credentials for gh-pages deploy

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -113,7 +113,9 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: false
+          # mkdocs gh-deploy invokes `git push` internally via ghp-import, which relies on
+          # the credentials persisted by actions/checkout to authenticate against gh-pages.
+          persist-credentials: true
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
## Problem

The `Deploy documentation to GitHub Pages` job has been failing on `main` (e.g. [run 27352324385](https://github.com/github-aws-runners/terraform-aws-github-runner/actions/runs/27352324385/job/80817419053)) with:

```
fatal: could not read Username for 'https://github.com': No such device or address
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'gh-pages', '--force']' returned non-zero exit status 128.
```

## Root cause

In #4808, `persist-credentials: false` was added to the `actions/checkout` step of the `deploy-pages` job as part of the zizmor hardening pass.

`mkdocs gh-deploy` invokes `git push` internally via `ghp-import`, which relies on the credential helper / extraheader installed by `actions/checkout`. With `persist-credentials: false`, no token is configured, so the push prompts for a username and fails.

The job has `contents: write` permission, so the token itself is sufficient — only the persisted credential is missing.

## Fix

Set `persist-credentials: true` on the checkout step for this job and document why it is required. The token is only used to push to `gh-pages`, which the job already declares it needs via `permissions: contents: write`.