### PR TITLE
feat: support dedicated host ec2 overrides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -353,11 +353,11 @@ Dynamic labels allow workflow authors to pass arbitrary metadata and EC2 instanc
 Dynamic labels serve two purposes:
 
 1. **Custom identity / restriction labels (`ghr-<key>:<value>`)** — Any `ghr-` prefixed label that is *not* `ghr-ec2-` acts as a custom identity label. These can represent a unique job ID, a team name, a cost center, an environment tag, or any arbitrary restriction. They do not affect EC2 configuration but are included in the label hash, guaranteeing unique runner matching per combination.
-2. **EC2 override labels (`ghr-ec2-<key>:<value>`)** — Labels prefixed with `ghr-ec2-` are parsed by the scale-up lambda to dynamically configure the EC2 fleet request — including instance type, vCPU/memory requirements, GPU/accelerator specs, EBS volumes, placement, and networking. This eliminates the need to create separate runner configurations for each hardware combination.
+2. **EC2 override labels (`ghr-ec2-<key>:<value>`)** — Labels prefixed with `ghr-ec2-` are parsed by the scale-up lambda to dynamically configure the EC2 launch request. For EC2 Fleet launches this can include instance type, vCPU/memory requirements, GPU/accelerator specs, EBS volumes, placement, and networking. For dedicated-host launches, only labels that map to `RunInstances` launch parameters are applied. This eliminates the need to create separate runner configurations for each hardware combination.
 
 #### How it works
 
-When `enable_dynamic_labels` is enabled, the webhook and scale-up lambdas inspect the `runs-on` labels of incoming `workflow_job` events. Labels starting with `ghr-ec2-` are parsed into an EC2 override configuration that is applied to the [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html) API call. All other `ghr-` prefixed labels are carried through as custom identity labels. A deterministic hash of **all** `ghr-` prefixed labels (both custom and EC2) is used to ensure consistent and unique runner matching.
+When `enable_dynamic_labels` is enabled, the webhook and scale-up lambdas inspect the `runs-on` labels of incoming `workflow_job` events. Labels starting with `ghr-ec2-` are parsed into an EC2 override configuration that is applied to the [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html) API call, or to supported [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) parameters when `use_dedicated_host = true`. All other `ghr-` prefixed labels are carried through as custom identity labels. A deterministic hash of **all** `ghr-` prefixed labels (both custom and EC2) is used to ensure consistent and unique runner matching.
 
 #### Configuration
 
@@ -417,108 +417,119 @@ In the example above, the three `ghr-` labels produce a unique hash, ensuring th
 
 #### EC2 override labels
 
-Labels using the format `ghr-ec2-<key>:<value>` override EC2 fleet configuration. Values with multiple items use comma-separated lists.
+Labels using the format `ghr-ec2-<key>:<value>` override EC2 launch configuration. Values with multiple items use comma-separated lists.
+
+For default EC2 Fleet launches (`use_dedicated_host = false`), labels in this section are parsed into the `CreateFleet` request. Basic fleet overrides, placement, and block device labels are sent as launch template overrides where EC2 Fleet accepts them. Instance requirement labels become `InstanceRequirements`; pricing labels set either the fleet override price (`ghr-ec2-max-price`) or instance requirement price preferences.
+
+When `use_dedicated_host = true`, runner instances are launched with `RunInstances` instead of EC2 Fleet. In this mode:
+
+- Labels marked `Yes` in the Dedicated host column are forwarded to `RunInstances`.
+- Labels marked `No` in the Dedicated host column are Fleet-only and are not applied.
+- Use `ghr-ec2-instance-type` to select a concrete instance type for dedicated hosts.
 
 ##### Basic Fleet Overrides
 
-| Label                                        | Description                          | Example value       |
-| -------------------------------------------- | ------------------------------------ | ------------------- |
-| `ghr-ec2-instance-type:<type>`               | Set specific instance type           | `c5.xlarge`         |
-| `ghr-ec2-max-price:<price>`                  | Set maximum spot price               | `0.10`              |
-| `ghr-ec2-subnet-id:<id>`                     | Set subnet ID                        | `subnet-abc123`     |
-| `ghr-ec2-availability-zone:<zone>`           | Set availability zone                | `us-east-1a`        |
-| `ghr-ec2-availability-zone-id:<id>`          | Set availability zone ID             | `use1-az1`          |
-| `ghr-ec2-weighted-capacity:<number>`         | Set weighted capacity                | `2`                 |
-| `ghr-ec2-priority:<number>`                  | Set launch priority                  | `1`                 |
-| `ghr-ec2-image-id:<ami-id>`                  | Override AMI ID                      | `ami-0abcdef123`    |
+| Label                                        | Description                          | Example value       | EC2 Fleet | Dedicated host |
+| -------------------------------------------- | ------------------------------------ | ------------------- | --------- | -------------- |
+| `ghr-ec2-instance-type:<type>`               | Set specific instance type           | `c5.xlarge`         | Yes       | Yes            |
+| `ghr-ec2-max-price:<price>`                  | Set maximum spot price               | `0.10`              | Yes       | No             |
+| `ghr-ec2-subnet-id:<id>`                     | Set subnet ID                        | `subnet-abc123`     | Yes       | Yes            |
+| `ghr-ec2-availability-zone:<zone>`           | Set availability zone                | `us-east-1a`        | Yes       | Yes            |
+| `ghr-ec2-availability-zone-id:<id>`          | Set availability zone ID             | `use1-az1`          | Yes       | Yes            |
+| `ghr-ec2-weighted-capacity:<number>`         | Set weighted capacity                | `2`                 | Yes       | No             |
+| `ghr-ec2-priority:<number>`                  | Set launch priority                  | `1`                 | Yes       | No             |
+| `ghr-ec2-image-id:<ami-id>`                  | Override AMI ID                      | `ami-0abcdef123`    | Yes       | Yes            |
 
 ##### Instance Requirements — vCPU & Memory
 
-| Label                                        | Description                          | Example value       |
-| -------------------------------------------- | ------------------------------------ | ------------------- |
-| `ghr-ec2-vcpu-count-min:<number>`            | Minimum vCPU count                   | `4`                 |
-| `ghr-ec2-vcpu-count-max:<number>`            | Maximum vCPU count                   | `16`                |
-| `ghr-ec2-memory-mib-min:<number>`            | Minimum memory in MiB               | `16384`             |
-| `ghr-ec2-memory-mib-max:<number>`            | Maximum memory in MiB               | `65536`             |
-| `ghr-ec2-memory-gib-per-vcpu-min:<number>`   | Min memory per vCPU ratio (GiB)     | `2`                 |
-| `ghr-ec2-memory-gib-per-vcpu-max:<number>`   | Max memory per vCPU ratio (GiB)     | `8`                 |
+| Label                                        | Description                          | Example value       | EC2 Fleet | Dedicated host |
+| -------------------------------------------- | ------------------------------------ | ------------------- | --------- | -------------- |
+| `ghr-ec2-vcpu-count-min:<number>`            | Minimum vCPU count                   | `4`                 | Yes       | No             |
+| `ghr-ec2-vcpu-count-max:<number>`            | Maximum vCPU count                   | `16`                | Yes       | No             |
+| `ghr-ec2-memory-mib-min:<number>`            | Minimum memory in MiB               | `16384`             | Yes       | No             |
+| `ghr-ec2-memory-mib-max:<number>`            | Maximum memory in MiB               | `65536`             | Yes       | No             |
+| `ghr-ec2-memory-gib-per-vcpu-min:<number>`   | Min memory per vCPU ratio (GiB)     | `2`                 | Yes       | No             |
+| `ghr-ec2-memory-gib-per-vcpu-max:<number>`   | Max memory per vCPU ratio (GiB)     | `8`                 | Yes       | No             |
 
 ##### Instance Requirements — CPU & Performance
 
-| Label                                        | Description                                                       | Example value              |
-| -------------------------------------------- | ----------------------------------------------------------------- | -------------------------- |
-| `ghr-ec2-cpu-manufacturers:<list>`           | CPU manufacturers (comma-separated)                               | `intel,amd`                |
-| `ghr-ec2-instance-generations:<list>`        | Instance generations (comma-separated)                            | `current`                  |
-| `ghr-ec2-excluded-instance-types:<list>`     | Exclude instance types (comma-separated)                          | `t2.micro,t3.nano`        |
-| `ghr-ec2-allowed-instance-types:<list>`      | Allow only specific instance types (comma-separated)              | `c5.xlarge,c5.2xlarge`    |
-| `ghr-ec2-burstable-performance:<value>`      | Burstable performance (`included`, `excluded`, `required`)        | `excluded`                 |
-| `ghr-ec2-bare-metal:<value>`                 | Bare metal (`included`, `excluded`, `required`)                   | `excluded`                 |
+| Label                                        | Description                                                       | Example value              | EC2 Fleet | Dedicated host |
+| -------------------------------------------- | ----------------------------------------------------------------- | -------------------------- | --------- | -------------- |
+| `ghr-ec2-cpu-manufacturers:<list>`           | CPU manufacturers (comma-separated: `intel`, `amd`, `amazon-web-services`) | `intel,amd`                | Yes       | No             |
+| `ghr-ec2-instance-generations:<list>`        | Instance generations (comma-separated)                            | `current`                  | Yes       | No             |
+| `ghr-ec2-excluded-instance-types:<list>`     | Exclude instance types (comma-separated)                          | `t2.micro,t3.nano`        | Yes       | No             |
+| `ghr-ec2-allowed-instance-types:<list>`      | Allow only specific instance types (comma-separated)              | `c5.xlarge,c5.2xlarge`    | Yes       | No             |
+| `ghr-ec2-burstable-performance:<value>`      | Burstable performance (`included`, `excluded`, `required`)        | `excluded`                 | Yes       | No             |
+| `ghr-ec2-bare-metal:<value>`                 | Bare metal (`included`, `excluded`, `required`)                   | `excluded`                 | Yes       | No             |
 
 ##### Instance Requirements — Accelerators / GPU
 
-| Label                                             | Description                                                              | Example value                    |
-| ------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------- |
-| `ghr-ec2-accelerator-types:<list>`                | Accelerator types (comma-separated: `gpu`, `fpga`, `inference`)          | `gpu`                            |
-| `ghr-ec2-accelerator-count-min:<number>`          | Minimum accelerator count                                                | `1`                              |
-| `ghr-ec2-accelerator-count-max:<number>`          | Maximum accelerator count                                                | `4`                              |
-| `ghr-ec2-accelerator-manufacturers:<list>`        | Accelerator manufacturers (comma-separated)                              | `nvidia`                         |
-| `ghr-ec2-accelerator-names:<list>`                | Specific accelerator names (comma-separated)                             | `t4,v100`                        |
-| `ghr-ec2-accelerator-memory-mib-min:<number>`     | Min accelerator total memory in MiB                                      | `8192`                           |
-| `ghr-ec2-accelerator-memory-mib-max:<number>`     | Max accelerator total memory in MiB                                      | `32768`                          |
+| Label                                             | Description                                                              | Example value                    | EC2 Fleet | Dedicated host |
+| ------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------- | --------- | -------------- |
+| `ghr-ec2-accelerator-types:<list>`                | Accelerator types (comma-separated: `gpu`, `fpga`, `inference`)          | `gpu`                            | Yes       | No             |
+| `ghr-ec2-accelerator-count-min:<number>`          | Minimum accelerator count                                                | `1`                              | Yes       | No             |
+| `ghr-ec2-accelerator-count-max:<number>`          | Maximum accelerator count                                                | `4`                              | Yes       | No             |
+| `ghr-ec2-accelerator-manufacturers:<list>`        | Accelerator manufacturers (comma-separated: `nvidia`, `amd`, `amazon-web-services`, `xilinx`) | `nvidia`                         | Yes       | No             |
+| `ghr-ec2-accelerator-names:<list>`                | Specific accelerator names (comma-separated)                             | `t4,v100`                        | Yes       | No             |
+| `ghr-ec2-accelerator-total-memory-mib-min:<number>` | Min accelerator total memory in MiB                                    | `8192`                           | Yes       | No             |
+| `ghr-ec2-accelerator-total-memory-mib-max:<number>` | Max accelerator total memory in MiB                                    | `32768`                          | Yes       | No             |
 
 ##### Instance Requirements — Network & Storage
 
-| Label                                              | Description                                                       | Example value       |
-| -------------------------------------------------- | ----------------------------------------------------------------- | ------------------- |
-| `ghr-ec2-network-interface-count-min:<number>`     | Min network interfaces                                            | `1`                 |
-| `ghr-ec2-network-interface-count-max:<number>`     | Max network interfaces                                            | `4`                 |
-| `ghr-ec2-network-bandwidth-gbps-min:<number>`      | Min network bandwidth in Gbps                                     | `10`                |
-| `ghr-ec2-network-bandwidth-gbps-max:<number>`      | Max network bandwidth in Gbps                                     | `25`                |
-| `ghr-ec2-local-storage:<value>`                    | Local storage (`included`, `excluded`, `required`)                | `required`          |
-| `ghr-ec2-local-storage-types:<list>`               | Local storage types (comma-separated: `hdd`, `ssd`)              | `ssd`               |
-| `ghr-ec2-total-local-storage-gb-min:<number>`      | Min total local storage in GB                                     | `100`               |
-| `ghr-ec2-total-local-storage-gb-max:<number>`      | Max total local storage in GB                                     | `500`               |
-| `ghr-ec2-baseline-ebs-bandwidth-mbps-min:<number>` | Min baseline EBS bandwidth in Mbps                                | `1000`              |
-| `ghr-ec2-baseline-ebs-bandwidth-mbps-max:<number>` | Max baseline EBS bandwidth in Mbps                                | `5000`              |
+| Label                                              | Description                                                       | Example value       | EC2 Fleet | Dedicated host |
+| -------------------------------------------------- | ----------------------------------------------------------------- | ------------------- | --------- | -------------- |
+| `ghr-ec2-network-interface-count-min:<number>`     | Min network interfaces                                            | `1`                 | Yes       | No             |
+| `ghr-ec2-network-interface-count-max:<number>`     | Max network interfaces                                            | `4`                 | Yes       | No             |
+| `ghr-ec2-network-bandwidth-gbps-min:<number>`      | Min network bandwidth in Gbps                                     | `10`                | Yes       | No             |
+| `ghr-ec2-network-bandwidth-gbps-max:<number>`      | Max network bandwidth in Gbps                                     | `25`                | Yes       | No             |
+| `ghr-ec2-local-storage:<value>`                    | Local storage (`included`, `excluded`, `required`)                | `required`          | Yes       | No             |
+| `ghr-ec2-local-storage-types:<list>`               | Local storage types (comma-separated: `hdd`, `ssd`)              | `ssd`               | Yes       | No             |
+| `ghr-ec2-total-local-storage-gb-min:<number>`      | Min total local storage in GB                                     | `100`               | Yes       | No             |
+| `ghr-ec2-total-local-storage-gb-max:<number>`      | Max total local storage in GB                                     | `500`               | Yes       | No             |
+| `ghr-ec2-baseline-ebs-bandwidth-mbps-min:<number>` | Min baseline EBS bandwidth in Mbps                                | `1000`              | Yes       | No             |
+| `ghr-ec2-baseline-ebs-bandwidth-mbps-max:<number>` | Max baseline EBS bandwidth in Mbps                                | `5000`              | Yes       | No             |
 
 ##### Placement
 
-| Label                                                  | Description                                                | Example value         |
-| ------------------------------------------------------ | ---------------------------------------------------------- | --------------------- |
-| `ghr-ec2-placement-group:<name>`                       | Placement group name                                       | `my-cluster-group`    |
-| `ghr-ec2-placement-tenancy:<value>`                    | Tenancy (`default`, `dedicated`, `host`)                   | `dedicated`           |
-| `ghr-ec2-placement-host-id:<id>`                       | Dedicated host ID                                          | `h-abc123`            |
-| `ghr-ec2-placement-affinity:<value>`                   | Affinity (`default`, `host`)                               | `host`                |
-| `ghr-ec2-placement-partition-number:<number>`          | Partition number                                           | `1`                   |
-| `ghr-ec2-placement-availability-zone:<zone>`           | Placement availability zone                                | `us-east-1a`          |
-| `ghr-ec2-placement-spread-domain:<domain>`             | Spread domain                                              | `my-domain`           |
-| `ghr-ec2-placement-host-resource-group-arn:<arn>`      | Host resource group ARN                                    | `arn:aws:...`         |
+| Label                                                  | Description                                                | Example value         | EC2 Fleet | Dedicated host |
+| ------------------------------------------------------ | ---------------------------------------------------------- | --------------------- | --------- | -------------- |
+| `ghr-ec2-placement-group-name:<name>`                  | Placement group name                                       | `my-cluster-group`    | Yes       | Yes            |
+| `ghr-ec2-placement-group-id:<id>`                      | Placement group ID                                         | `pg-abc123`           | Yes       | Yes            |
+| `ghr-ec2-placement-tenancy:<value>`                    | Tenancy (`default`, `dedicated`, `host`)                   | `dedicated`           | Yes       | Yes            |
+| `ghr-ec2-placement-host-id:<id>`                       | Dedicated host ID                                          | `h-abc123`            | Yes       | Yes            |
+| `ghr-ec2-placement-affinity:<value>`                   | Affinity (`default`, `host`)                               | `host`                | Yes       | Yes            |
+| `ghr-ec2-placement-partition-number:<number>`          | Partition number                                           | `1`                   | Yes       | Yes            |
+| `ghr-ec2-placement-availability-zone:<zone>`           | Placement availability zone                                | `us-east-1a`          | Yes       | Yes            |
+| `ghr-ec2-placement-availability-zone-id:<id>`          | Placement availability zone ID                             | `use1-az1`            | Yes       | Yes            |
+| `ghr-ec2-placement-spread-domain:<domain>`             | Spread domain                                              | `my-domain`           | Yes       | Yes            |
+| `ghr-ec2-placement-host-resource-group-arn:<arn>`      | Host resource group ARN                                    | `arn:aws:...`         | Yes       | Yes            |
 
 ##### Block Device Mappings (EBS)
 
-| Label                                            | Description                                                    | Example value  |
-| ------------------------------------------------ | -------------------------------------------------------------- | -------------- |
-| `ghr-ec2-ebs-volume-size:<size>`                 | EBS volume size in GB                                          | `100`          |
-| `ghr-ec2-ebs-volume-type:<type>`                 | EBS volume type (`gp2`, `gp3`, `io1`, `io2`, `st1`, `sc1`)   | `gp3`          |
-| `ghr-ec2-ebs-iops:<number>`                      | EBS IOPS                                                       | `3000`         |
-| `ghr-ec2-ebs-throughput:<number>`                 | EBS throughput in MB/s (gp3 only)                              | `125`          |
-| `ghr-ec2-ebs-encrypted:<boolean>`                 | EBS encryption (`true`, `false`)                               | `true`         |
-| `ghr-ec2-ebs-kms-key-id:<id>`                    | KMS key ID for encryption                                      | `key-abc123`   |
-| `ghr-ec2-ebs-delete-on-termination:<boolean>`     | Delete on termination (`true`, `false`)                        | `true`         |
-| `ghr-ec2-ebs-snapshot-id:<id>`                    | Snapshot ID for EBS volume                                     | `snap-abc123`  |
-| `ghr-ec2-block-device-virtual-name:<name>`        | Virtual device name (ephemeral storage)                        | `ephemeral0`   |
-| `ghr-ec2-block-device-no-device:<string>`         | Suppresses device mapping                                      | `true`         |
+| Label                                            | Description                                                    | Example value  | EC2 Fleet | Dedicated host |
+| ------------------------------------------------ | -------------------------------------------------------------- | -------------- | --------- | -------------- |
+| `ghr-ec2-block-device-name:<name>`               | Block device name                                              | `/dev/sda1`    | Yes       | Yes            |
+| `ghr-ec2-ebs-volume-size:<size>`                 | EBS volume size in GB                                          | `100`          | Yes       | Yes            |
+| `ghr-ec2-ebs-volume-type:<type>`                 | EBS volume type (`gp2`, `gp3`, `io1`, `io2`, `st1`, `sc1`)   | `gp3`          | Yes       | Yes            |
+| `ghr-ec2-ebs-iops:<number>`                      | EBS IOPS                                                       | `3000`         | Yes       | Yes            |
+| `ghr-ec2-ebs-throughput:<number>`                 | EBS throughput in MB/s (gp3 only)                              | `125`          | Yes       | Yes            |
+| `ghr-ec2-ebs-encrypted:<boolean>`                 | EBS encryption (`true`, `false`)                               | `true`         | Yes       | Yes            |
+| `ghr-ec2-ebs-kms-key-id:<id>`                    | KMS key ID for encryption                                      | `key-abc123`   | Yes       | Yes            |
+| `ghr-ec2-ebs-delete-on-termination:<boolean>`     | Delete on termination (`true`, `false`)                        | `true`         | Yes       | Yes            |
+| `ghr-ec2-ebs-snapshot-id:<id>`                    | Snapshot ID for EBS volume                                     | `snap-abc123`  | Yes       | Yes            |
+| `ghr-ec2-block-device-virtual-name:<name>`        | Virtual device name (ephemeral storage)                        | `ephemeral0`   | Yes       | Yes            |
+| `ghr-ec2-block-device-no-device:<string>`         | Suppresses device mapping                                      | `true`         | Yes       | Yes            |
 
 ##### Pricing & Advanced
 
-| Label                                                                         | Description                                                        | Example value  |
-| ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------- |
-| `ghr-ec2-spot-max-price-percentage-over-lowest-price:<number>`                | Spot max price as % over lowest price                              | `20`           |
-| `ghr-ec2-on-demand-max-price-percentage-over-lowest-price:<number>`           | On-demand max price as % over lowest price                         | `10`           |
-| `ghr-ec2-max-spot-price-as-percentage-of-optimal-on-demand-price:<number>`    | Max spot price as % of optimal on-demand                           | `50`           |
-| `ghr-ec2-require-hibernate-support:<boolean>`                                 | Require hibernate support (`true`, `false`)                        | `true`         |
-| `ghr-ec2-require-encryption-in-transit:<boolean>`                             | Require encryption in-transit (`true`, `false`)                    | `true`         |
-| `ghr-ec2-baseline-performance-factors-cpu-reference-families:<list>`          | CPU baseline performance reference families (comma-separated)      | `c5,m5`        |
+| Label                                                                         | Description                                                        | Example value  | EC2 Fleet | Dedicated host |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------- | --------- | -------------- |
+| `ghr-ec2-spot-max-price-percentage-over-lowest-price:<number>`                | Spot max price as % over lowest price                              | `20`           | Yes       | No             |
+| `ghr-ec2-on-demand-max-price-percentage-over-lowest-price:<number>`           | On-demand max price as % over lowest price                         | `10`           | Yes       | No             |
+| `ghr-ec2-max-spot-price-as-percentage-of-optimal-on-demand-price:<number>`    | Max spot price as % of optimal on-demand                           | `50`           | Yes       | No             |
+| `ghr-ec2-require-hibernate-support:<boolean>`                                 | Require hibernate support (`true`, `false`)                        | `true`         | Yes       | No             |
+| `ghr-ec2-require-encryption-in-transit:<boolean>`                             | Require encryption in-transit (`true`, `false`)                    | `true`         | Yes       | No             |
+| `ghr-ec2-baseline-performance-factors-cpu-reference-families:<list>`          | CPU baseline performance reference families (comma-separated)      | `c5,m5`        | Yes       | No             |
 
 #### Examples
 

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -13,6 +13,7 @@ import {
   RunInstancesCommand,
   SpotAllocationStrategy,
   TerminateInstancesCommand,
+  type _InstanceType,
 } from '@aws-sdk/client-ec2';
 import { GetParameterCommand, type GetParameterResult, PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -21,7 +22,7 @@ import 'aws-sdk-client-mock-jest/vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ScaleError from './../scale-runners/ScaleError';
 import { createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
-import type { RunnerInfo, RunnerInputParameters, RunnerType } from './runners.d';
+import type { Ec2OverrideConfig, RunnerInfo, RunnerInputParameters, RunnerType } from './runners.d';
 import { LambdaRunnerSource } from '../scale-runners/scale-up';
 
 process.env.AWS_REGION = 'eu-east-1';
@@ -966,6 +967,7 @@ interface RunnerConfig {
   scaleErrors: string[];
   source: LambdaRunnerSource;
   useDedicatedHost?: boolean;
+  ec2OverrideConfig?: Ec2OverrideConfig;
 }
 
 function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
@@ -988,6 +990,7 @@ function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
     scaleErrors: runnerConfig.scaleErrors,
     source: runnerConfig.source,
     useDedicatedHost: runnerConfig.useDedicatedHost,
+    ec2OverrideConfig: runnerConfig.ec2OverrideConfig,
   };
 }
 
@@ -1319,5 +1322,87 @@ describe('create runner with useDedicatedHost', () => {
     expect(mockSSMClient).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: 'my-ami-id-param',
     });
+  });
+
+  it('applies supported EC2 override config values to RunInstances', async () => {
+    const paramValue: GetParameterResult = {
+      Parameter: {
+        Value: 'ami-from-ssm',
+      },
+    };
+    mockSSMClient.on(GetParameterCommand).resolves(paramValue);
+
+    const ec2OverrideConfig: Ec2OverrideConfig = {
+      InstanceType: 'm7i.large' as _InstanceType,
+      SubnetId: 'subnet-dynamic',
+      AvailabilityZone: 'us-east-1a',
+      ImageId: 'ami-from-dynamic-label',
+      Placement: {
+        Affinity: 'host',
+        HostResourceGroupArn: 'arn:aws:ec2:us-east-1:123456789012:host-resource-group/hrg-1234',
+        Tenancy: 'host',
+      },
+      BlockDeviceMappings: [
+        {
+          DeviceName: '/dev/sda1',
+          Ebs: {
+            DeleteOnTermination: false,
+            Encrypted: true,
+            VolumeSize: 100,
+            VolumeType: 'gp3',
+          },
+        },
+      ],
+      InstanceRequirements: {
+        VCpuCount: {
+          Min: 4,
+        },
+        MemoryMiB: {
+          Min: 16384,
+        },
+      },
+      MaxPrice: '0.50',
+      Priority: 10,
+      WeightedCapacity: 2,
+    };
+
+    await createRunner(
+      createRunnerConfig({
+        ...dedicatedHostRunnerConfig,
+        amiIdSsmParameterName: 'my-ami-id-param',
+        ec2OverrideConfig,
+      }),
+    );
+
+    const runInstancesInput = mockEC2Client.commandCalls(RunInstancesCommand)[0].args[0].input;
+
+    expect(runInstancesInput).toEqual(
+      expect.objectContaining({
+        InstanceType: 'm7i.large',
+        SubnetId: 'subnet-dynamic',
+        ImageId: 'ami-from-dynamic-label',
+        Placement: {
+          Affinity: 'host',
+          AvailabilityZone: 'us-east-1a',
+          HostResourceGroupArn: 'arn:aws:ec2:us-east-1:123456789012:host-resource-group/hrg-1234',
+          Tenancy: 'host',
+        },
+        BlockDeviceMappings: [
+          {
+            DeviceName: '/dev/sda1',
+            Ebs: {
+              DeleteOnTermination: false,
+              Encrypted: true,
+              VolumeSize: 100,
+              VolumeType: 'gp3',
+            },
+          },
+        ],
+      }),
+    );
+    expect(runInstancesInput).not.toHaveProperty('InstanceRequirements');
+    expect(runInstancesInput).not.toHaveProperty('MaxPrice');
+    expect(runInstancesInput).not.toHaveProperty('Priority');
+    expect(runInstancesInput).not.toHaveProperty('WeightedCapacity');
   });
 });

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -1,4 +1,5 @@
 import {
+  type BlockDeviceMapping,
   CreateFleetCommand,
   CreateFleetResult,
   CreateTagsCommand,
@@ -6,6 +7,7 @@ import {
   DescribeInstancesCommand,
   DescribeInstancesResult,
   RunInstancesCommand,
+  type RunInstancesCommandInput,
   RunInstancesCommandOutput,
   EC2Client,
   FleetLaunchTemplateOverridesRequest,
@@ -148,6 +150,60 @@ function generateFleetOverrides(
     });
   });
   return result;
+}
+
+// Keep this allow-list explicit so Fleet-only override fields are not sent to RunInstances.
+type RunInstancesLaunchOverrides = Pick<
+  RunInstancesCommandInput,
+  'BlockDeviceMappings' | 'ImageId' | 'InstanceType' | 'Placement' | 'SubnetId'
+>;
+
+interface RunInstancesLaunchDefaults {
+  imageId?: string;
+  instanceType: _InstanceType;
+  subnetId: string;
+}
+
+function buildRunInstancesOverrides(
+  ec2OverrideConfig: Runners.Ec2OverrideConfig | undefined,
+  defaults: RunInstancesLaunchDefaults,
+): RunInstancesLaunchOverrides {
+  const imageIdToUse = ec2OverrideConfig?.ImageId ?? defaults.imageId;
+  const placement = {
+    ...ec2OverrideConfig?.Placement,
+  };
+
+  if (!placement.AvailabilityZone && !placement.AvailabilityZoneId) {
+    if (ec2OverrideConfig?.AvailabilityZone) {
+      placement.AvailabilityZone = ec2OverrideConfig.AvailabilityZone;
+    } else if (ec2OverrideConfig?.AvailabilityZoneId) {
+      placement.AvailabilityZoneId = ec2OverrideConfig.AvailabilityZoneId;
+    }
+  }
+
+  const overrides: RunInstancesLaunchOverrides = {
+    InstanceType: ec2OverrideConfig?.InstanceType ?? defaults.instanceType,
+    SubnetId: ec2OverrideConfig?.SubnetId ?? defaults.subnetId,
+  };
+
+  if (imageIdToUse) {
+    overrides.ImageId = imageIdToUse;
+  }
+
+  if (Object.keys(placement).length > 0) {
+    overrides.Placement = placement;
+  }
+
+  if (ec2OverrideConfig?.BlockDeviceMappings) {
+    overrides.BlockDeviceMappings = ec2OverrideConfig.BlockDeviceMappings.map(
+      (blockDeviceMapping): BlockDeviceMapping => ({
+        ...blockDeviceMapping,
+        ...(blockDeviceMapping.Ebs ? { Ebs: { ...blockDeviceMapping.Ebs } } : {}),
+      }),
+    );
+  }
+
+  return overrides;
 }
 
 export async function createRunner(runnerParameters: Runners.RunnerInputParameters): Promise<string[]> {
@@ -363,17 +419,18 @@ async function createInstancesWithRunInstances(
       );
     }
 
-    const instanceType = runnerParameters.ec2instanceCriteria.instanceTypes[0] as _InstanceType;
     const runInstancesCommand = new RunInstancesCommand({
       LaunchTemplate: {
         LaunchTemplateName: runnerParameters.launchTemplateName,
         Version: '$Default',
       },
-      InstanceType: instanceType,
+      ...buildRunInstancesOverrides(runnerParameters.ec2OverrideConfig, {
+        imageId: amiIdOverride,
+        instanceType: runnerParameters.ec2instanceCriteria.instanceTypes[0] as _InstanceType,
+        subnetId: runnerParameters.subnets[0],
+      }),
       MinCount: runnerParameters.numberOfRunners,
       MaxCount: runnerParameters.numberOfRunners,
-      SubnetId: runnerParameters.subnets[0],
-      ...(amiIdOverride ? { ImageId: amiIdOverride } : {}),
       TagSpecifications: [
         {
           ResourceType: 'instance',

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -1,6 +1,7 @@
 import {
   type BlockDeviceMapping,
   CreateFleetCommand,
+  type CreateFleetCommandInput,
   CreateFleetResult,
   CreateTagsCommand,
   DeleteTagsCommand,
@@ -350,7 +351,7 @@ async function createInstances(
   let fleet: CreateFleetResult;
   try {
     // see for spec https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
-    const createFleetCommand = new CreateFleetCommand({
+    const createFleetInput: CreateFleetCommandInput = {
       LaunchTemplateConfigs: [
         {
           LaunchTemplateSpecification: {
@@ -384,8 +385,9 @@ async function createInstances(
         },
       ],
       Type: 'instant',
-    });
-    logger.debug('CreateFleet request payload.', { payload: createFleetCommand.input });
+    };
+    logger.debug('CreateFleet request payload.', { payload: createFleetInput });
+    const createFleetCommand = new CreateFleetCommand(createFleetInput);
     fleet = await ec2Client.send(createFleetCommand);
   } catch (e) {
     logger.warn('Create fleet request failed.', { error: e as Error });
@@ -419,7 +421,7 @@ async function createInstancesWithRunInstances(
       );
     }
 
-    const runInstancesCommand = new RunInstancesCommand({
+    const runInstancesInput: RunInstancesCommandInput = {
       LaunchTemplate: {
         LaunchTemplateName: runnerParameters.launchTemplateName,
         Version: '$Default',
@@ -441,9 +443,10 @@ async function createInstancesWithRunInstances(
           Tags: tags,
         },
       ],
-    });
+    };
 
-    logger.debug('RunInstances request payload.', { payload: runInstancesCommand.input });
+    logger.debug('RunInstances request payload.', { payload: runInstancesInput });
+    const runInstancesCommand = new RunInstancesCommand(runInstancesInput);
     result = await ec2Client.send(runInstancesCommand);
   } catch (e) {
     const errorName = (e as Error).name;

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -1,7 +1,6 @@
 import {
   type BlockDeviceMapping,
   CreateFleetCommand,
-  type CreateFleetCommandInput,
   CreateFleetResult,
   CreateTagsCommand,
   DeleteTagsCommand,
@@ -351,7 +350,7 @@ async function createInstances(
   let fleet: CreateFleetResult;
   try {
     // see for spec https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
-    const createFleetInput: CreateFleetCommandInput = {
+    const createFleetCommand = new CreateFleetCommand({
       LaunchTemplateConfigs: [
         {
           LaunchTemplateSpecification: {
@@ -385,8 +384,7 @@ async function createInstances(
         },
       ],
       Type: 'instant',
-    };
-    const createFleetCommand = new CreateFleetCommand(createFleetInput);
+    });
     logger.debug('CreateFleet request payload.', { payload: createFleetCommand.input });
     fleet = await ec2Client.send(createFleetCommand);
   } catch (e) {
@@ -421,7 +419,7 @@ async function createInstancesWithRunInstances(
       );
     }
 
-    const runInstancesInput: RunInstancesCommandInput = {
+    const runInstancesCommand = new RunInstancesCommand({
       LaunchTemplate: {
         LaunchTemplateName: runnerParameters.launchTemplateName,
         Version: '$Default',
@@ -443,9 +441,8 @@ async function createInstancesWithRunInstances(
           Tags: tags,
         },
       ],
-    };
+    });
 
-    const runInstancesCommand = new RunInstancesCommand(runInstancesInput);
     logger.debug('RunInstances request payload.', { payload: runInstancesCommand.input });
     result = await ec2Client.send(runInstancesCommand);
   } catch (e) {

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -386,8 +386,8 @@ async function createInstances(
       ],
       Type: 'instant',
     };
-    logger.debug('CreateFleet request payload.', { payload: createFleetInput });
     const createFleetCommand = new CreateFleetCommand(createFleetInput);
+    logger.debug('CreateFleet request payload.', { payload: createFleetCommand.input });
     fleet = await ec2Client.send(createFleetCommand);
   } catch (e) {
     logger.warn('Create fleet request failed.', { error: e as Error });
@@ -445,8 +445,8 @@ async function createInstancesWithRunInstances(
       ],
     };
 
-    logger.debug('RunInstances request payload.', { payload: runInstancesInput });
     const runInstancesCommand = new RunInstancesCommand(runInstancesInput);
+    logger.debug('RunInstances request payload.', { payload: runInstancesCommand.input });
     result = await ec2Client.send(runInstancesCommand);
   } catch (e) {
     const errorName = (e as Error).name;


### PR DESCRIPTION
## Description

Adds support for applying supported dynamic EC2 override labels to dedicated-host runner launches that use `RunInstances`.

This maps the parsed `ec2OverrideConfig` into the `RunInstances` request for supported fields:

- `InstanceType`
- `SubnetId`
- `ImageId`
- `Placement`
- `BlockDeviceMappings`

Fleet-only override fields such as `InstanceRequirements`, `MaxPrice`, `Priority`, and `WeightedCapacity` are intentionally not forwarded to `RunInstances`.

Also updates the dynamic label documentation to show which EC2 override labels work with EC2 Fleet and which work with dedicated-host launches.

## Test Plan

- Added unit test coverage for dedicated-host `RunInstances` overrides.
- Verified supported EC2 override config values are passed to `RunInstances`.
- Verified Fleet-only fields are not passed to `RunInstances`.
- Ran `yarn exec vitest run functions/control-plane/src/aws/runners.test.ts --config functions/control-plane/vitest.config.ts`
- Ran `yarn exec eslint functions/control-plane/src/aws/runners.ts functions/control-plane/src/aws/runners.test.ts`
- Ran `yarn workspace @aws-github-runner/control-plane build`
- Ran `git diff --check`

## Related Issues

N/A