### PR TITLE
feat(runners): tag EC2 fleets

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -1059,6 +1059,10 @@ function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues):
         ResourceType: 'volume',
         Tags: tags,
       },
+      {
+        ResourceType: 'fleet',
+        Tags: tags,
+      },
     ],
     TargetCapacitySpecification: {
       DefaultTargetCapacityType: expectedValues.capacityType,

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -382,6 +382,10 @@ async function createInstances(
           ResourceType: 'volume',
           Tags: tags,
         },
+        {
+          ResourceType: 'fleet',
+          Tags: tags,
+        },
       ],
       Type: 'instant',
     });


### PR DESCRIPTION
## Description

Adds EC2 Fleet tag specifications to the CreateFleet request so fleets receive the same runner tags as instances and volumes. Updates the shared CreateFleet request expectation in the runner tests.

## Test Plan
N/A
## Related Issues

None