### PR TITLE
fix: clean up fleets after runner termination

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.d.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.d.ts
@@ -12,6 +12,7 @@ export type RunnerType = 'Org' | 'Repo';
 
 export interface RunnerList {
   instanceId: string;
+  fleetId?: string;
   launchTime?: Date;
   owner?: string;
   type?: string;
@@ -24,6 +25,7 @@ export interface RunnerList {
 
 export interface RunnerInfo {
   instanceId: string;
+  fleetId?: string;
   launchTime?: Date;
   owner: string;
   type: string;

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -6,7 +6,9 @@ import {
   type CreateFleetResult,
   CreateTagsCommand,
   type DefaultTargetCapacityType,
+  DeleteFleetsCommand,
   DeleteTagsCommand,
+  DescribeFleetsCommand,
   DescribeInstancesCommand,
   type DescribeInstancesResult,
   EC2Client,
@@ -20,7 +22,7 @@ import 'aws-sdk-client-mock-jest/vitest';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ScaleError from './../scale-runners/ScaleError';
-import { createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
+import { cleanupFleet, createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
 import type { RunnerInfo, RunnerInputParameters, RunnerType } from './runners.d';
 import { LambdaRunnerSource } from '../scale-runners/scale-up';
 
@@ -108,6 +110,42 @@ describe('list instances', () => {
       owner: 'CoderToCat',
       orphan: false,
       runnerId: '9876543210',
+      bypassRemoval: false,
+    });
+  });
+
+  it('returns the fleet id from the instance fleet tag', async () => {
+    const instances: DescribeInstancesResult = {
+      Reservations: [
+        {
+          Instances: [
+            {
+              LaunchTime: new Date('2020-10-10T14:48:00.000+09:00'),
+              InstanceId: 'i-1234',
+              Tags: [
+                { Key: 'ghr:Application', Value: 'github-action-runner' },
+                { Key: 'ghr:runner_name_prefix', Value: RUNNER_NAME_PREFIX },
+                { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+                { Key: 'ghr:Type', Value: 'Org' },
+                { Key: 'ghr:Owner', Value: 'CoderToCat' },
+                { Key: 'aws:ec2:fleet-id', Value: 'fleet-1234' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+
+    const resp = await listEC2Runners();
+
+    expect(resp).toContainEqual({
+      instanceId: 'i-1234',
+      fleetId: 'fleet-1234',
+      launchTime: new Date('2020-10-10T14:48:00.000+09:00'),
+      type: 'Org',
+      owner: 'CoderToCat',
+      orphan: false,
       bypassRemoval: false,
     });
   });
@@ -248,6 +286,58 @@ describe('list instances', () => {
         { Name: 'instance-state-name', Values: ['running', 'pending'] },
         { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
       ],
+    });
+  });
+});
+
+describe('cleanup fleet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEC2Client.reset();
+  });
+
+  it('does not delete the fleet when it still has a running instance', async () => {
+    mockEC2Client.on(DescribeFleetsCommand).resolves({
+      Fleets: [
+        {
+          FleetId: 'fleet-1234',
+          FleetState: 'active',
+          Instances: [{ InstanceIds: ['i-running'] }],
+        },
+      ],
+    });
+    mockEC2Client.on(DescribeInstancesCommand, { InstanceIds: ['i-running'] }).resolves({
+      Reservations: [{ Instances: [{ InstanceId: 'i-running', State: { Name: 'running' } }] }],
+    });
+    mockEC2Client.on(DeleteFleetsCommand).resolves({});
+
+    await cleanupFleet('fleet-1234');
+
+    expect(mockEC2Client).not.toHaveReceivedCommand(DeleteFleetsCommand);
+  });
+
+  it('deletes the fleet when associated instances are terminated or missing', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'InvalidInstanceID.NotFound' });
+    mockEC2Client.on(DescribeFleetsCommand).resolves({
+      Fleets: [
+        {
+          FleetId: 'fleet-1234',
+          FleetState: 'active',
+          Instances: [{ InstanceIds: ['i-terminated', 'i-missing'] }],
+        },
+      ],
+    });
+    mockEC2Client.on(DescribeInstancesCommand, { InstanceIds: ['i-terminated'] }).resolves({
+      Reservations: [{ Instances: [{ InstanceId: 'i-terminated', State: { Name: 'terminated' } }] }],
+    });
+    mockEC2Client.on(DescribeInstancesCommand, { InstanceIds: ['i-missing'] }).rejects(notFound);
+    mockEC2Client.on(DeleteFleetsCommand).resolves({});
+
+    await cleanupFleet('fleet-1234');
+
+    expect(mockEC2Client).toHaveReceivedCommandWith(DeleteFleetsCommand, {
+      FleetIds: ['fleet-1234'],
+      TerminateInstances: false,
     });
   });
 });
@@ -1054,6 +1144,10 @@ function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues):
       },
       {
         ResourceType: 'volume',
+        Tags: tags,
+      },
+      {
+        ResourceType: 'fleet',
         Tags: tags,
       },
     ],

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -2,7 +2,9 @@ import {
   CreateFleetCommand,
   CreateFleetResult,
   CreateTagsCommand,
+  DeleteFleetsCommand,
   DeleteTagsCommand,
+  DescribeFleetsCommand,
   DescribeInstancesCommand,
   DescribeInstancesResult,
   RunInstancesCommand,
@@ -22,6 +24,7 @@ import ScaleError from './../scale-runners/ScaleError';
 import * as Runners from './runners.d';
 
 const logger = createChildLogger('runners');
+const FLEET_ID_TAG_KEYS = ['ghr:FleetId', 'aws:ec2:fleet-id', 'aws:ec2spot:fleet-request-id'];
 
 interface Ec2Filter {
   Name: string;
@@ -80,6 +83,10 @@ async function getRunners(ec2Filters: Ec2Filter[]): Promise<Runners.RunnerList[]
   return runners;
 }
 
+function fleetIdFromTags(tags: Tag[] | undefined): string | undefined {
+  return tags?.find((tag) => FLEET_ID_TAG_KEYS.includes(tag.Key ?? ''))?.Value;
+}
+
 function getRunnerInfo(runningInstances: DescribeInstancesResult) {
   const runners: Runners.RunnerList[] = [];
   if (runningInstances.Reservations) {
@@ -88,6 +95,7 @@ function getRunnerInfo(runningInstances: DescribeInstancesResult) {
         for (const i of r.Instances) {
           runners.push({
             instanceId: i.InstanceId as string,
+            fleetId: fleetIdFromTags(i.Tags),
             launchTime: i.LaunchTime,
             owner: i.Tags?.find((e) => e.Key === 'ghr:Owner')?.Value as string,
             type: i.Tags?.find((e) => e.Key === 'ghr:Type')?.Value as string,
@@ -109,6 +117,90 @@ export async function terminateRunner(instanceId: string): Promise<void> {
   const ec2 = getTracedAWSV3Client(new EC2Client({ region: process.env.AWS_REGION }));
   await ec2.send(new TerminateInstancesCommand({ InstanceIds: [instanceId] }));
   logger.debug(`Runner ${instanceId} has been terminated.`);
+}
+
+export async function cleanupFleet(fleetId: string): Promise<void> {
+  const ec2 = getTracedAWSV3Client(new EC2Client({ region: process.env.AWS_REGION }));
+  const fleetInstanceIds = await getFleetInstanceIds(fleetId, ec2);
+
+  if (fleetInstanceIds === undefined) {
+    return;
+  }
+
+  const activeInstanceIds = await getActiveFleetInstanceIds(fleetInstanceIds, ec2);
+  if (activeInstanceIds.length > 0) {
+    logger.info(`EC2 Fleet '${fleetId}' still has active instance(s), skipping delete.`, {
+      activeInstanceIds,
+    });
+    return;
+  }
+
+  await deleteFleet(fleetId, ec2);
+}
+
+async function getFleetInstanceIds(fleetId: string, ec2: EC2Client): Promise<string[] | undefined> {
+  try {
+    const fleet = await ec2.send(new DescribeFleetsCommand({ FleetIds: [fleetId] }));
+    const fleetData = fleet.Fleets?.[0];
+
+    if (!fleetData) {
+      logger.debug(`EC2 Fleet '${fleetId}' was not returned by DescribeFleets.`);
+      return undefined;
+    }
+
+    if (fleetData.FleetState?.startsWith('deleted')) {
+      logger.debug(`EC2 Fleet '${fleetId}' is already deleted.`, { fleetState: fleetData.FleetState });
+      return undefined;
+    }
+
+    return fleetData.Instances?.flatMap((instance) => instance.InstanceIds ?? []) ?? [];
+  } catch (e) {
+    if (isNotFoundError(e)) {
+      logger.debug(`EC2 Fleet '${fleetId}' no longer exists.`);
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+async function getActiveFleetInstanceIds(instanceIds: string[], ec2: EC2Client): Promise<string[]> {
+  const activeInstanceIds: string[] = [];
+
+  for (const instanceId of instanceIds) {
+    const state = await getInstanceState(instanceId, ec2);
+    if (state && state !== 'terminated') {
+      activeInstanceIds.push(instanceId);
+    }
+  }
+
+  return activeInstanceIds;
+}
+
+async function getInstanceState(instanceId: string, ec2: EC2Client): Promise<string | undefined> {
+  try {
+    const instances = await ec2.send(new DescribeInstancesCommand({ InstanceIds: [instanceId] }));
+    return instances.Reservations?.flatMap((reservation) => reservation.Instances ?? [])[0]?.State?.Name;
+  } catch (e) {
+    if (isNotFoundError(e)) {
+      logger.debug(`EC2 Fleet instance '${instanceId}' no longer exists.`);
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+async function deleteFleet(fleetId: string, ec2: EC2Client): Promise<void> {
+  logger.info(`Deleting EC2 Fleet '${fleetId}'.`);
+  const result = await ec2.send(new DeleteFleetsCommand({ FleetIds: [fleetId], TerminateInstances: false }));
+  const unsuccessful = result.UnsuccessfulFleetDeletions ?? [];
+  if (unsuccessful.length > 0) {
+    logger.warn(`EC2 Fleet '${fleetId}' was not deleted.`, { unsuccessful });
+  }
+}
+
+function isNotFoundError(e: unknown): boolean {
+  const name = (e as { name?: string }).name ?? '';
+  return name.includes('NotFound');
 }
 
 export async function tag(instanceId: string, tags: Tag[]): Promise<void> {
@@ -324,6 +416,10 @@ async function createInstances(
         },
         {
           ResourceType: 'volume',
+          Tags: tags,
+        },
+        {
+          ResourceType: 'fleet',
           Tags: tags,
         },
       ],

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 import { RunnerInfo, RunnerList } from '../aws/runners.d';
 import * as ghAuth from '../github/auth';
-import { listEC2Runners, terminateRunner, tag, untag } from './../aws/runners';
+import { cleanupFleet, listEC2Runners, terminateRunner, tag, untag } from './../aws/runners';
 import { githubCache } from './cache';
 import { newestFirstStrategy, oldestFirstStrategy, scaleDown } from './scale-down';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -37,6 +37,7 @@ vi.mock('./../aws/runners', async (importOriginal) => {
     ...actual,
     tag: vi.fn(),
     untag: vi.fn(),
+    cleanupFleet: vi.fn(),
     terminateRunner: vi.fn(),
     listEC2Runners: vi.fn(),
   };
@@ -67,6 +68,7 @@ const mockCreateClient = vi.mocked(ghAuth.createOctokitClient);
 const mockListRunners = vi.mocked(listEC2Runners);
 const mockTagRunners = vi.mocked(tag);
 const mockUntagRunners = vi.mocked(untag);
+const mockCleanupFleet = vi.mocked(cleanupFleet);
 const mockTerminateRunners = vi.mocked(terminateRunner);
 
 export interface TestData {
@@ -164,6 +166,7 @@ describe('Scale down runners', () => {
     mockTerminateRunners.mockImplementation(async () => {
       return;
     });
+    mockCleanupFleet.mockResolvedValue(undefined);
     mockedAppAuth.mockResolvedValue({
       type: 'app',
       token: 'token',
@@ -239,6 +242,22 @@ describe('Scale down runners', () => {
 
         checkTerminated(runners);
         checkNonTerminated(runners);
+      });
+
+      it(`Should cleanup fleet after terminating runner ${type} runners.`, async () => {
+        // setup
+        const runners = [
+          createRunnerTestData('idle-with-fleet', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 4, true, false, true),
+        ];
+        runners[0].fleetId = 'fleet-1234';
+
+        mockGitHubRunners(runners);
+        mockAwsRunners(runners);
+
+        await scaleDown();
+
+        expect(terminateRunner).toHaveBeenCalledWith(runners[0].instanceId);
+        expect(cleanupFleet).toHaveBeenCalledWith('fleet-1234');
       });
 
       it(`Should respect idle runner with minimum running time not exceeded.`, async () => {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
@@ -5,7 +5,7 @@ import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import moment from 'moment';
 
 import { createGithubAppAuth, createGithubInstallationAuth, createOctokitClient } from '../github/auth';
-import { bootTimeExceeded, listEC2Runners, tag, untag, terminateRunner } from './../aws/runners';
+import { bootTimeExceeded, cleanupFleet, listEC2Runners, tag, untag, terminateRunner } from './../aws/runners';
 import { RunnerInfo, RunnerList } from './../aws/runners.d';
 import { GhRunners, githubCache } from './cache';
 import { ScalingDownConfig, getEvictionStrategy, getIdleRunnerCount } from './scale-down-config';
@@ -13,6 +13,7 @@ import { metricGitHubAppRateLimit } from '../github/rate-limit';
 import { getGitHubEnterpriseApiUrl } from './scale-up';
 
 const logger = createChildLogger('scale-down');
+const FLEET_CLEANUP_INSTANCE_STATES = ['pending', 'running', 'shutting-down', 'stopping', 'stopped', 'terminated'];
 
 type OrgRunnerList = Endpoints['GET /orgs/{org}/actions/runners']['response']['data']['runners'];
 type RepoRunnerList = Endpoints['GET /repos/{owner}/{repo}/actions/runners']['response']['data']['runners'];
@@ -127,6 +128,37 @@ function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   return launchTimePlusMinimum < now;
 }
 
+async function cleanupFleetForRunner(ec2runner: Pick<RunnerList, 'instanceId' | 'fleetId'>): Promise<void> {
+  if (!ec2runner.fleetId) {
+    return;
+  }
+
+  try {
+    await cleanupFleet(ec2runner.fleetId);
+  } catch (e) {
+    logger.warn(`Failed to cleanup EC2 Fleet '${ec2runner.fleetId}' for runner '${ec2runner.instanceId}'.`, {
+      error: e as Error,
+    });
+  }
+}
+
+async function cleanupDiscoveredFleets(environment: string): Promise<void> {
+  try {
+    const runners = await listEC2Runners({ environment, statuses: FLEET_CLEANUP_INSTANCE_STATES });
+    const fleetIds = [
+      ...new Set(runners.map((runner) => runner.fleetId).filter((fleetId): fleetId is string => Boolean(fleetId))),
+    ];
+
+    for (const fleetId of fleetIds) {
+      await cleanupFleet(fleetId).catch((e) => {
+        logger.warn(`Failed to cleanup EC2 Fleet '${fleetId}'.`, { error: e as Error });
+      });
+    }
+  } catch (e) {
+    logger.warn(`Failure during EC2 Fleet cleanup processing.`, { error: e as Error });
+  }
+}
+
 async function removeRunner(ec2runner: RunnerInfo, ghRunnerIds: number[]): Promise<void> {
   const githubAppClient = await getOrCreateOctokit(ec2runner);
   try {
@@ -165,6 +197,7 @@ async function removeRunner(ec2runner: RunnerInfo, ghRunnerIds: number[]): Promi
 
       if (statuses.every((status) => status == 204)) {
         await terminateRunner(ec2runner.instanceId);
+        await cleanupFleetForRunner(ec2runner);
         logger.info(`AWS runner instance '${ec2runner.instanceId}' is terminated and GitHub runner is de-registered.`);
       } else {
         logger.error(`Failed to de-register GitHub runner: ${statuses}`);
@@ -276,14 +309,17 @@ async function terminateOrphan(environment: string): Promise<void> {
         const isOrphan = await lastChanceCheckOrphanRunner(runner);
         if (isOrphan) {
           await terminateRunner(runner.instanceId);
+          await cleanupFleetForRunner(runner);
         } else {
           await unMarkOrphan(runner.instanceId);
         }
       } else {
         logger.info(`Terminating orphan runner '${runner.instanceId}'`);
-        await terminateRunner(runner.instanceId).catch((e) => {
-          logger.error(`Failed to terminate orphan runner '${runner.instanceId}'`, { error: e });
-        });
+        await terminateRunner(runner.instanceId)
+          .then(() => cleanupFleetForRunner(runner))
+          .catch((e) => {
+            logger.error(`Failed to terminate orphan runner '${runner.instanceId}'`, { error: e });
+          });
       }
     }
   } catch (e) {
@@ -320,6 +356,7 @@ export async function scaleDown(): Promise<void> {
 
   // first runners marked to be orphan.
   await terminateOrphan(environment);
+  await cleanupDiscoveredFleets(environment);
 
   // next scale down idle runners with respect to config and mark potential orphans
   const ec2Runners = await listRunners(environment);
@@ -337,4 +374,5 @@ export async function scaleDown(): Promise<void> {
 
   const activeEc2RunnersCountAfter = (await listRunners(environment)).length;
   logger.info(`Found: '${activeEc2RunnersCountAfter}' active GitHub EC2 runners instances after clean-up.`);
+  await cleanupDiscoveredFleets(environment);
 }

--- a/modules/runners/policies/lambda-scale-down.json
+++ b/modules/runners/policies/lambda-scale-down.json
@@ -4,6 +4,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeFleets",
         "ec2:DescribeInstances",
         "ec2:DescribeTags"
       ],
@@ -14,6 +15,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DeleteFleets",
         "ec2:TerminateInstances",
         "ec2:CreateTags",
         "ec2:DeleteTags"
@@ -30,6 +32,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DeleteFleets",
         "ec2:TerminateInstances",
         "ec2:CreateTags",
         "ec2:DeleteTags"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes in this PR. -->

## Test Plan

<!--
  Please describe how you tested these changes. This helps reviewers understand
  the scope and confidence level of the change. Examples:

  - Ran `terraform plan` against an existing deployment
  - Added/updated unit tests (link to test file or describe coverage)
  - Deployed to a test environment and triggered a workflow run
  - Validated with `terraform validate` and `tflint`
-->

## Related Issues

<!-- Link any related issues, e.g. Fixes #123, Closes #456 -->
