### PR TITLE
fix(mac): handle RunInstances scale errors

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -1229,7 +1229,7 @@ describe('create runner with useDedicatedHost', () => {
     mockEC2Client.on(RunInstancesCommand).resolves({ Instances: [] });
 
     await expect(createRunner(createRunnerConfig(dedicatedHostRunnerConfig))).rejects.toThrow(
-      'RunInstances returned no instances for dedicated host.',
+      'RunInstances failed, no instance created.',
     );
   });
 
@@ -1237,6 +1237,37 @@ describe('create runner with useDedicatedHost', () => {
     mockEC2Client.on(RunInstancesCommand).rejects(new Error('EC2 error'));
 
     await expect(createRunner(createRunnerConfig(dedicatedHostRunnerConfig))).rejects.toThrow('EC2 error');
+  });
+
+  it('throws ScaleError when RunInstances fails with configured scale error', async () => {
+    const error = Object.assign(new Error('Insufficient capacity'), { name: 'InsufficientInstanceCapacity' });
+    mockEC2Client.on(RunInstancesCommand).rejects(error);
+
+    await expect(
+      createRunner({
+        ...createRunnerConfig({
+          ...dedicatedHostRunnerConfig,
+          scaleErrors: ['InsufficientInstanceCapacity'],
+        }),
+        numberOfRunners: 2,
+      }),
+    ).rejects.toMatchObject({
+      name: 'ScaleError',
+      failedInstanceCount: 2,
+    });
+  });
+
+  it('throws error when RunInstances returns fewer instances', async () => {
+    mockEC2Client.on(RunInstancesCommand).resolves({
+      Instances: [{ InstanceId: 'i-dedicated-1' }],
+    });
+
+    await expect(
+      createRunner({
+        ...createRunnerConfig(dedicatedHostRunnerConfig),
+        numberOfRunners: 2,
+      }),
+    ).rejects.toThrow('RunInstances failed, no instance created.');
   });
 
   it('uses ami id override from ssm parameter', async () => {

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -6,6 +6,7 @@ import {
   DescribeInstancesCommand,
   DescribeInstancesResult,
   RunInstancesCommand,
+  RunInstancesCommandOutput,
   EC2Client,
   FleetLaunchTemplateOverridesRequest,
   Tag,
@@ -232,6 +233,27 @@ function countScaleErrors(errors: string[], scaleErrors: string[]): number {
   return errors.reduce((acc, e) => (scaleErrors.includes(e) ? acc + 1 : acc), 0);
 }
 
+function processRunInstanceResult(
+  result: RunInstancesCommandOutput,
+  runnerParameters: Runners.RunnerInputParameters,
+): string[] {
+  const instances = result.Instances?.map((i) => i.InstanceId!).filter(Boolean) || [];
+
+  if (instances.length === runnerParameters.numberOfRunners) {
+    return instances;
+  }
+
+  logger.warn(
+    `${
+      instances.length === 0 ? 'No' : instances.length + ' off ' + runnerParameters.numberOfRunners
+    } instances created.`,
+    { data: result },
+  );
+
+  logger.warn('RunInstances failed, error not recognized as scaling error.', { data: result });
+  throw Error('RunInstances failed, no instance created.');
+}
+
 async function getAmiIdOverride(runnerParameters: Runners.RunnerInputParameters): Promise<string | undefined> {
   if (!runnerParameters.amiIdSsmParameterName) {
     return undefined;
@@ -333,6 +355,7 @@ async function createInstancesWithRunInstances(
     tags.push({ Key: 'ghr:trace_id', Value: traceId! });
   }
 
+  let result: RunInstancesCommandOutput;
   try {
     if (runnerParameters.ec2instanceCriteria.targetCapacityType === 'spot') {
       throw new Error(
@@ -364,18 +387,22 @@ async function createInstancesWithRunInstances(
     });
 
     logger.debug('RunInstances request payload.', { payload: runInstancesCommand.input });
-    const result = await ec2Client.send(runInstancesCommand);
-    const instanceIds = result.Instances?.map((i) => i.InstanceId!).filter(Boolean) || [];
-
-    if (instanceIds.length === 0) {
-      throw new Error('RunInstances returned no instances for dedicated host.');
+    result = await ec2Client.send(runInstancesCommand);
+  } catch (e) {
+    const errorName = (e as Error).name;
+    if (errorName && runnerParameters.scaleErrors.includes(errorName)) {
+      logger.warn('RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.', {
+        error: e as Error,
+        errorName,
+      });
+      throw new ScaleError(runnerParameters.numberOfRunners);
     }
 
-    return instanceIds;
-  } catch (e) {
     logger.warn('RunInstances request failed for dedicated host.', { error: e as Error });
     throw e;
   }
+
+  return processRunInstanceResult(result, runnerParameters);
 }
 
 // If launchTime is undefined, this will return false


### PR DESCRIPTION
## Description

Adds scale-error handling for the dedicated-host `RunInstances` path.

`RunInstances` does not return fleet-style `Errors`, so the catch block now checks the thrown AWS SDK error `name` against configured `scaleErrors` and throws `ScaleError` to trigger retry behavior. The successful response path is split into `processRunInstanceResult` to validate returned instance IDs.

## Test Plan

- Tested in my AWS environment with a dedicated-host scale-up where no compatible host capacity was available.
- Confirmed `RunInstances` failed with `InsufficientHostCapacity`, the error was matched through `error.name`, and `ScaleError` was thrown so the request is retried.

## Related Issues

N/A
