### PR TITLE
feat: tag runners with github labels

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,7 +568,7 @@ jobs:
       - ghr-ec2-vcpu-count-min:2
       - ghr-ec2-vcpu-count-max:8
       - ghr-ec2-memory-mib-min:8192
-      - "ghr-ec2-cpu-manufacturers:intel;amd"
+      - ghr-ec2-cpu-manufacturers:intel;amd
       - ghr-ec2-burstable-performance:excluded
 ```
 
@@ -579,6 +579,7 @@ jobs:
 - Labels are parsed at the scale-up lambda level — they do not change after the instance is launched.
 - A deterministic hash of all `ghr-` prefixed labels (both custom identity and EC2 override) is used for runner matching. Different label combinations produce different hashes, ensuring each unique set of requirements gets its own runner.
 - Dynamic `ghr-` labels can contain letters, numbers, `.`, `_`, `/`, `-`, `:`, and `;`. Comma is not allowed because it is reserved as a runner label separator.
+- GitHub runner labels are copied to EC2 as comma-separated values in `ghr:runner_labels` tags, capped at five label tags (`ghr:runner_labels` through `ghr:runner_labels:5`) to avoid consuming too many of the EC2 50 tags per resource.
 - Multiple EBS labels apply to the same (first) block device mapping. If you need more complex block device configurations, use a custom AMI or launch template instead.
 - This feature is compatible with both org-level and repo-level runners, spot and on-demand instances, and ephemeral and non-ephemeral runners.
 - Be mindful of the security implications: enabling this feature allows workflow authors to influence EC2 instance configuration via `ghr-ec2-` labels. Ensure your IAM policies and subnet configurations provide appropriate guardrails.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -579,7 +579,7 @@ jobs:
 - Labels are parsed at the scale-up lambda level — they do not change after the instance is launched.
 - A deterministic hash of all `ghr-` prefixed labels (both custom identity and EC2 override) is used for runner matching. Different label combinations produce different hashes, ensuring each unique set of requirements gets its own runner.
 - Dynamic `ghr-` labels can contain letters, numbers, `.`, `_`, `/`, `-`, `:`, and `;`. Comma is not allowed because it is reserved as a runner label separator.
-- GitHub runner labels are copied to EC2 as comma-separated values in `ghr:runner_labels` tags, capped at five label tags (`ghr:runner_labels` through `ghr:runner_labels:5`) to avoid consuming too many of the EC2 50 tags per resource.
+- GitHub runner labels are copied to EC2 as comma-separated values in `ghr:runner_labels` tags, capped at five label tags (`ghr:runner_labels` through `ghr:runner_labels:5`) to avoid consuming too many of the EC2 50 tags per resource. The comma-separated label value is split across those EC2 tags when it exceeds the tag value length limit.
 - Multiple EBS labels apply to the same (first) block device mapping. If you need more complex block device configurations, use a custom AMI or launch template instead.
 - This feature is compatible with both org-level and repo-level runners, spot and on-demand instances, and ephemeral and non-ephemeral runners.
 - Be mindful of the security implications: enabling this feature allows workflow authors to influence EC2 instance configuration via `ghr-ec2-` labels. Ensure your IAM policies and subnet configurations provide appropriate guardrails.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,9 +21,9 @@ The module uses the AWS System Manager Parameter Store to store configuration fo
 
 Furthermore, to accommodate larger JIT configurations or other stored values, the module implements automatic tier selection for SSM parameters:
 
--   **Parameter Tiering**: If the size of a parameter's value exceeds 4KB (specifically, 4000 bytes), the module will automatically use the 'Advanced' tier for that SSM parameter. Values smaller than this threshold will use the 'Standard' tier.
--   **Cost Implications**: While the 'Standard' tier is generally free for a certain number of parameters and operations, the 'Advanced' tier incurs costs. These costs are typically pro-rated per hour for each parameter stored using the Advanced tier. For detailed and up-to-date pricing, please refer to the [AWS Systems Manager Pricing page](https://aws.amazon.com/systems-manager/pricing/#Parameter_Store).
--   **Housekeeping Recommendation**: The last sentence of the "AWS SSM Parameters" section already mentions that "data not deleted after a day will be deleted by a SSM housekeeper lambda." It is crucial to ensure this or a similar housekeeping mechanism is active and correctly configured, especially considering the potential costs associated with 'Advanced' tier parameters. This utility should identify and delete any orphaned parameters to help manage costs and maintain a clean SSM environment.
+- **Parameter Tiering**: If the size of a parameter's value exceeds 4KB (specifically, 4000 bytes), the module will automatically use the 'Advanced' tier for that SSM parameter. Values smaller than this threshold will use the 'Standard' tier.
+- **Cost Implications**: While the 'Standard' tier is generally free for a certain number of parameters and operations, the 'Advanced' tier incurs costs. These costs are typically pro-rated per hour for each parameter stored using the Advanced tier. For detailed and up-to-date pricing, please refer to the [AWS Systems Manager Pricing page](https://aws.amazon.com/systems-manager/pricing/#Parameter_Store).
+- **Housekeeping Recommendation**: The last sentence of the "AWS SSM Parameters" section already mentions that "data not deleted after a day will be deleted by a SSM housekeeper lambda." It is crucial to ensure this or a similar housekeeping mechanism is active and correctly configured, especially considering the potential costs associated with 'Advanced' tier parameters. This utility should identify and delete any orphaned parameters to help manage costs and maintain a clean SSM environment.
 
 | Path                                                          | Description                                                                                                                                                                                                                     |
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -335,7 +335,7 @@ Below is an example of the log messages created.
 ### Dynamic Labels
 
 [!WARNING]
-**Security implication:** Dynamic labels are extracted from the `runs-on` labels in incoming `workflow_job` webhook events. These labels originate from what 
+**Security implication:** Dynamic labels are extracted from the `runs-on` labels in incoming `workflow_job` webhook events. These labels originate from what
 users define in their workflow files. Any user with permission to create or modify workflows can inject arbitrary EC2 configuration values — including instance types, AMI IDs, subnet IDs, EBS volumes, placement settings, and more. Unless constrained with `ec2_dynamic_labels_policy`, these values are not validated against label-specific rules before being passed to the EC2 CreateFleet API. This means a malicious or careless workflow author could, for example:
 
 - Launch expensive instance types (e.g., `p5.48xlarge`) to inflate costs
@@ -343,7 +343,7 @@ users define in their workflow files. Any user with permission to create or modi
 - Target specific subnets (`ghr-ec2-subnet-id`) to escape network boundaries
 - Set arbitrarily large EBS volumes (`ghr-ec2-ebs-volume-size:10000`)
 
-**Only enable this feature in repositories where you trust all workflow contributors.** Consider combining it with [GitHub branch protection 
+**Only enable this feature in repositories where you trust all workflow contributors.** Consider combining it with [GitHub branch protection
 rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-rule/about-branch-rules) and required reviews for workflow file changes.
 
 This feature is in early stage and therefore disabled by default. To enable dynamic labels, set `enable_dynamic_labels = true`.
@@ -352,7 +352,7 @@ Dynamic labels allow workflow authors to pass arbitrary metadata and EC2 instanc
 
 Dynamic labels serve two purposes:
 
-1. **Custom identity / restriction labels (`ghr-<key>:<value>`)** — Any `ghr-` prefixed label that is *not* `ghr-ec2-` acts as a custom identity label. These can represent a unique job ID, a team name, a cost center, an environment tag, or any arbitrary restriction. They do not affect EC2 configuration but are included in the label hash, guaranteeing unique runner matching per combination.
+1. **Custom identity / restriction labels (`ghr-<key>:<value>`)** — Any `ghr-` prefixed label that is _not_ `ghr-ec2-` acts as a custom identity label. These can represent a unique job ID, a team name, a cost center, an environment tag, or any arbitrary restriction. They do not affect EC2 configuration but are included in the label hash, guaranteeing unique runner matching per combination.
 2. **EC2 override labels (`ghr-ec2-<key>:<value>`)** — Labels prefixed with `ghr-ec2-` are parsed by the scale-up lambda to dynamically configure the EC2 launch request. For EC2 Fleet launches this can include instance type, vCPU/memory requirements, GPU/accelerator specs, EBS volumes, placement, and networking. For dedicated-host launches, only labels that map to `RunInstances` launch parameters are applied. This eliminates the need to create separate runner configurations for each hardware combination.
 
 #### How it works
@@ -417,7 +417,7 @@ In the example above, the three `ghr-` labels produce a unique hash, ensuring th
 
 #### EC2 override labels
 
-Labels using the format `ghr-ec2-<key>:<value>` override EC2 launch configuration. Values with multiple items use comma-separated lists.
+Labels using the format `ghr-ec2-<key>:<value>` override EC2 launch configuration. Values with multiple items use semicolon-separated lists, for example `ghr-ec2-cpu-manufacturers:intel;amd`. Comma is reserved as a runner label separator, so do not use comma inside dynamic `ghr-*` labels.
 
 For default EC2 Fleet launches (`use_dedicated_host = false`), labels in this section are parsed into the `CreateFleet` request. Basic fleet overrides, placement, and block device labels are sent as launch template overrides where EC2 Fleet accepts them. Instance requirement labels become `InstanceRequirements`; pricing labels set either the fleet override price (`ghr-ec2-max-price`) or instance requirement price preferences.
 
@@ -429,107 +429,107 @@ When `use_dedicated_host = true`, runner instances are launched with `RunInstanc
 
 ##### Basic Fleet Overrides
 
-| Label                                        | Description                          | Example value       | EC2 Fleet | Dedicated host |
-| -------------------------------------------- | ------------------------------------ | ------------------- | --------- | -------------- |
-| `ghr-ec2-instance-type:<type>`               | Set specific instance type           | `c5.xlarge`         | Yes       | Yes            |
-| `ghr-ec2-max-price:<price>`                  | Set maximum spot price               | `0.10`              | Yes       | No             |
-| `ghr-ec2-subnet-id:<id>`                     | Set subnet ID                        | `subnet-abc123`     | Yes       | Yes            |
-| `ghr-ec2-availability-zone:<zone>`           | Set availability zone                | `us-east-1a`        | Yes       | Yes            |
-| `ghr-ec2-availability-zone-id:<id>`          | Set availability zone ID             | `use1-az1`          | Yes       | Yes            |
-| `ghr-ec2-weighted-capacity:<number>`         | Set weighted capacity                | `2`                 | Yes       | No             |
-| `ghr-ec2-priority:<number>`                  | Set launch priority                  | `1`                 | Yes       | No             |
-| `ghr-ec2-image-id:<ami-id>`                  | Override AMI ID                      | `ami-0abcdef123`    | Yes       | Yes            |
+| Label                                | Description                | Example value    | EC2 Fleet | Dedicated host |
+| ------------------------------------ | -------------------------- | ---------------- | --------- | -------------- |
+| `ghr-ec2-instance-type:<type>`       | Set specific instance type | `c5.xlarge`      | Yes       | Yes            |
+| `ghr-ec2-max-price:<price>`          | Set maximum spot price     | `0.10`           | Yes       | No             |
+| `ghr-ec2-subnet-id:<id>`             | Set subnet ID              | `subnet-abc123`  | Yes       | Yes            |
+| `ghr-ec2-availability-zone:<zone>`   | Set availability zone      | `us-east-1a`     | Yes       | Yes            |
+| `ghr-ec2-availability-zone-id:<id>`  | Set availability zone ID   | `use1-az1`       | Yes       | Yes            |
+| `ghr-ec2-weighted-capacity:<number>` | Set weighted capacity      | `2`              | Yes       | No             |
+| `ghr-ec2-priority:<number>`          | Set launch priority        | `1`              | Yes       | No             |
+| `ghr-ec2-image-id:<ami-id>`          | Override AMI ID            | `ami-0abcdef123` | Yes       | Yes            |
 
 ##### Instance Requirements — vCPU & Memory
 
-| Label                                        | Description                          | Example value       | EC2 Fleet | Dedicated host |
-| -------------------------------------------- | ------------------------------------ | ------------------- | --------- | -------------- |
-| `ghr-ec2-vcpu-count-min:<number>`            | Minimum vCPU count                   | `4`                 | Yes       | No             |
-| `ghr-ec2-vcpu-count-max:<number>`            | Maximum vCPU count                   | `16`                | Yes       | No             |
-| `ghr-ec2-memory-mib-min:<number>`            | Minimum memory in MiB               | `16384`             | Yes       | No             |
-| `ghr-ec2-memory-mib-max:<number>`            | Maximum memory in MiB               | `65536`             | Yes       | No             |
-| `ghr-ec2-memory-gib-per-vcpu-min:<number>`   | Min memory per vCPU ratio (GiB)     | `2`                 | Yes       | No             |
-| `ghr-ec2-memory-gib-per-vcpu-max:<number>`   | Max memory per vCPU ratio (GiB)     | `8`                 | Yes       | No             |
+| Label                                      | Description                     | Example value | EC2 Fleet | Dedicated host |
+| ------------------------------------------ | ------------------------------- | ------------- | --------- | -------------- |
+| `ghr-ec2-vcpu-count-min:<number>`          | Minimum vCPU count              | `4`           | Yes       | No             |
+| `ghr-ec2-vcpu-count-max:<number>`          | Maximum vCPU count              | `16`          | Yes       | No             |
+| `ghr-ec2-memory-mib-min:<number>`          | Minimum memory in MiB           | `16384`       | Yes       | No             |
+| `ghr-ec2-memory-mib-max:<number>`          | Maximum memory in MiB           | `65536`       | Yes       | No             |
+| `ghr-ec2-memory-gib-per-vcpu-min:<number>` | Min memory per vCPU ratio (GiB) | `2`           | Yes       | No             |
+| `ghr-ec2-memory-gib-per-vcpu-max:<number>` | Max memory per vCPU ratio (GiB) | `8`           | Yes       | No             |
 
 ##### Instance Requirements — CPU & Performance
 
-| Label                                        | Description                                                       | Example value              | EC2 Fleet | Dedicated host |
-| -------------------------------------------- | ----------------------------------------------------------------- | -------------------------- | --------- | -------------- |
-| `ghr-ec2-cpu-manufacturers:<list>`           | CPU manufacturers (comma-separated: `intel`, `amd`, `amazon-web-services`) | `intel,amd`                | Yes       | No             |
-| `ghr-ec2-instance-generations:<list>`        | Instance generations (comma-separated)                            | `current`                  | Yes       | No             |
-| `ghr-ec2-excluded-instance-types:<list>`     | Exclude instance types (comma-separated)                          | `t2.micro,t3.nano`        | Yes       | No             |
-| `ghr-ec2-allowed-instance-types:<list>`      | Allow only specific instance types (comma-separated)              | `c5.xlarge,c5.2xlarge`    | Yes       | No             |
-| `ghr-ec2-burstable-performance:<value>`      | Burstable performance (`included`, `excluded`, `required`)        | `excluded`                 | Yes       | No             |
-| `ghr-ec2-bare-metal:<value>`                 | Bare metal (`included`, `excluded`, `required`)                   | `excluded`                 | Yes       | No             |
+| Label                                    | Description                                                                    | Example value          | EC2 Fleet | Dedicated host |
+| ---------------------------------------- | ------------------------------------------------------------------------------ | ---------------------- | --------- | -------------- |
+| `ghr-ec2-cpu-manufacturers:<list>`       | CPU manufacturers (semicolon-separated: `intel`, `amd`, `amazon-web-services`) | `intel;amd`            | Yes       | No             |
+| `ghr-ec2-instance-generations:<list>`    | Instance generations (semicolon-separated)                                     | `current`              | Yes       | No             |
+| `ghr-ec2-excluded-instance-types:<list>` | Exclude instance types (semicolon-separated)                                   | `t2.micro;t3.nano`     | Yes       | No             |
+| `ghr-ec2-allowed-instance-types:<list>`  | Allow only specific instance types (semicolon-separated)                       | `c5.xlarge;c5.2xlarge` | Yes       | No             |
+| `ghr-ec2-burstable-performance:<value>`  | Burstable performance (`included`, `excluded`, `required`)                     | `excluded`             | Yes       | No             |
+| `ghr-ec2-bare-metal:<value>`             | Bare metal (`included`, `excluded`, `required`)                                | `excluded`             | Yes       | No             |
 
 ##### Instance Requirements — Accelerators / GPU
 
-| Label                                             | Description                                                              | Example value                    | EC2 Fleet | Dedicated host |
-| ------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------- | --------- | -------------- |
-| `ghr-ec2-accelerator-types:<list>`                | Accelerator types (comma-separated: `gpu`, `fpga`, `inference`)          | `gpu`                            | Yes       | No             |
-| `ghr-ec2-accelerator-count-min:<number>`          | Minimum accelerator count                                                | `1`                              | Yes       | No             |
-| `ghr-ec2-accelerator-count-max:<number>`          | Maximum accelerator count                                                | `4`                              | Yes       | No             |
-| `ghr-ec2-accelerator-manufacturers:<list>`        | Accelerator manufacturers (comma-separated: `nvidia`, `amd`, `amazon-web-services`, `xilinx`) | `nvidia`                         | Yes       | No             |
-| `ghr-ec2-accelerator-names:<list>`                | Specific accelerator names (comma-separated)                             | `t4,v100`                        | Yes       | No             |
-| `ghr-ec2-accelerator-total-memory-mib-min:<number>` | Min accelerator total memory in MiB                                    | `8192`                           | Yes       | No             |
-| `ghr-ec2-accelerator-total-memory-mib-max:<number>` | Max accelerator total memory in MiB                                    | `32768`                          | Yes       | No             |
+| Label                                               | Description                                                                                       | Example value | EC2 Fleet | Dedicated host |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------- | --------- | -------------- |
+| `ghr-ec2-accelerator-types:<list>`                  | Accelerator types (semicolon-separated: `gpu`, `fpga`, `inference`)                               | `gpu`         | Yes       | No             |
+| `ghr-ec2-accelerator-count-min:<number>`            | Minimum accelerator count                                                                         | `1`           | Yes       | No             |
+| `ghr-ec2-accelerator-count-max:<number>`            | Maximum accelerator count                                                                         | `4`           | Yes       | No             |
+| `ghr-ec2-accelerator-manufacturers:<list>`          | Accelerator manufacturers (semicolon-separated: `nvidia`, `amd`, `amazon-web-services`, `xilinx`) | `nvidia`      | Yes       | No             |
+| `ghr-ec2-accelerator-names:<list>`                  | Specific accelerator names (semicolon-separated)                                                  | `t4;v100`     | Yes       | No             |
+| `ghr-ec2-accelerator-total-memory-mib-min:<number>` | Min accelerator total memory in MiB                                                               | `8192`        | Yes       | No             |
+| `ghr-ec2-accelerator-total-memory-mib-max:<number>` | Max accelerator total memory in MiB                                                               | `32768`       | Yes       | No             |
 
 ##### Instance Requirements — Network & Storage
 
-| Label                                              | Description                                                       | Example value       | EC2 Fleet | Dedicated host |
-| -------------------------------------------------- | ----------------------------------------------------------------- | ------------------- | --------- | -------------- |
-| `ghr-ec2-network-interface-count-min:<number>`     | Min network interfaces                                            | `1`                 | Yes       | No             |
-| `ghr-ec2-network-interface-count-max:<number>`     | Max network interfaces                                            | `4`                 | Yes       | No             |
-| `ghr-ec2-network-bandwidth-gbps-min:<number>`      | Min network bandwidth in Gbps                                     | `10`                | Yes       | No             |
-| `ghr-ec2-network-bandwidth-gbps-max:<number>`      | Max network bandwidth in Gbps                                     | `25`                | Yes       | No             |
-| `ghr-ec2-local-storage:<value>`                    | Local storage (`included`, `excluded`, `required`)                | `required`          | Yes       | No             |
-| `ghr-ec2-local-storage-types:<list>`               | Local storage types (comma-separated: `hdd`, `ssd`)              | `ssd`               | Yes       | No             |
-| `ghr-ec2-total-local-storage-gb-min:<number>`      | Min total local storage in GB                                     | `100`               | Yes       | No             |
-| `ghr-ec2-total-local-storage-gb-max:<number>`      | Max total local storage in GB                                     | `500`               | Yes       | No             |
-| `ghr-ec2-baseline-ebs-bandwidth-mbps-min:<number>` | Min baseline EBS bandwidth in Mbps                                | `1000`              | Yes       | No             |
-| `ghr-ec2-baseline-ebs-bandwidth-mbps-max:<number>` | Max baseline EBS bandwidth in Mbps                                | `5000`              | Yes       | No             |
+| Label                                              | Description                                             | Example value | EC2 Fleet | Dedicated host |
+| -------------------------------------------------- | ------------------------------------------------------- | ------------- | --------- | -------------- |
+| `ghr-ec2-network-interface-count-min:<number>`     | Min network interfaces                                  | `1`           | Yes       | No             |
+| `ghr-ec2-network-interface-count-max:<number>`     | Max network interfaces                                  | `4`           | Yes       | No             |
+| `ghr-ec2-network-bandwidth-gbps-min:<number>`      | Min network bandwidth in Gbps                           | `10`          | Yes       | No             |
+| `ghr-ec2-network-bandwidth-gbps-max:<number>`      | Max network bandwidth in Gbps                           | `25`          | Yes       | No             |
+| `ghr-ec2-local-storage:<value>`                    | Local storage (`included`, `excluded`, `required`)      | `required`    | Yes       | No             |
+| `ghr-ec2-local-storage-types:<list>`               | Local storage types (semicolon-separated: `hdd`, `ssd`) | `ssd`         | Yes       | No             |
+| `ghr-ec2-total-local-storage-gb-min:<number>`      | Min total local storage in GB                           | `100`         | Yes       | No             |
+| `ghr-ec2-total-local-storage-gb-max:<number>`      | Max total local storage in GB                           | `500`         | Yes       | No             |
+| `ghr-ec2-baseline-ebs-bandwidth-mbps-min:<number>` | Min baseline EBS bandwidth in Mbps                      | `1000`        | Yes       | No             |
+| `ghr-ec2-baseline-ebs-bandwidth-mbps-max:<number>` | Max baseline EBS bandwidth in Mbps                      | `5000`        | Yes       | No             |
 
 ##### Placement
 
-| Label                                                  | Description                                                | Example value         | EC2 Fleet | Dedicated host |
-| ------------------------------------------------------ | ---------------------------------------------------------- | --------------------- | --------- | -------------- |
-| `ghr-ec2-placement-group-name:<name>`                  | Placement group name                                       | `my-cluster-group`    | Yes       | Yes            |
-| `ghr-ec2-placement-group-id:<id>`                      | Placement group ID                                         | `pg-abc123`           | Yes       | Yes            |
-| `ghr-ec2-placement-tenancy:<value>`                    | Tenancy (`default`, `dedicated`, `host`)                   | `dedicated`           | Yes       | Yes            |
-| `ghr-ec2-placement-host-id:<id>`                       | Dedicated host ID                                          | `h-abc123`            | Yes       | Yes            |
-| `ghr-ec2-placement-affinity:<value>`                   | Affinity (`default`, `host`)                               | `host`                | Yes       | Yes            |
-| `ghr-ec2-placement-partition-number:<number>`          | Partition number                                           | `1`                   | Yes       | Yes            |
-| `ghr-ec2-placement-availability-zone:<zone>`           | Placement availability zone                                | `us-east-1a`          | Yes       | Yes            |
-| `ghr-ec2-placement-availability-zone-id:<id>`          | Placement availability zone ID                             | `use1-az1`            | Yes       | Yes            |
-| `ghr-ec2-placement-spread-domain:<domain>`             | Spread domain                                              | `my-domain`           | Yes       | Yes            |
-| `ghr-ec2-placement-host-resource-group-arn:<arn>`      | Host resource group ARN                                    | `arn:aws:...`         | Yes       | Yes            |
+| Label                                             | Description                              | Example value      | EC2 Fleet | Dedicated host |
+| ------------------------------------------------- | ---------------------------------------- | ------------------ | --------- | -------------- |
+| `ghr-ec2-placement-group-name:<name>`             | Placement group name                     | `my-cluster-group` | Yes       | Yes            |
+| `ghr-ec2-placement-group-id:<id>`                 | Placement group ID                       | `pg-abc123`        | Yes       | Yes            |
+| `ghr-ec2-placement-tenancy:<value>`               | Tenancy (`default`, `dedicated`, `host`) | `dedicated`        | Yes       | Yes            |
+| `ghr-ec2-placement-host-id:<id>`                  | Dedicated host ID                        | `h-abc123`         | Yes       | Yes            |
+| `ghr-ec2-placement-affinity:<value>`              | Affinity (`default`, `host`)             | `host`             | Yes       | Yes            |
+| `ghr-ec2-placement-partition-number:<number>`     | Partition number                         | `1`                | Yes       | Yes            |
+| `ghr-ec2-placement-availability-zone:<zone>`      | Placement availability zone              | `us-east-1a`       | Yes       | Yes            |
+| `ghr-ec2-placement-availability-zone-id:<id>`     | Placement availability zone ID           | `use1-az1`         | Yes       | Yes            |
+| `ghr-ec2-placement-spread-domain:<domain>`        | Spread domain                            | `my-domain`        | Yes       | Yes            |
+| `ghr-ec2-placement-host-resource-group-arn:<arn>` | Host resource group ARN                  | `arn:aws:...`      | Yes       | Yes            |
 
 ##### Block Device Mappings (EBS)
 
-| Label                                            | Description                                                    | Example value  | EC2 Fleet | Dedicated host |
-| ------------------------------------------------ | -------------------------------------------------------------- | -------------- | --------- | -------------- |
-| `ghr-ec2-block-device-name:<name>`               | Block device name                                              | `/dev/sda1`    | Yes       | Yes            |
-| `ghr-ec2-ebs-volume-size:<size>`                 | EBS volume size in GB                                          | `100`          | Yes       | Yes            |
-| `ghr-ec2-ebs-volume-type:<type>`                 | EBS volume type (`gp2`, `gp3`, `io1`, `io2`, `st1`, `sc1`)   | `gp3`          | Yes       | Yes            |
-| `ghr-ec2-ebs-iops:<number>`                      | EBS IOPS                                                       | `3000`         | Yes       | Yes            |
-| `ghr-ec2-ebs-throughput:<number>`                 | EBS throughput in MB/s (gp3 only)                              | `125`          | Yes       | Yes            |
-| `ghr-ec2-ebs-encrypted:<boolean>`                 | EBS encryption (`true`, `false`)                               | `true`         | Yes       | Yes            |
-| `ghr-ec2-ebs-kms-key-id:<id>`                    | KMS key ID for encryption                                      | `key-abc123`   | Yes       | Yes            |
-| `ghr-ec2-ebs-delete-on-termination:<boolean>`     | Delete on termination (`true`, `false`)                        | `true`         | Yes       | Yes            |
-| `ghr-ec2-ebs-snapshot-id:<id>`                    | Snapshot ID for EBS volume                                     | `snap-abc123`  | Yes       | Yes            |
-| `ghr-ec2-block-device-virtual-name:<name>`        | Virtual device name (ephemeral storage)                        | `ephemeral0`   | Yes       | Yes            |
-| `ghr-ec2-block-device-no-device:<string>`         | Suppresses device mapping                                      | `true`         | Yes       | Yes            |
+| Label                                         | Description                                                | Example value | EC2 Fleet | Dedicated host |
+| --------------------------------------------- | ---------------------------------------------------------- | ------------- | --------- | -------------- |
+| `ghr-ec2-block-device-name:<name>`            | Block device name                                          | `/dev/sda1`   | Yes       | Yes            |
+| `ghr-ec2-ebs-volume-size:<size>`              | EBS volume size in GB                                      | `100`         | Yes       | Yes            |
+| `ghr-ec2-ebs-volume-type:<type>`              | EBS volume type (`gp2`, `gp3`, `io1`, `io2`, `st1`, `sc1`) | `gp3`         | Yes       | Yes            |
+| `ghr-ec2-ebs-iops:<number>`                   | EBS IOPS                                                   | `3000`        | Yes       | Yes            |
+| `ghr-ec2-ebs-throughput:<number>`             | EBS throughput in MB/s (gp3 only)                          | `125`         | Yes       | Yes            |
+| `ghr-ec2-ebs-encrypted:<boolean>`             | EBS encryption (`true`, `false`)                           | `true`        | Yes       | Yes            |
+| `ghr-ec2-ebs-kms-key-id:<id>`                 | KMS key ID for encryption                                  | `key-abc123`  | Yes       | Yes            |
+| `ghr-ec2-ebs-delete-on-termination:<boolean>` | Delete on termination (`true`, `false`)                    | `true`        | Yes       | Yes            |
+| `ghr-ec2-ebs-snapshot-id:<id>`                | Snapshot ID for EBS volume                                 | `snap-abc123` | Yes       | Yes            |
+| `ghr-ec2-block-device-virtual-name:<name>`    | Virtual device name (ephemeral storage)                    | `ephemeral0`  | Yes       | Yes            |
+| `ghr-ec2-block-device-no-device:<string>`     | Suppresses device mapping                                  | `true`        | Yes       | Yes            |
 
 ##### Pricing & Advanced
 
-| Label                                                                         | Description                                                        | Example value  | EC2 Fleet | Dedicated host |
-| ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------- | --------- | -------------- |
-| `ghr-ec2-spot-max-price-percentage-over-lowest-price:<number>`                | Spot max price as % over lowest price                              | `20`           | Yes       | No             |
-| `ghr-ec2-on-demand-max-price-percentage-over-lowest-price:<number>`           | On-demand max price as % over lowest price                         | `10`           | Yes       | No             |
-| `ghr-ec2-max-spot-price-as-percentage-of-optimal-on-demand-price:<number>`    | Max spot price as % of optimal on-demand                           | `50`           | Yes       | No             |
-| `ghr-ec2-require-hibernate-support:<boolean>`                                 | Require hibernate support (`true`, `false`)                        | `true`         | Yes       | No             |
-| `ghr-ec2-require-encryption-in-transit:<boolean>`                             | Require encryption in-transit (`true`, `false`)                    | `true`         | Yes       | No             |
-| `ghr-ec2-baseline-performance-factors-cpu-reference-families:<list>`          | CPU baseline performance reference families (comma-separated)      | `c5,m5`        | Yes       | No             |
+| Label                                                                      | Description                                                       | Example value | EC2 Fleet | Dedicated host |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------- | --------- | -------------- |
+| `ghr-ec2-spot-max-price-percentage-over-lowest-price:<number>`             | Spot max price as % over lowest price                             | `20`          | Yes       | No             |
+| `ghr-ec2-on-demand-max-price-percentage-over-lowest-price:<number>`        | On-demand max price as % over lowest price                        | `10`          | Yes       | No             |
+| `ghr-ec2-max-spot-price-as-percentage-of-optimal-on-demand-price:<number>` | Max spot price as % of optimal on-demand                          | `50`          | Yes       | No             |
+| `ghr-ec2-require-hibernate-support:<boolean>`                              | Require hibernate support (`true`, `false`)                       | `true`        | Yes       | No             |
+| `ghr-ec2-require-encryption-in-transit:<boolean>`                          | Require encryption in-transit (`true`, `false`)                   | `true`        | Yes       | No             |
+| `ghr-ec2-baseline-performance-factors-cpu-reference-families:<list>`       | CPU baseline performance reference families (semicolon-separated) | `c5;m5`       | Yes       | No             |
 
 #### Examples
 
@@ -557,7 +557,7 @@ jobs:
       - ghr-ec2-ebs-volume-type:gp3
 ```
 
-Attribute-based instance selection with Intel CPUs only:
+Attribute-based instance selection with Intel or AMD CPUs:
 
 ```yaml
 jobs:
@@ -568,7 +568,7 @@ jobs:
       - ghr-ec2-vcpu-count-min:2
       - ghr-ec2-vcpu-count-max:8
       - ghr-ec2-memory-mib-min:8192
-      - ghr-ec2-cpu-manufacturers:intel
+      - "ghr-ec2-cpu-manufacturers:intel;amd"
       - ghr-ec2-burstable-performance:excluded
 ```
 
@@ -578,7 +578,7 @@ jobs:
 - When using `ghr-ec2-instance-type`, the fleet request uses a direct instance type override. When using `ghr-ec2-vcpu-count-*`, `ghr-ec2-memory-mib-*`, or other instance requirement labels, the fleet request uses [attribute-based instance type selection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-attribute-based-instance-type-selection.html).
 - Labels are parsed at the scale-up lambda level — they do not change after the instance is launched.
 - A deterministic hash of all `ghr-` prefixed labels (both custom identity and EC2 override) is used for runner matching. Different label combinations produce different hashes, ensuring each unique set of requirements gets its own runner.
-- Custom `ghr-` labels (non-`ec2`) are free-form — you can use any key/value pair. They are not validated by the module.
+- Dynamic `ghr-` labels can contain letters, numbers, `.`, `_`, `/`, `-`, `:`, and `;`. Comma is not allowed because it is reserved as a runner label separator.
 - Multiple EBS labels apply to the same (first) block device mapping. If you need more complex block device configurations, use a custom AMI or launch template instead.
 - This feature is compatible with both org-level and repo-level runners, spot and on-demand instances, and ephemeral and non-ephemeral runners.
 - Be mindful of the security implications: enabling this feature allows workflow authors to influence EC2 instance configuration via `ghr-ec2-` labels. Ensure your IAM policies and subnet configurations provide appropriate guardrails.

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -7,7 +7,7 @@ import nock from 'nock';
 import { performance } from 'perf_hooks';
 
 import * as ghAuth from '../github/auth';
-import { createRunner, listEC2Runners } from './../aws/runners';
+import { createRunner, listEC2Runners, tag } from './../aws/runners';
 import { RunnerInputParameters } from './../aws/runners.d';
 import * as scaleUpModule from './scale-up';
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
@@ -33,6 +33,7 @@ const mockOctokit = {
 
 const mockCreateRunner = vi.mocked(createRunner);
 const mockListRunners = vi.mocked(listEC2Runners);
+const mockTag = vi.mocked(tag);
 const mockEC2Client = mockClient(EC2Client);
 const mockSSMClient = mockClient(SSMClient);
 const mockSSMgetParameter = vi.mocked(getParameter);
@@ -286,6 +287,29 @@ describe('scaleUp with GHES', () => {
     it('creates a runner with correct config', async () => {
       await scaleUpModule.scaleUp(TEST_DATA);
       expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('tags the EC2 runner with the GitHub runner metadata returned by JIT config', async () => {
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockTag).toHaveBeenCalledWith('i-12345', [
+        { Key: 'ghr:github_runner_id', Value: '9876543210' },
+        { Key: 'ghr:runner_labels', Value: 'label1,label2' },
+      ]);
+    });
+
+    it('splits GitHub runner labels over multiple EC2 tags when the tag value would be too long', async () => {
+      const firstLabel = `label-${'a'.repeat(120)}`;
+      const secondLabel = `label-${'b'.repeat(120)}`;
+      const thirdLabel = `label-${'c'.repeat(120)}`;
+      process.env.RUNNER_LABELS = [firstLabel, secondLabel, thirdLabel].join(',');
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(mockTag).toHaveBeenCalledWith('i-12345', [
+        { Key: 'ghr:github_runner_id', Value: '9876543210' },
+        { Key: 'ghr:runner_labels', Value: `${firstLabel},${secondLabel}` },
+        { Key: 'ghr:runner_labels:2', Value: thirdLabel },
+      ]);
     });
 
     it('creates a runner with labels in a specific group', async () => {
@@ -644,6 +668,16 @@ describe('scaleUp with GHES', () => {
           }),
         }),
       );
+      expect(mockTag).toHaveBeenCalledWith('i-12345', [
+        {
+          Key: 'ghr:github_runner_id',
+          Value: '9876543210',
+        },
+        {
+          Key: 'ghr:runner_labels',
+          Value: 'base-label,ghr-ec2-instance-type:c5.2xlarge,ghr-ec2-custom:value',
+        },
+      ]);
     });
 
     it('uses default instance types when no instance type EC2 label is provided', async () => {
@@ -3333,15 +3367,15 @@ function defaultOctokitMockImpl() {
       name: 'Default',
     },
   ]);
-  mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(() => ({
+  mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ labels }: { labels: string[] }) => ({
     data: {
-      runner: { id: 9876543210 },
+      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
       encoded_jit_config: 'TEST_JIT_CONFIG_ORG',
     },
   }));
-  mockOctokit.actions.generateRunnerJitconfigForRepo.mockImplementation(() => ({
+  mockOctokit.actions.generateRunnerJitconfigForRepo.mockImplementation(({ labels }: { labels: string[] }) => ({
     data: {
-      runner: { id: 9876543210 },
+      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
       encoded_jit_config: 'TEST_JIT_CONFIG_REPO',
     },
   }));

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -310,6 +310,28 @@ describe('scaleUp with GHES', () => {
       ]);
     });
 
+    it('limits GitHub runner label metadata to five EC2 tags', async () => {
+      process.env.RUNNER_LABELS = [
+        'a'.repeat(256),
+        'b'.repeat(256),
+        'c'.repeat(256),
+        'd'.repeat(256),
+        'e'.repeat(256),
+        'f'.repeat(256),
+      ].join(',');
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(mockTag).toHaveBeenCalledWith('i-12345', [
+        { Key: 'ghr:github_runner_id', Value: '9876543210' },
+        { Key: 'ghr:runner_labels', Value: 'a'.repeat(256) },
+        { Key: 'ghr:runner_labels:2', Value: 'b'.repeat(256) },
+        { Key: 'ghr:runner_labels:3', Value: 'c'.repeat(256) },
+        { Key: 'ghr:runner_labels:4', Value: 'd'.repeat(256) },
+        { Key: 'ghr:runner_labels:5', Value: 'e'.repeat(256) },
+      ]);
+    });
+
     it('uses a reserved separator when packing GitHub runner labels into EC2 tags', async () => {
       process.env.RUNNER_LABELS = ['label:with/slash', 'label+with+plus'].join(',');
       const testDataWithSemicolonDynamicLabel = [

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -297,18 +297,37 @@ describe('scaleUp with GHES', () => {
       ]);
     });
 
-    it('splits GitHub runner labels over multiple EC2 tags when the tag value would be too long', async () => {
-      const firstLabel = `label-${'a'.repeat(120)}`;
-      const secondLabel = `label-${'b'.repeat(120)}`;
-      const thirdLabel = `label-${'c'.repeat(120)}`;
-      process.env.RUNNER_LABELS = [firstLabel, secondLabel, thirdLabel].join(',');
+    it('splits a GitHub runner label over multiple EC2 tags when the tag value would be too long', async () => {
+      const longLabel = `label-${'a'.repeat(300)}`;
+      process.env.RUNNER_LABELS = longLabel;
 
       await scaleUpModule.scaleUp(TEST_DATA);
 
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
-        { Key: 'ghr:runner_labels', Value: `${firstLabel},${secondLabel}` },
-        { Key: 'ghr:runner_labels:2', Value: thirdLabel },
+        { Key: 'ghr:runner_labels', Value: `label-${'a'.repeat(250)}` },
+        { Key: 'ghr:runner_labels:2', Value: 'a'.repeat(50) },
+      ]);
+    });
+
+    it('uses a reserved separator when packing GitHub runner labels into EC2 tags', async () => {
+      process.env.RUNNER_LABELS = ['label:with/slash', 'label+with+plus'].join(',');
+      const testDataWithSemicolonDynamicLabel = [
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['ghr-ec2-cpu-manufacturers:intel;amd'],
+          messageId: 'test-semicolon-dynamic-label',
+        },
+      ];
+
+      await scaleUpModule.scaleUp(testDataWithSemicolonDynamicLabel);
+
+      expect(mockTag).toHaveBeenCalledWith('i-12345', [
+        { Key: 'ghr:github_runner_id', Value: '9876543210' },
+        {
+          Key: 'ghr:runner_labels',
+          Value: 'label:with/slash,label+with+plus,ghr-ec2-cpu-manufacturers:intel;amd',
+        },
       ]);
     });
 
@@ -396,6 +415,33 @@ describe('scaleUp with GHES', () => {
         Value:
           '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
           '--labels label1,label2 --runnergroup Default',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'InstanceId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('quotes runner labels with semicolon separators in non-ephemeral runner config', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+
+      await scaleUpModule.scaleUp([
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['ghr-ec2-cpu-manufacturers:intel;amd'],
+          messageId: 'test-semicolon-labels',
+        },
+      ]);
+
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value:
+          '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
+          "--labels 'label1,label2,ghr-ec2-cpu-manufacturers:intel;amd' --runnergroup Default",
         Type: 'SecureString',
         Tags: [
           {
@@ -898,7 +944,7 @@ describe('scaleUp with GHES', () => {
       const testDataWithCpuLabels = [
         {
           ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-cpu-manufacturers:intel,amd'],
+          labels: ['self-hosted', 'ghr-ec2-cpu-manufacturers:intel;amd'],
           messageId: 'test-11',
         },
       ];
@@ -2888,8 +2934,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.CpuManufacturers).toEqual(['intel']);
     });
 
-    it('should parse cpu-manufacturers as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-cpu-manufacturers:intel,amd']);
+    it('should parse cpu-manufacturers as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-cpu-manufacturers:intel;amd']);
       expect(result?.InstanceRequirements?.CpuManufacturers).toEqual(['intel', 'amd']);
     });
 
@@ -2898,8 +2944,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.InstanceGenerations).toEqual(['current']);
     });
 
-    it('should parse instance-generations as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-instance-generations:current,previous']);
+    it('should parse instance-generations as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-instance-generations:current;previous']);
       expect(result?.InstanceRequirements?.InstanceGenerations).toEqual(['current', 'previous']);
     });
 
@@ -2908,8 +2954,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.ExcludedInstanceTypes).toEqual(['t2.micro']);
     });
 
-    it('should parse excluded-instance-types as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-excluded-instance-types:t2.micro,t2.small']);
+    it('should parse excluded-instance-types as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-excluded-instance-types:t2.micro;t2.small']);
       expect(result?.InstanceRequirements?.ExcludedInstanceTypes).toEqual(['t2.micro', 't2.small']);
     });
 
@@ -2918,8 +2964,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.AllowedInstanceTypes).toEqual(['c5.xlarge']);
     });
 
-    it('should parse allowed-instance-types as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-allowed-instance-types:c5.xlarge,c5.2xlarge']);
+    it('should parse allowed-instance-types as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-allowed-instance-types:c5.xlarge;c5.2xlarge']);
       expect(result?.InstanceRequirements?.AllowedInstanceTypes).toEqual(['c5.xlarge', 'c5.2xlarge']);
     });
 
@@ -2959,8 +3005,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.AcceleratorTypes).toEqual(['gpu']);
     });
 
-    it('should parse accelerator-types as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-types:gpu,fpga']);
+    it('should parse accelerator-types as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-types:gpu;fpga']);
       expect(result?.InstanceRequirements?.AcceleratorTypes).toEqual(['gpu', 'fpga']);
     });
 
@@ -2969,8 +3015,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.AcceleratorManufacturers).toEqual(['nvidia']);
     });
 
-    it('should parse accelerator-manufacturers as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-manufacturers:nvidia,amd']);
+    it('should parse accelerator-manufacturers as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-manufacturers:nvidia;amd']);
       expect(result?.InstanceRequirements?.AcceleratorManufacturers).toEqual(['nvidia', 'amd']);
     });
 
@@ -2979,8 +3025,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.AcceleratorNames).toEqual(['a100']);
     });
 
-    it('should parse accelerator-names as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-names:a100,v100']);
+    it('should parse accelerator-names as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-accelerator-names:a100;v100']);
       expect(result?.InstanceRequirements?.AcceleratorNames).toEqual(['a100', 'v100']);
     });
 
@@ -3039,8 +3085,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.InstanceRequirements?.LocalStorageTypes).toEqual(['ssd']);
     });
 
-    it('should parse local-storage-types as comma-separated list', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-local-storage-types:hdd,ssd']);
+    it('should parse local-storage-types as semicolon-separated list', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-local-storage-types:hdd;ssd']);
       expect(result?.InstanceRequirements?.LocalStorageTypes).toEqual(['hdd', 'ssd']);
     });
 
@@ -3115,7 +3161,7 @@ describe('parseEc2OverrideConfig', () => {
     });
     it('should parse baseline-performance-factors-cpu-reference-families list label', () => {
       const result = scaleUpModule.parseEc2OverrideConfig([
-        'ghr-ec2-baseline-performance-factors-cpu-reference-families:intel,amd',
+        'ghr-ec2-baseline-performance-factors-cpu-reference-families:intel;amd',
       ]);
       expect(result?.InstanceRequirements?.BaselinePerformanceFactors?.Cpu?.References?.[0]?.InstanceFamily).toBe(
         'intel',
@@ -3205,8 +3251,8 @@ describe('parseEc2OverrideConfig', () => {
       expect(result?.MaxPrice).toBe('0.12345');
     });
 
-    it('should handle whitespace in comma-separated lists', () => {
-      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-cpu-manufacturers: intel , amd ']);
+    it('should handle whitespace in semicolon-separated lists', () => {
+      const result = scaleUpModule.parseEc2OverrideConfig(['ghr-ec2-cpu-manufacturers: intel ; amd ']);
       expect(result?.InstanceRequirements?.CpuManufacturers).toEqual([' intel ', ' amd ']);
     });
 
@@ -3244,7 +3290,7 @@ describe('parseEc2OverrideConfig', () => {
         'ghr-ec2-vcpu-count-min:8',
         'ghr-ec2-vcpu-count-max:32',
         'ghr-ec2-memory-mib-min:32768',
-        'ghr-ec2-cpu-manufacturers:intel,amd',
+        'ghr-ec2-cpu-manufacturers:intel;amd',
         'ghr-ec2-instance-generations:current',
       ]);
 
@@ -3269,7 +3315,7 @@ describe('parseEc2OverrideConfig', () => {
         'ghr-ec2-accelerator-count-max:4',
         'ghr-ec2-accelerator-types:gpu',
         'ghr-ec2-accelerator-manufacturers:nvidia',
-        'ghr-ec2-accelerator-names:a100,v100',
+        'ghr-ec2-accelerator-names:a100;v100',
         'ghr-ec2-accelerator-total-memory-mib-min:16384',
       ]);
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -297,38 +297,39 @@ describe('scaleUp with GHES', () => {
       ]);
     });
 
-    it('splits a GitHub runner label over multiple EC2 tags when the tag value would be too long', async () => {
-      const longLabel = `label-${'a'.repeat(300)}`;
-      process.env.RUNNER_LABELS = longLabel;
+    it('chunks comma-joined GitHub runner labels by the EC2 tag value max length', async () => {
+      const runnerLabels = ['a'.repeat(scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH), 'b'].join(',');
+      process.env.RUNNER_LABELS = runnerLabels;
 
       await scaleUpModule.scaleUp(TEST_DATA);
 
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
-        { Key: 'ghr:runner_labels', Value: `label-${'a'.repeat(250)}` },
-        { Key: 'ghr:runner_labels:2', Value: 'a'.repeat(50) },
+        { Key: 'ghr:runner_labels', Value: runnerLabels.slice(0, scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH) },
+        {
+          Key: 'ghr:runner_labels:2',
+          Value: runnerLabels.slice(scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH),
+        },
       ]);
     });
 
     it('limits GitHub runner label metadata to five EC2 tags', async () => {
-      process.env.RUNNER_LABELS = [
-        'a'.repeat(256),
-        'b'.repeat(256),
-        'c'.repeat(256),
-        'd'.repeat(256),
-        'e'.repeat(256),
-        'f'.repeat(256),
-      ].join(',');
+      const runnerLabels = Array.from({ length: scaleUpModule.RUNNER_LABELS_TAG_MAX_COUNT + 1 }, (_, index) =>
+        String.fromCharCode('a'.charCodeAt(0) + index).repeat(scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH),
+      ).join(',');
+      process.env.RUNNER_LABELS = runnerLabels;
 
       await scaleUpModule.scaleUp(TEST_DATA);
 
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
-        { Key: 'ghr:runner_labels', Value: 'a'.repeat(256) },
-        { Key: 'ghr:runner_labels:2', Value: 'b'.repeat(256) },
-        { Key: 'ghr:runner_labels:3', Value: 'c'.repeat(256) },
-        { Key: 'ghr:runner_labels:4', Value: 'd'.repeat(256) },
-        { Key: 'ghr:runner_labels:5', Value: 'e'.repeat(256) },
+        ...Array.from({ length: scaleUpModule.RUNNER_LABELS_TAG_MAX_COUNT }, (_, index) => ({
+          Key: index === 0 ? 'ghr:runner_labels' : `ghr:runner_labels:${index + 1}`,
+          Value: runnerLabels.slice(
+            index * scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH,
+            (index + 1) * scaleUpModule.EC2_TAG_VALUE_MAX_LENGTH,
+          ),
+        })),
       ]);
     });
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -50,8 +50,8 @@ const logger = createChildLogger('scale-up');
 const RUNNER_LABELS_TAG_KEY = 'ghr:runner_labels';
 const RUNNER_LABELS_TAG_VALUE_SEPARATOR = ',';
 const EC2_OVERRIDE_LIST_VALUE_SEPARATOR = ';';
-const EC2_TAG_VALUE_MAX_LENGTH = 256;
-const RUNNER_LABELS_TAG_MAX_COUNT = 5;
+export const EC2_TAG_VALUE_MAX_LENGTH = 256;
+export const RUNNER_LABELS_TAG_MAX_COUNT = 5;
 
 export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
 
@@ -369,41 +369,15 @@ function generateRunnerLabelsTags(labels: string[]): Tag[] {
 }
 
 function packRunnerLabelsTagValues(labels: string[]): string[] {
+  const runnerLabelsValue = labels.join(RUNNER_LABELS_TAG_VALUE_SEPARATOR);
+  const characters = Array.from(runnerLabelsValue);
   const tagValues: string[] = [];
-  let currentValue = '';
 
-  for (const label of labels) {
-    for (const labelPart of splitEc2TagValue(label)) {
-      const nextValue = currentValue ? `${currentValue}${RUNNER_LABELS_TAG_VALUE_SEPARATOR}${labelPart}` : labelPart;
-
-      if (Array.from(nextValue).length <= EC2_TAG_VALUE_MAX_LENGTH) {
-        currentValue = nextValue;
-        continue;
-      }
-
-      if (currentValue) {
-        tagValues.push(currentValue);
-      }
-      currentValue = labelPart;
-    }
-  }
-
-  if (currentValue) {
-    tagValues.push(currentValue);
+  for (let start = 0; start < characters.length; start += EC2_TAG_VALUE_MAX_LENGTH) {
+    tagValues.push(characters.slice(start, start + EC2_TAG_VALUE_MAX_LENGTH).join(''));
   }
 
   return tagValues;
-}
-
-function splitEc2TagValue(value: string): string[] {
-  const characters = Array.from(value);
-  const values: string[] = [];
-
-  for (let start = 0; start < characters.length; start += EC2_TAG_VALUE_MAX_LENGTH) {
-    values.push(characters.slice(start, start + EC2_TAG_VALUE_MAX_LENGTH).join(''));
-  }
-
-  return values;
 }
 
 export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<string[]> {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -43,9 +43,12 @@ import {
   BaselineEbsBandwidthMbpsRequest,
   DescribeLaunchTemplateVersionsCommand,
   EC2Client,
+  Tag,
 } from '@aws-sdk/client-ec2';
 
 const logger = createChildLogger('scale-up');
+const RUNNER_LABELS_TAG_KEY = 'ghr:runner_labels';
+const EC2_TAG_VALUE_MAX_LENGTH = 256;
 
 export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
 
@@ -325,6 +328,67 @@ export async function createRunners(
   }
 
   return instances;
+}
+
+function generateRunnerLabelsTags(labels: string[]): Tag[] {
+  if (labels.length === 0) {
+    return [];
+  }
+
+  const tagValues: string[] = [];
+  let currentValue = '';
+
+  for (const label of labels) {
+    if (label.length > EC2_TAG_VALUE_MAX_LENGTH) {
+      if (currentValue) {
+        tagValues.push(currentValue);
+        currentValue = '';
+      }
+      for (let start = 0; start < label.length; start += EC2_TAG_VALUE_MAX_LENGTH) {
+        tagValues.push(label.slice(start, start + EC2_TAG_VALUE_MAX_LENGTH));
+      }
+      continue;
+    }
+
+    const nextValue = currentValue ? `${currentValue},${label}` : label;
+    if (nextValue.length <= EC2_TAG_VALUE_MAX_LENGTH) {
+      currentValue = nextValue;
+      continue;
+    }
+
+    if (currentValue) {
+      tagValues.push(currentValue);
+    }
+    currentValue = label;
+  }
+
+  if (currentValue) {
+    tagValues.push(currentValue);
+  }
+
+  return tagValues.map((value, index) => ({
+    Key: index === 0 ? RUNNER_LABELS_TAG_KEY : `${RUNNER_LABELS_TAG_KEY}:${index + 1}`,
+    Value: value,
+  }));
+}
+
+function getRunnerLabelNames(labels: unknown): string[] {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+
+  return labels
+    .map((label) => {
+      if (typeof label === 'string') {
+        return label;
+      }
+      if (label !== null && typeof label === 'object' && 'name' in label && typeof label.name === 'string') {
+        return label.name;
+      }
+      return '';
+    })
+    .map((label) => label.trim())
+    .filter(Boolean);
 }
 
 export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<string[]> {
@@ -704,11 +768,16 @@ async function createRegistrationTokenConfig(
   return [];
 }
 
-async function tagRunnerId(instanceId: string, runnerId: string): Promise<void> {
+async function tagRunnerMetadata(instanceId: string, runnerId: string, runnerLabels: unknown): Promise<void> {
+  const tags = [
+    { Key: 'ghr:github_runner_id', Value: runnerId },
+    ...generateRunnerLabelsTags(getRunnerLabelNames(runnerLabels)),
+  ];
+
   try {
-    await tag(instanceId, [{ Key: 'ghr:github_runner_id', Value: runnerId }]);
+    await tag(instanceId, tags);
   } catch (e) {
-    logger.error(`Failed to mark runner '${instanceId}' with ${runnerId}.`, { error: e });
+    logger.error(`Failed to mark runner '${instanceId}' with GitHub runner metadata.`, { error: e });
   }
 }
 
@@ -757,8 +826,8 @@ async function createJitConfig(
 
       metricGitHubAppRateLimit(runnerConfig.headers);
 
-      // tag the EC2 instance with the Github runner id
-      await tagRunnerId(instance, runnerConfig.data.runner.id.toString());
+      // tag the EC2 instance with GitHub runner metadata
+      await tagRunnerMetadata(instance, runnerConfig.data.runner.id.toString(), runnerConfig.data.runner.labels);
 
       // store jit config in ssm parameter store
       logger.debug('Runner JIT config for ephemeral runner generated.', {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -341,13 +341,6 @@ export async function createRunners(
   return instances;
 }
 
-export function parseRunnerLabels(runnerLabels: string): string[] {
-  return runnerLabels
-    .split(',')
-    .map((label) => label.trim())
-    .filter(Boolean);
-}
-
 function generateRunnerLabelsTags(labels: string[]): Tag[] {
   if (labels.length === 0) {
     return [];
@@ -523,8 +516,9 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
 
     if (allDynamicLabels.length > 0) {
       logger.debug('Dynamic labels present on message', { labels: allDynamicLabels });
-      const dynamicRunnerLabels = allDynamicLabels.join(',');
-      groupRunnerLabels = groupRunnerLabels ? `${groupRunnerLabels},${dynamicRunnerLabels}` : dynamicRunnerLabels;
+      groupRunnerLabels = groupRunnerLabels
+        ? `${groupRunnerLabels},${allDynamicLabels.join(',')}`
+        : allDynamicLabels.join(',');
       logger.debug('Updated runner labels', { runnerLabels: groupRunnerLabels });
 
       if (dynamicEC2Labels.length > 0) {
@@ -779,7 +773,10 @@ async function createJitConfig(
 ): Promise<string[]> {
   const runnerGroupId = await getRunnerGroupId(githubRunnerConfig, ghClient);
   const { isDelay, delay } = addDelay(instances);
-  const runnerLabels = parseRunnerLabels(githubRunnerConfig.runnerLabels);
+  const runnerLabels = githubRunnerConfig.runnerLabels
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
   const failedInstances: string[] = [];
 
   logger.debug(`Runner group id: ${runnerGroupId}`);

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -773,10 +773,7 @@ async function createJitConfig(
 ): Promise<string[]> {
   const runnerGroupId = await getRunnerGroupId(githubRunnerConfig, ghClient);
   const { isDelay, delay } = addDelay(instances);
-  const runnerLabels = githubRunnerConfig.runnerLabels
-    .split(',')
-    .map((label) => label.trim())
-    .filter(Boolean);
+  const runnerLabels = githubRunnerConfig.runnerLabels.split(',');
   const failedInstances: string[] = [];
 
   logger.debug(`Runner group id: ${runnerGroupId}`);

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -48,7 +48,14 @@ import {
 
 const logger = createChildLogger('scale-up');
 const RUNNER_LABELS_TAG_KEY = 'ghr:runner_labels';
+const RUNNER_LABELS_TAG_VALUE_SEPARATOR = ',';
+const EC2_OVERRIDE_LIST_VALUE_SEPARATOR = ';';
+const RUNNER_INSTANCE_BASE_TAG_MAX_COUNT = 5;
+const RUNNER_METADATA_RESERVED_TAG_COUNT = 1;
+const EC2_RESOURCE_MAX_TAGS = 50;
 const EC2_TAG_VALUE_MAX_LENGTH = 256;
+const RUNNER_LABELS_TAG_MAX_COUNT =
+  EC2_RESOURCE_MAX_TAGS - RUNNER_INSTANCE_BASE_TAG_MAX_COUNT - RUNNER_METADATA_RESERVED_TAG_COUNT;
 
 export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
 
@@ -118,7 +125,7 @@ function generateRunnerServiceConfig(githubRunnerConfig: CreateGitHubRunnerConfi
   ];
 
   if (githubRunnerConfig.runnerLabels) {
-    config.push(`--labels ${githubRunnerConfig.runnerLabels}`.trim());
+    config.push(`--labels ${quoteRunnerLabelsForShell(githubRunnerConfig.runnerLabels)}`.trim());
   }
 
   if (githubRunnerConfig.disableAutoUpdate) {
@@ -134,6 +141,14 @@ function generateRunnerServiceConfig(githubRunnerConfig: CreateGitHubRunnerConfi
   }
 
   return config;
+}
+
+function quoteRunnerLabelsForShell(labels: string): string {
+  return /[\s;&|<>()$`"'*?[\\\]{}!]/.test(labels) ? quoteShellArg(labels) : labels;
+}
+
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 export function validateSsmParameterStoreTags(tagsJson: string): { Key: string; Value: string }[] {
@@ -330,46 +345,73 @@ export async function createRunners(
   return instances;
 }
 
+export function parseRunnerLabels(runnerLabels: string): string[] {
+  return runnerLabels
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
 function generateRunnerLabelsTags(labels: string[]): Tag[] {
   if (labels.length === 0) {
     return [];
   }
 
-  const tagValues: string[] = [];
-  let currentValue = '';
+  const generatedTagValues = packRunnerLabelsTagValues(labels);
+  const tagValues = generatedTagValues.slice(0, RUNNER_LABELS_TAG_MAX_COUNT);
 
-  for (const label of labels) {
-    if (label.length > EC2_TAG_VALUE_MAX_LENGTH) {
-      if (currentValue) {
-        tagValues.push(currentValue);
-        currentValue = '';
-      }
-      for (let start = 0; start < label.length; start += EC2_TAG_VALUE_MAX_LENGTH) {
-        tagValues.push(label.slice(start, start + EC2_TAG_VALUE_MAX_LENGTH));
-      }
-      continue;
-    }
-
-    const nextValue = currentValue ? `${currentValue},${label}` : label;
-    if (nextValue.length <= EC2_TAG_VALUE_MAX_LENGTH) {
-      currentValue = nextValue;
-      continue;
-    }
-
-    if (currentValue) {
-      tagValues.push(currentValue);
-    }
-    currentValue = label;
-  }
-
-  if (currentValue) {
-    tagValues.push(currentValue);
+  if (generatedTagValues.length > RUNNER_LABELS_TAG_MAX_COUNT) {
+    logger.warn('GitHub runner label EC2 tags were truncated to avoid exceeding EC2 tag limits.', {
+      maxRunnerLabelsTagCount: RUNNER_LABELS_TAG_MAX_COUNT,
+    });
   }
 
   return tagValues.map((value, index) => ({
     Key: index === 0 ? RUNNER_LABELS_TAG_KEY : `${RUNNER_LABELS_TAG_KEY}:${index + 1}`,
     Value: value,
   }));
+}
+
+function packRunnerLabelsTagValues(labels: string[]): string[] {
+  const tagValues: string[] = [];
+  let currentValue = '';
+
+  for (const label of labels) {
+    for (const labelPart of splitEc2TagValue(label)) {
+      const nextValue = currentValue ? `${currentValue}${RUNNER_LABELS_TAG_VALUE_SEPARATOR}${labelPart}` : labelPart;
+
+      if (Array.from(nextValue).length <= EC2_TAG_VALUE_MAX_LENGTH) {
+        currentValue = nextValue;
+        continue;
+      }
+
+      if (currentValue) {
+        tagValues.push(currentValue);
+      }
+      currentValue = labelPart;
+    }
+  }
+
+  if (currentValue) {
+    tagValues.push(currentValue);
+  }
+
+  return tagValues;
+}
+
+function splitEc2TagValue(value: string): string[] {
+  const characters = Array.from(value);
+  const values: string[] = [];
+
+  for (let start = 0; start < characters.length; start += EC2_TAG_VALUE_MAX_LENGTH) {
+    values.push(characters.slice(start, start + EC2_TAG_VALUE_MAX_LENGTH).join(''));
+  }
+
+  return values;
+}
+
+function truncateEc2TagValue(value: string): string {
+  return Array.from(value).slice(0, EC2_TAG_VALUE_MAX_LENGTH).join('');
 }
 
 function getRunnerLabelNames(labels: unknown): string[] {
@@ -534,9 +576,8 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
 
     if (allDynamicLabels.length > 0) {
       logger.debug('Dynamic labels present on message', { labels: allDynamicLabels });
-      groupRunnerLabels = groupRunnerLabels
-        ? `${groupRunnerLabels},${allDynamicLabels.join(',')}`
-        : allDynamicLabels.join(',');
+      const dynamicRunnerLabels = allDynamicLabels.join(',');
+      groupRunnerLabels = groupRunnerLabels ? `${groupRunnerLabels},${dynamicRunnerLabels}` : dynamicRunnerLabels;
       logger.debug('Updated runner labels', { runnerLabels: groupRunnerLabels });
 
       if (dynamicEC2Labels.length > 0) {
@@ -770,7 +811,7 @@ async function createRegistrationTokenConfig(
 
 async function tagRunnerMetadata(instanceId: string, runnerId: string, runnerLabels: unknown): Promise<void> {
   const tags = [
-    { Key: 'ghr:github_runner_id', Value: runnerId },
+    { Key: 'ghr:github_runner_id', Value: truncateEc2TagValue(runnerId) },
     ...generateRunnerLabelsTags(getRunnerLabelNames(runnerLabels)),
   ];
 
@@ -794,7 +835,7 @@ async function createJitConfig(
 ): Promise<string[]> {
   const runnerGroupId = await getRunnerGroupId(githubRunnerConfig, ghClient);
   const { isDelay, delay } = addDelay(instances);
-  const runnerLabels = githubRunnerConfig.runnerLabels.split(',');
+  const runnerLabels = parseRunnerLabels(githubRunnerConfig.runnerLabels);
   const failedInstances: string[] = [];
 
   logger.debug(`Runner group id: ${runnerGroupId}`);
@@ -884,19 +925,19 @@ async function createJitConfig(
  * - ghr-ec2-memory-gib-per-vcpu-max:<number>  - Set max memory per vCPU ratio
  *
  * Instance Requirements (CPU & Performance):
- * - ghr-ec2-cpu-manufacturers:<list>          - CPU manufacturers (comma-separated: intel,amd,amazon-web-services)
- * - ghr-ec2-instance-generations:<list>       - Instance generations (comma-separated: current,previous)
- * - ghr-ec2-excluded-instance-types:<list>    - Exclude instance types (comma-separated)
- * - ghr-ec2-allowed-instance-types:<list>     - Allow only specific instance types (comma-separated)
+ * - ghr-ec2-cpu-manufacturers:<list>          - CPU manufacturers (semicolon-separated: intel;amd;amazon-web-services)
+ * - ghr-ec2-instance-generations:<list>       - Instance generations (semicolon-separated: current;previous)
+ * - ghr-ec2-excluded-instance-types:<list>    - Exclude instance types (semicolon-separated)
+ * - ghr-ec2-allowed-instance-types:<list>     - Allow only specific instance types (semicolon-separated)
  * - ghr-ec2-burstable-performance:<value>     - Burstable performance (included,excluded,required)
  * - ghr-ec2-bare-metal:<value>                - Bare metal (included,excluded,required)
  *
  * Instance Requirements (Accelerators/GPU):
- * - ghr-ec2-accelerator-types:<list>          - Accelerator types (comma-separated: gpu,fpga,inference)
+ * - ghr-ec2-accelerator-types:<list>          - Accelerator types (semicolon-separated: gpu;fpga;inference)
  * - ghr-ec2-accelerator-count-min:<num>       - Set minimum accelerator count
  * - ghr-ec2-accelerator-count-max:<num>       - Set maximum accelerator count
- * - ghr-ec2-accelerator-manufacturers:<list>  - Accelerator manufacturers (comma-separated: nvidia,amd,amazon-web-services,xilinx)
- * - ghr-ec2-accelerator-names:<list>          - Specific accelerator names (comma-separated)
+ * - ghr-ec2-accelerator-manufacturers:<list>  - Accelerator manufacturers (semicolon-separated: nvidia;amd;amazon-web-services;xilinx)
+ * - ghr-ec2-accelerator-names:<list>          - Specific accelerator names (semicolon-separated)
  * - ghr-ec2-accelerator-total-memory-mib-min:<num> - Min accelerator total memory in MiB
  * - ghr-ec2-accelerator-total-memory-mib-max:<num> - Max accelerator total memory in MiB
  *
@@ -906,7 +947,7 @@ async function createJitConfig(
  * - ghr-ec2-network-bandwidth-gbps-min:<num>  - Min network bandwidth in Gbps
  * - ghr-ec2-network-bandwidth-gbps-max:<num>  - Max network bandwidth in Gbps
  * - ghr-ec2-local-storage:<value>             - Local storage (included,excluded,required)
- * - ghr-ec2-local-storage-types:<list>        - Local storage types (comma-separated: hdd,ssd)
+ * - ghr-ec2-local-storage-types:<list>        - Local storage types (semicolon-separated: hdd;ssd)
  * - ghr-ec2-total-local-storage-gb-min:<num>  - Min total local storage in GB
  * - ghr-ec2-total-local-storage-gb-max:<num>  - Max total local storage in GB
  * - ghr-ec2-baseline-ebs-bandwidth-mbps-min:<num> - Min baseline EBS bandwidth in Mbps
@@ -943,7 +984,7 @@ async function createJitConfig(
  * - ghr-ec2-max-spot-price-as-percentage-of-optimal-on-demand-price:<num> - Max spot price as % of optimal on-demand
  * - ghr-ec2-require-hibernate-support:<bool>  - Require hibernate support (true,false)
  * - ghr-ec2-require-encryption-in-transit:<bool> - Require encryption in-transit (true,false)
- * - ghr-ec2-baseline-performance-factors-cpu-reference-families:<families> - CPU baseline performance reference families (comma-separated)
+ * - ghr-ec2-baseline-performance-factors-cpu-reference-families:<families> - CPU baseline performance reference families (semicolon-separated)
  *
  * Example:
  *   runs-on: [self-hosted, linux, ghr-ec2-vcpu-count-min:4, ghr-ec2-memory-mib-min:16384, ghr-ec2-accelerator-types:gpu]
@@ -1055,7 +1096,7 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.MemoryMiB![subKey === 'min' ? 'Min' : 'Max'] = parseInt(value, 10);
     } else if (key === 'cpu-manufacturers') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.CpuManufacturers = value.split(',') as CpuManufacturer[];
+      config.InstanceRequirements.CpuManufacturers = splitEc2OverrideListValue(value) as CpuManufacturer[];
     } else if (key.startsWith('memory-gib-per-vcpu-')) {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.MemoryGiBPerVCpu =
@@ -1064,10 +1105,10 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.MemoryGiBPerVCpu![subKey === 'min' ? 'Min' : 'Max'] = parseFloat(value);
     } else if (key === 'excluded-instance-types') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.ExcludedInstanceTypes = value.split(',');
+      config.InstanceRequirements.ExcludedInstanceTypes = splitEc2OverrideListValue(value);
     } else if (key === 'instance-generations') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.InstanceGenerations = value.split(',') as InstanceGeneration[];
+      config.InstanceRequirements.InstanceGenerations = splitEc2OverrideListValue(value) as InstanceGeneration[];
     } else if (key === 'spot-max-price-percentage-over-lowest-price') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.SpotMaxPricePercentageOverLowestPrice = parseInt(value, 10);
@@ -1094,7 +1135,7 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.LocalStorage = value as LocalStorage;
     } else if (key === 'local-storage-types') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.LocalStorageTypes = value.split(',') as LocalStorageType[];
+      config.InstanceRequirements.LocalStorageTypes = splitEc2OverrideListValue(value) as LocalStorageType[];
     } else if (key.startsWith('total-local-storage-gb-')) {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.TotalLocalStorageGB =
@@ -1109,7 +1150,7 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.BaselineEbsBandwidthMbps![subKey === 'min' ? 'Min' : 'Max'] = parseInt(value, 10);
     } else if (key === 'accelerator-types') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.AcceleratorTypes = value.split(',') as AcceleratorType[];
+      config.InstanceRequirements.AcceleratorTypes = splitEc2OverrideListValue(value) as AcceleratorType[];
     } else if (key.startsWith('accelerator-count-')) {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.AcceleratorCount =
@@ -1118,10 +1159,12 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.AcceleratorCount![subKey === 'min' ? 'Min' : 'Max'] = parseInt(value, 10);
     } else if (key === 'accelerator-manufacturers') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.AcceleratorManufacturers = value.split(',') as AcceleratorManufacturer[];
+      config.InstanceRequirements.AcceleratorManufacturers = splitEc2OverrideListValue(
+        value,
+      ) as AcceleratorManufacturer[];
     } else if (key === 'accelerator-names') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.AcceleratorNames = value.split(',') as AcceleratorName[];
+      config.InstanceRequirements.AcceleratorNames = splitEc2OverrideListValue(value) as AcceleratorName[];
     } else if (key.startsWith('accelerator-total-memory-mib-')) {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.AcceleratorTotalMemoryMiB =
@@ -1136,7 +1179,7 @@ export function parseEc2OverrideConfig(
       config.InstanceRequirements.NetworkBandwidthGbps![subKey === 'min' ? 'Min' : 'Max'] = parseFloat(value);
     } else if (key === 'allowed-instance-types') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
-      config.InstanceRequirements.AllowedInstanceTypes = value.split(',');
+      config.InstanceRequirements.AllowedInstanceTypes = splitEc2OverrideListValue(value);
     } else if (key === 'max-spot-price-as-percentage-of-optimal-on-demand-price') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.MaxSpotPriceAsPercentageOfOptimalOnDemandPrice = parseInt(value, 10);
@@ -1146,9 +1189,9 @@ export function parseEc2OverrideConfig(
         config.InstanceRequirements.BaselinePerformanceFactors || ({} as BaselinePerformanceFactorsRequest);
       config.InstanceRequirements.BaselinePerformanceFactors.Cpu =
         config.InstanceRequirements.BaselinePerformanceFactors.Cpu || ({} as CpuPerformanceFactorRequest);
-      config.InstanceRequirements.BaselinePerformanceFactors.Cpu.References = value
-        .split(',')
-        .map((family) => ({ InstanceFamily: family })) as PerformanceFactorReferenceRequest[];
+      config.InstanceRequirements.BaselinePerformanceFactors.Cpu.References = splitEc2OverrideListValue(value).map(
+        (family) => ({ InstanceFamily: family }),
+      ) as PerformanceFactorReferenceRequest[];
     } else if (key === 'require-encryption-in-transit') {
       config.InstanceRequirements = config.InstanceRequirements || ({} as InstanceRequirementsRequest);
       config.InstanceRequirements.RequireEncryptionInTransit = value.toLowerCase() === 'true';
@@ -1156,6 +1199,10 @@ export function parseEc2OverrideConfig(
   }
 
   return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function splitEc2OverrideListValue(value: string): string[] {
+  return value.split(EC2_OVERRIDE_LIST_VALUE_SEPARATOR);
 }
 
 function getOrCreateBlockDeviceMapping(

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -50,12 +50,8 @@ const logger = createChildLogger('scale-up');
 const RUNNER_LABELS_TAG_KEY = 'ghr:runner_labels';
 const RUNNER_LABELS_TAG_VALUE_SEPARATOR = ',';
 const EC2_OVERRIDE_LIST_VALUE_SEPARATOR = ';';
-const RUNNER_INSTANCE_BASE_TAG_MAX_COUNT = 5;
-const RUNNER_METADATA_RESERVED_TAG_COUNT = 1;
-const EC2_RESOURCE_MAX_TAGS = 50;
 const EC2_TAG_VALUE_MAX_LENGTH = 256;
-const RUNNER_LABELS_TAG_MAX_COUNT =
-  EC2_RESOURCE_MAX_TAGS - RUNNER_INSTANCE_BASE_TAG_MAX_COUNT - RUNNER_METADATA_RESERVED_TAG_COUNT;
+const RUNNER_LABELS_TAG_MAX_COUNT = 5;
 
 export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
 
@@ -408,29 +404,6 @@ function splitEc2TagValue(value: string): string[] {
   }
 
   return values;
-}
-
-function truncateEc2TagValue(value: string): string {
-  return Array.from(value).slice(0, EC2_TAG_VALUE_MAX_LENGTH).join('');
-}
-
-function getRunnerLabelNames(labels: unknown): string[] {
-  if (!Array.isArray(labels)) {
-    return [];
-  }
-
-  return labels
-    .map((label) => {
-      if (typeof label === 'string') {
-        return label;
-      }
-      if (label !== null && typeof label === 'object' && 'name' in label && typeof label.name === 'string') {
-        return label.name;
-      }
-      return '';
-    })
-    .map((label) => label.trim())
-    .filter(Boolean);
 }
 
 export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<string[]> {
@@ -809,11 +782,8 @@ async function createRegistrationTokenConfig(
   return [];
 }
 
-async function tagRunnerMetadata(instanceId: string, runnerId: string, runnerLabels: unknown): Promise<void> {
-  const tags = [
-    { Key: 'ghr:github_runner_id', Value: truncateEc2TagValue(runnerId) },
-    ...generateRunnerLabelsTags(getRunnerLabelNames(runnerLabels)),
-  ];
+async function tagRunnerMetadata(instanceId: string, runnerId: string, runnerLabels: string[]): Promise<void> {
+  const tags = [{ Key: 'ghr:github_runner_id', Value: runnerId }, ...generateRunnerLabelsTags(runnerLabels)];
 
   try {
     await tag(instanceId, tags);
@@ -868,7 +838,7 @@ async function createJitConfig(
       metricGitHubAppRateLimit(runnerConfig.headers);
 
       // tag the EC2 instance with GitHub runner metadata
-      await tagRunnerMetadata(instance, runnerConfig.data.runner.id.toString(), runnerConfig.data.runner.labels);
+      await tagRunnerMetadata(instance, runnerConfig.data.runner.id.toString(), runnerLabels);
 
       // store jit config in ssm parameter store
       logger.debug('Runner JIT config for ephemeral runner generated.', {

--- a/lambdas/functions/webhook/src/runners/dispatch.test.ts
+++ b/lambdas/functions/webhook/src/runners/dispatch.test.ts
@@ -380,13 +380,22 @@ describe('Dispatcher', () => {
         ...workFlowJobEvent,
         workflow_job: {
           ...workFlowJobEvent.workflow_job,
-          labels: ['self-hosted', 'linux', 'ghr-valid:value', 'ghr-bad label', longLabel],
+          labels: [
+            'self-hosted',
+            'linux',
+            'ghr-valid:value',
+            'ghr-list:value;another',
+            'ghr-bad,separator',
+            'ghr-bad|separator',
+            'ghr-bad label',
+            longLabel,
+          ],
         },
       } as unknown as WorkflowJobEvent;
       const resp = await dispatch(event, 'workflow_job', config);
       expect(resp.statusCode).toBe(201);
       expect(sendActionRequest).toHaveBeenCalledWith(
-        expect.objectContaining({ labels: ['self-hosted', 'linux', 'ghr-valid:value'] }),
+        expect.objectContaining({ labels: ['self-hosted', 'linux', 'ghr-valid:value', 'ghr-list:value;another'] }),
       );
     });
 

--- a/lambdas/functions/webhook/src/runners/dispatch.ts
+++ b/lambdas/functions/webhook/src/runners/dispatch.ts
@@ -10,7 +10,7 @@ import { violationsAgainstPolicy } from './dynamic-labels-policy';
 const logger = createChildLogger('handler');
 
 const GHR_LABEL_MAX_LENGTH = 128;
-const GHR_LABEL_VALUE_PATTERN = /^[a-zA-Z0-9._/\-:]+$/;
+const GHR_LABEL_VALUE_PATTERN = /^[a-zA-Z0-9._/;\-:]+$/;
 
 export async function dispatch(
   event: WorkflowJobEvent,


### PR DESCRIPTION
## Description

Adds EC2 tags for the GitHub runner labels registered through the JIT runner flow.

Now that dynamic labels are supported, runners created from the same multi-runner entry can register with different label sets. Before this change, AWS-side inspection only had the instance/runner identity, so checking the exact labels required going to GitHub.

The labels are taken from `runnerConfig.data.runner.labels`, so the EC2 tags reflect the labels GitHub registered for that runner. The instance create-tags policy was also updated to allow the new label tag keys.

## Test Plan

Deploy the lambda, run workflow and check the new labels

## Related Issues

None