### PR TITLE
fix(scale-down): respect bypass-removal tag for orphaned runners

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
@@ -305,6 +305,30 @@ describe('Scale down runners', () => {
         checkNonTerminated(runners);
       });
 
+      it(`Should not terminate orphaned runner with bypass-removal tag set.`, async () => {
+        // setup - orphan runner with bypass-removal tag
+        const orphanRunner = createRunnerTestData('orphan-bypass', type, MINIMUM_BOOT_TIME + 1, false, false, false);
+        orphanRunner.bypassRemoval = true;
+
+        const idleRunner = createRunnerTestData('idle-1', type, MINIMUM_BOOT_TIME + 1, true, false, false);
+        const runners = [orphanRunner, idleRunner];
+
+        mockGitHubRunners([idleRunner]);
+        mockAwsRunners(runners);
+
+        // act - first cycle marks orphan
+        await scaleDown();
+
+        // mark as orphan for next cycle
+        orphanRunner.orphan = true;
+
+        // act - second cycle should skip termination due to bypass-removal
+        await scaleDown();
+
+        // assert - orphan runner should NOT be terminated
+        expect(terminateRunner).not.toHaveBeenCalledWith(orphanRunner.instanceId);
+      });
+
       it(`Should not terminate a runner that became busy just before deregister runner.`, async () => {
         // setup
         const runners = [

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
@@ -194,6 +194,10 @@ async function evaluateAndRemoveRunners(
     logger.debug(`Found: '${ec2RunnersFiltered.length}' active GitHub runners with owner tag: '${ownerTag}'`);
     logger.debug(`Active GitHub runners with owner tag: '${ownerTag}': ${JSON.stringify(ec2RunnersFiltered)}`);
     for (const ec2Runner of ec2RunnersFiltered) {
+      if ((ec2Runner as unknown as RunnerList).bypassRemoval) {
+        logger.debug(`Runner '${ec2Runner.instanceId}' has bypass-removal tag set, skipping evaluation.`);
+        continue;
+      }
       const ghRunners = await listGitHubRunners(ec2Runner);
       const ghRunnersFiltered = ghRunners.filter((runner: { name: string }) =>
         runner.name.endsWith(ec2Runner.instanceId),
@@ -272,6 +276,10 @@ async function terminateOrphan(environment: string): Promise<void> {
     const orphanRunners = await listEC2Runners({ environment, orphan: true });
 
     for (const runner of orphanRunners) {
+      if (runner.bypassRemoval) {
+        logger.info(`Orphan runner '${runner.instanceId}' has bypass-removal tag set, skipping termination.`);
+        continue;
+      }
       if (runner.runnerId) {
         const isOrphan = await lastChanceCheckOrphanRunner(runner);
         if (isOrphan) {


### PR DESCRIPTION
## Problem

The scale-down lambda terminates instances tagged with `ghr:bypass-removal=true` when they appear as orphans (no matching GitHub runner found in the GitHub API).

The `ghr:bypass-removal` tag is intended to prevent the scale-down lambda from terminating an instance under any circumstance. However, only the `removeRunner()` function (normal idle-runner removal path) checks this tag. The orphan detection and termination paths do not:

1. **`evaluateAndRemoveRunners()`** — when no GitHub runner matches an EC2 instance and boot time is exceeded, it marks the instance as orphan without checking bypass-removal
2. **`terminateOrphan()`** — when processing previously-marked orphan instances, it terminates them without checking bypass-removal

This is particularly problematic for ephemeral runners that deregister from GitHub immediately after completing a job — the next scale-down invocation sees no matching runner and marks them as orphans, then terminates them on the subsequent cycle regardless of the bypass tag.

## Fix

- Add `bypassRemoval` check at the top of the evaluation loop in `evaluateAndRemoveRunners()`, before any orphan-marking or idle removal logic runs — runners with this tag are skipped entirely
- Add `bypassRemoval` check in `terminateOrphan()` before terminating orphaned runners
- Runners with bypass-removal tag are logged and skipped in both paths

## Tests

Added test case:
- Orphaned runners with bypass-removal tag are not terminated (covers both the marking and termination cycles)