### PR TITLE
fix: stop a malformed SQS body from poisoning the whole batch

### DIFF
--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -116,6 +116,49 @@ describe('Test scale up lambda wrapper.', () => {
       vi.clearAllMocks();
     });
 
+    const malformedRecord = (messageId: string): SQSRecord =>
+      ({ ...sqsRecord, eventSource: 'aws:sqs', messageId, body: 'not-json{' }) as SQSRecord;
+
+    it('Should not let one malformed message fail the whole invocation', async () => {
+      // Previously JSON.parse ran outside the try/catch, so an unparseable body threw
+      // straight out of the handler, failing the invocation and making SQS redeliver
+      // every message in the batch.
+      const records = [...createMultipleRecords(2), malformedRecord('message-bad')];
+      vi.mocked(scaleUp).mockResolvedValue([]);
+
+      await expect(scaleUpHandler({ Records: records }, context)).resolves.not.toThrow();
+    });
+
+    it('Should report only the malformed message as a batch item failure', async () => {
+      const records = [...createMultipleRecords(2), malformedRecord('message-bad')];
+      vi.mocked(scaleUp).mockResolvedValue([]);
+
+      await expect(scaleUpHandler({ Records: records }, context)).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-bad' }],
+      });
+    });
+
+    it('Should still process the valid messages alongside a malformed one', async () => {
+      const records = [...createMultipleRecords(2), malformedRecord('message-bad')];
+      vi.mocked(scaleUp).mockResolvedValue([]);
+
+      await scaleUpHandler({ Records: records }, context);
+
+      expect(scaleUp).toHaveBeenCalledWith([
+        expect.objectContaining({ messageId: 'message-0' }),
+        expect.objectContaining({ messageId: 'message-1' }),
+      ]);
+    });
+
+    it('Should combine malformed and rejected messages in batch item failures', async () => {
+      const records = [...createMultipleRecords(2), malformedRecord('message-bad')];
+      vi.mocked(scaleUp).mockResolvedValue(['message-1']);
+
+      await expect(scaleUpHandler({ Records: records }, context)).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-bad' }, { itemIdentifier: 'message-1' }],
+      });
+    });
+
     const createMultipleRecords = (count: number, eventSource = 'aws:sqs'): SQSRecord[] => {
       return Array.from({ length: count }, (_, i) => ({
         ...sqsRecord,

--- a/lambdas/functions/control-plane/src/lambda.ts
+++ b/lambdas/functions/control-plane/src/lambda.ts
@@ -16,6 +16,7 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
 
   const sqsMessages: ActionRequestMessageSQS[] = [];
   const warnedEventSources = new Set<string>();
+  const malformedMessageIds: string[] = [];
 
   for (const { body, eventSource, messageId } of event.Records) {
     if (eventSource !== 'aws:sqs') {
@@ -27,7 +28,25 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
       continue;
     }
 
-    const payload = JSON.parse(body) as ActionRequestMessage;
+    let payload: ActionRequestMessage;
+    try {
+      payload = JSON.parse(body) as ActionRequestMessage;
+    } catch (e) {
+      // Parsing happens outside the try/catch below, so an unparseable body used to
+      // throw straight out of the handler. That failed the whole invocation and made
+      // SQS redeliver the entire batch, so one malformed message held up every valid
+      // message alongside it, indefinitely.
+      //
+      // Report it as an individual failure instead: the rest of the batch proceeds,
+      // and the malformed message exhausts maxReceiveCount on its own. It cannot be
+      // acknowledged and discarded here — reporting it is the only way to single it
+      // out — so configure redrive_build_queue if these should be captured rather
+      // than expire.
+      logger.error(`Ignoring message ${messageId}, body is not valid JSON`, { error: e, messageId });
+      malformedMessageIds.push(messageId);
+
+      continue;
+    }
     sqsMessages.push({ ...payload, messageId });
   }
 
@@ -38,7 +57,7 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
     return (l.retryCounter ?? 0) - (r.retryCounter ?? 0);
   });
 
-  const batchItemFailures: SQSBatchItemFailure[] = [];
+  const batchItemFailures: SQSBatchItemFailure[] = malformedMessageIds.map((itemIdentifier) => ({ itemIdentifier }));
 
   try {
     const rejectedMessageIds = await scaleUp(sqsMessages);


### PR DESCRIPTION
### Problem

`JSON.parse(body)` runs in the record loop at the top of `scaleUpHandler`, outside the `try`/`catch` further down. An unparseable message body therefore throws straight out of the handler.

Lambda treats a thrown exception as a complete batch failure, so **nothing is deleted and the entire batch returns to the queue** after the visibility timeout. The body is malformed deterministically, so every redelivery reproduces the same `SyntaxError`. `scaleUp` is never reached, which means valid messages batched alongside the malformed one are never processed either — they are blocked as collateral damage.

Two things make it worse:

- `ReportBatchItemFailures` [disables Lambda's scale-down of message polling when invocations fail](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html), so the usual concurrency backoff does not apply.
- `redrive_build_queue` defaults to `enabled = false`, so there is no `maxReceiveCount` cap. The only backstop is `job_queue_retention_in_seconds`, default 24h.

Verified empirically against `main`: a batch of two valid records plus one malformed one rejects with `SyntaxError` and `scaleUp` is called zero times.

### Change

Parse each record defensively. A malformed body is logged and reported as an individual batch item failure; the rest of the batch proceeds to `scaleUp` as normal.

The malformed message then exhausts `maxReceiveCount` on its own rather than taking the batch with it. It cannot be acknowledged and discarded through the partial-failure mechanism — reporting it is the only way to single it out — so with the default configuration it expires by retention rather than moving to a DLQ. Operators who want these captured should enable `redrive_build_queue`.

### Tests

Four tests covering: the invocation no longer fails, only the malformed message is reported, valid messages still reach `scaleUp`, and malformed and rejected messages combine correctly. All four fail against the current implementation.

### Note on scope

This is distinct from #5129. That PR addresses the `catch` block, where a non-`ScaleError` returns an empty `batchItemFailures` — which AWS treats as complete success, so the batch is **deleted**. Opposite failure mode, different path, and worth keeping separate. I originally conflated the two in a comment on #5129 and have corrected it there.

Touches the same file as #5129, so whichever lands second will need a trivial rebase.