### PR TITLE
fix(codeowners): require admin review for nested .github paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 # admins
 CODEOWNERS @github-aws-runners/terraform-aws-github-runner-admins
 LICENSE* @github-aws-runners/terraform-aws-github-runner-admins
-.github/* @github-aws-runners/terraform-aws-github-runner-admins
+.github/** @github-aws-runners/terraform-aws-github-runner-admins
 
 # maintainers - protect potential interface changes by maintainer team
 /*.* @github-aws-runners/terraform-aws-github-runner-maintainers


### PR DESCRIPTION
## Problem

The CODEOWNERS rule for the `.github` directory currently is:

```
.github/* @github-aws-runners/terraform-aws-github-runner-admins
```

`.github/*` only matches files directly inside `.github/` (e.g. `.github/dependabot.yml`). It does **not** match nested paths such as `.github/workflows/update-docs.yml`, so workflow changes can be merged without admin approval — contrary to the intent of the rule.

Concrete recent example: #4808 modified `.github/workflows/update-docs.yml` and was approved/merged without going through the admins team, which introduced the bug fixed in #5162.

## Fix

Use the recursive glob `.github/**` so the admins team is required for any file under `.github/`, including subdirectories.