### PR TITLE
fix(scale-up): prevent runnerLabels accumulation across dynamic label groups

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -955,6 +955,100 @@ describe('scaleUp with GHES', () => {
         }),
       );
     });
+
+    it('does not accumulate labels across groups when multiple messages have different dynamic labels', async () => {
+      const testDataMultipleGroups = [
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:m7a.large', 'ghr-job-id:run-1-inst-0'],
+          messageId: 'msg-1',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:m7i.xlarge', 'ghr-job-id:run-1-inst-1'],
+          messageId: 'msg-2',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:c7a.large', 'ghr-job-id:run-1-inst-2'],
+          messageId: 'msg-3',
+        },
+      ];
+
+      await scaleUpModule.scaleUp(testDataMultipleGroups);
+
+      expect(createRunner).toBeCalledTimes(3);
+
+      const jitCalls = mockOctokit.actions.generateRunnerJitconfigForOrg.mock.calls;
+      expect(jitCalls).toHaveLength(3);
+
+      for (const call of jitCalls) {
+        const labels = call[0].labels as string[];
+
+        if (labels.includes('ghr-ec2-instance-type:m7a.large')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-ec2-instance-type:m7i.xlarge');
+          expect(labels).not.toContain('ghr-ec2-instance-type:c7a.large');
+        } else if (labels.includes('ghr-ec2-instance-type:m7i.xlarge')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
+          expect(labels).not.toContain('ghr-ec2-instance-type:c7a.large');
+        } else if (labels.includes('ghr-ec2-instance-type:c7a.large')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
+          expect(labels).not.toContain('ghr-ec2-instance-type:m7i.xlarge');
+        } else {
+          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
+        }
+      }
+    });
+
+    it('preserves base RUNNER_LABELS for each group without mutation', async () => {
+      process.env.RUNNER_LABELS = 'ubuntu-2404,x64';
+
+      const testDataTwoGroups = [
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'ghr-ec2-instance-type:m7a.large', 'ghr-team:alpha'],
+          messageId: 'msg-a',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'ghr-ec2-instance-type:c7i.large', 'ghr-team:beta'],
+          messageId: 'msg-b',
+        },
+      ];
+
+      await scaleUpModule.scaleUp(testDataTwoGroups);
+
+      expect(createRunner).toBeCalledTimes(2);
+
+      const jitCalls = mockOctokit.actions.generateRunnerJitconfigForOrg.mock.calls;
+      expect(jitCalls).toHaveLength(2);
+
+      for (const call of jitCalls) {
+        const labels = call[0].labels as string[];
+
+        expect(labels).toContain('ubuntu-2404');
+        expect(labels).toContain('x64');
+
+        if (labels.includes('ghr-team:alpha')) {
+          expect(labels).not.toContain('ghr-team:beta');
+          expect(labels).not.toContain('ghr-ec2-instance-type:c7i.large');
+        } else if (labels.includes('ghr-team:beta')) {
+          expect(labels).not.toContain('ghr-team:alpha');
+          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
+        } else {
+          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
+        }
+      }
+    });
   });
 
   describe('on repo level', () => {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -328,7 +328,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
 
   const enableOrgLevel = yn(process.env.ENABLE_ORGANIZATION_RUNNERS, { default: true });
   const maximumRunners = parseInt(process.env.RUNNERS_MAXIMUM_COUNT || '3');
-  let runnerLabels = process.env.RUNNER_LABELS || '';
+  const runnerLabels = process.env.RUNNER_LABELS || '';
   const runnerGroup = process.env.RUNNER_GROUP_NAME || 'Default';
   const environment = process.env.ENVIRONMENT;
   const ssmTokenPath = process.env.SSM_TOKEN_PATH;
@@ -457,6 +457,9 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
 
     let ec2OverrideConfig: Ec2OverrideConfig | undefined = undefined;
 
+    // Reset per group to avoid accumulating labels across iterations
+    let groupRunnerLabels = runnerLabels;
+
     if (messages.length > 0 && dynamicLabelsEnabled) {
       logger.debug('Dynamic EC2 config enabled, processing labels', { labels: messages[0].labels });
 
@@ -464,9 +467,11 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
       const allDynamicLabels = messages[0].labels?.map((l) => l.trim()).filter((l) => l.startsWith('ghr-')) ?? [];
 
       if (allDynamicLabels.length > 0) {
-        runnerLabels = runnerLabels ? `${runnerLabels},${allDynamicLabels.join(',')}` : allDynamicLabels.join(',');
+        groupRunnerLabels = groupRunnerLabels
+          ? `${groupRunnerLabels},${allDynamicLabels.join(',')}`
+          : allDynamicLabels.join(',');
 
-        logger.debug('Updated runner labels', { runnerLabels });
+        logger.debug('Updated runner labels', { runnerLabels: groupRunnerLabels });
 
         if (dynamicEC2Labels.length > 0) {
           ec2OverrideConfig = parseEc2OverrideConfig(dynamicEC2Labels);
@@ -562,7 +567,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
         ephemeral: ephemeralEnabled,
         enableJitConfig,
         ghesBaseUrl,
-        runnerLabels,
+        runnerLabels: groupRunnerLabels,
         runnerGroup,
         runnerNamePrefix,
         runnerOwner: runnerOwner,


### PR DESCRIPTION
## Summary

Fixes a bug where the `runnerLabels` variable accumulates labels from all batch groups, causing runners to be registered with labels from unrelated jobs.

## Problem

When multiple jobs with different `ghr-*` dynamic labels arrive in the same SQS batch (single lambda invocation), the `runnerLabels` variable is mutated across loop iterations:

```typescript
// Declared once outside the loop
let runnerLabels = process.env.RUNNER_LABELS || '';

for (const [group, { ... }] of validMessages.entries()) {
  // ACCUMULATES on each iteration — bug!
  runnerLabels = runnerLabels ? `${runnerLabels},${allDynamicLabels.join(',')}` : allDynamicLabels.join(',');
  createRunners({ runnerLabels, ... });
}
```

**Result**: By the Nth iteration, `runnerLabels` contains labels from groups 1 through N. Runners get registered with labels from all previously processed groups.

**Impact**:
- GitHub's superset matching assigns runners to wrong jobs
- `ghr-job-id` uniqueness guarantee broken (all job IDs from batch end up on every runner)
- Instance type mismatches (e.g., job requesting `m7a.large` gets a runner launched as `m7i.xlarge`)

## Fix

Introduce `groupRunnerLabels` scoped per loop iteration, initialized from the immutable base `runnerLabels` (now `const`):

```typescript
const runnerLabels = process.env.RUNNER_LABELS || '';

for (const [group, { ... }] of validMessages.entries()) {
  let groupRunnerLabels = runnerLabels; // fresh copy each iteration
  groupRunnerLabels = groupRunnerLabels ? `${groupRunnerLabels},${...}` : ...;
  createRunners({ runnerLabels: groupRunnerLabels, ... });
}
```

## Tests Added

- `does not accumulate labels across groups when multiple messages have different dynamic labels` — verifies 3 jobs in the same batch each get only their own labels in JIT config
- `preserves base RUNNER_LABELS for each group without mutation` — verifies base labels are present but not cross-contaminated

Closes #5175