### PR TITLE
fix: wrap LOG_LEVEL env var with upper() for Powertools v2 compatibility

### DIFF
--- a/modules/ami-housekeeper/main.tf
+++ b/modules/ami-housekeeper/main.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "ami_housekeeper" {
 
   environment {
     variables = {
-      LOG_LEVEL                                = var.log_level
+      LOG_LEVEL                                = upper(var.log_level)
       POWERTOOLS_LOGGER_LOG_EVENT              = var.log_level == "debug" ? "true" : "false"
       AMI_CLEANUP_OPTIONS                      = jsonencode(var.cleanup_config)
       POWERTOOLS_SERVICE_NAME                  = "${var.prefix}-ami-housekeeper"

--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "syncer" {
       ENVIRONMENT                              = var.prefix
       GITHUB_RUNNER_ARCHITECTURE               = var.runner_architecture
       GITHUB_RUNNER_OS                         = local.gh_binary_os_label[var.runner_os]
-      LOG_LEVEL                                = var.log_level
+      LOG_LEVEL                                = upper(var.log_level)
       POWERTOOLS_LOGGER_LOG_EVENT              = var.log_level == "debug" ? "true" : "false"
       POWERTOOLS_TRACE_ENABLED                 = var.tracing_config.mode != null ? true : false
       POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS = var.tracing_config.capture_http_requests

--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -38,7 +38,7 @@ resource "aws_lambda_function" "pool" {
       INSTANCE_TYPE_PRIORITIES                 = var.config.instance_type_priorities != null ? jsonencode(var.config.instance_type_priorities) : ""
       INSTANCE_TYPES                           = join(",", var.config.instance_types)
       LAUNCH_TEMPLATE_NAME                     = var.config.runner.launch_template.name
-      LOG_LEVEL                                = var.config.lambda.log_level
+      LOG_LEVEL                                = upper(var.config.lambda.log_level)
       NODE_TLS_REJECT_UNAUTHORIZED             = var.config.ghes.url != null && !var.config.ghes.ssl_verify ? 0 : 1
       PARAMETER_GITHUB_APP_ID_NAME             = var.config.github_app_parameters.id.name
       PARAMETER_GITHUB_APP_KEY_BASE64_NAME     = var.config.github_app_parameters.key_base64.name

--- a/modules/runners/scale-down.tf
+++ b/modules/runners/scale-down.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "scale_down" {
       ENABLE_METRIC_GITHUB_APP_RATE_LIMIT      = var.metrics.enable && var.metrics.metric.enable_github_app_rate_limit
       GHES_URL                                 = var.ghes_url
       USER_AGENT                               = var.user_agent
-      LOG_LEVEL                                = var.log_level
+      LOG_LEVEL                                = upper(var.log_level)
       MINIMUM_RUNNING_TIME_IN_MINUTES          = coalesce(var.minimum_running_time_in_minutes, local.min_runtime_defaults[var.runner_os])
       NODE_TLS_REJECT_UNAUTHORIZED             = var.ghes_url != null && !var.ghes_ssl_verify ? 0 : 1
       PARAMETER_GITHUB_APP_ID_NAME             = var.github_app_parameters.id.name

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "scale_up" {
       INSTANCE_TYPE_PRIORITIES                 = var.instance_type_priorities != null ? jsonencode(var.instance_type_priorities) : ""
       INSTANCE_TYPES                           = join(",", var.instance_types)
       LAUNCH_TEMPLATE_NAME                     = aws_launch_template.runner.name
-      LOG_LEVEL                                = var.log_level
+      LOG_LEVEL                                = upper(var.log_level)
       MINIMUM_RUNNING_TIME_IN_MINUTES          = coalesce(var.minimum_running_time_in_minutes, local.min_runtime_defaults[var.runner_os])
       NODE_TLS_REJECT_UNAUTHORIZED             = var.ghes_url != null && !var.ghes_ssl_verify ? 0 : 1
       PARAMETER_GITHUB_APP_ID_NAME             = var.github_app_parameters.id.name

--- a/modules/runners/ssm-housekeeper.tf
+++ b/modules/runners/ssm-housekeeper.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "ssm_housekeeper" {
   environment {
     variables = {
       ENVIRONMENT                              = var.prefix
-      LOG_LEVEL                                = var.log_level
+      LOG_LEVEL                                = upper(var.log_level)
       SSM_CLEANUP_CONFIG                       = jsonencode(local.ssm_housekeeper.config)
       POWERTOOLS_SERVICE_NAME                  = "${var.prefix}-ssm-housekeeper"
       POWERTOOLS_TRACE_ENABLED                 = var.tracing_config.mode != null ? true : false

--- a/modules/webhook/direct/webhook.tf
+++ b/modules/webhook/direct/webhook.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "webhook" {
   environment {
     variables = {
       for k, v in {
-        LOG_LEVEL                                = var.config.log_level
+        LOG_LEVEL                                = upper(var.config.log_level)
         POWERTOOLS_LOGGER_LOG_EVENT              = var.config.log_level == "debug" ? "true" : "false"
         POWERTOOLS_TRACE_ENABLED                 = var.config.tracing_config.mode != null ? true : false
         POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS = var.config.tracing_config.capture_http_requests

--- a/modules/webhook/eventbridge/dispatcher.tf
+++ b/modules/webhook/eventbridge/dispatcher.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "dispatcher" {
   environment {
     variables = {
       for k, v in {
-        LOG_LEVEL                                = var.config.log_level
+        LOG_LEVEL                                = upper(var.config.log_level)
         POWERTOOLS_LOGGER_LOG_EVENT              = var.config.log_level == "debug" ? "true" : "false"
         POWERTOOLS_SERVICE_NAME                  = "${var.config.prefix}-dispatcher"
         POWERTOOLS_TRACE_ENABLED                 = var.config.tracing_config.mode != null ? true : false

--- a/modules/webhook/eventbridge/webhook.tf
+++ b/modules/webhook/eventbridge/webhook.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "webhook" {
   environment {
     variables = {
       for k, v in {
-        LOG_LEVEL                                = var.config.log_level
+        LOG_LEVEL                                = upper(var.config.log_level)
         POWERTOOLS_LOGGER_LOG_EVENT              = var.config.log_level == "debug" ? "true" : "false"
         POWERTOOLS_SERVICE_NAME                  = "${var.config.prefix}-webhook"
         POWERTOOLS_TRACE_ENABLED                 = var.config.tracing_config.mode != null ? true : false


### PR DESCRIPTION
## Description

Powertools v2 Logger reads the `LOG_LEVEL` environment variable without calling `.toUpperCase()`, and the internal `LogLevelThreshold` map only has uppercase keys (`DEBUG`, `INFO`, `WARN`, `ERROR`). When a lowercase value like `debug` is passed, it fails validation silently and defaults to `INFO`.

This wraps all `LOG_LEVEL` assignments with Terraform's `upper()` function, ensuring the Lambda always receives an uppercase value regardless of how the Terraform variable is cased.

**Files changed (9):**
- `modules/runners/scale-up.tf`
- `modules/runners/scale-down.tf`
- `modules/runners/ssm-housekeeper.tf`
- `modules/runners/pool/main.tf`
- `modules/webhook/eventbridge/webhook.tf`
- `modules/webhook/eventbridge/dispatcher.tf`
- `modules/webhook/direct/webhook.tf`
- `modules/ami-housekeeper/main.tf`
- `modules/runner-binaries-syncer/runner-binaries-syncer.tf`

## Test Plan

- Deployed to a staging environment with `log_level = "debug"` and verified Lambdas receive `LOG_LEVEL=DEBUG`
- Confirmed debug-level log output appears in CloudWatch after the fix (previously defaulted to INFO silently)
- Ran `terraform validate` successfully

## Related Issues

N/A — discovered during debugging of silent log level failures after upgrading to `@aws-lambda-powertools/logger` v2.31.0