### PR TITLE
test(control-plane): separate orchestration tests from EC2 provider tests

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
@@ -1,8 +1,70 @@
+import type { Octokit } from '@octokit/rest';
+import { RequestError } from '@octokit/request-error';
 import moment from 'moment';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { newestFirstStrategy, oldestFirstStrategy } from './scale-down';
-import type { RunnerInfo } from './scale-down-provider';
+import { controlPlaneProviderRegistry } from '../control-plane-providers';
+import * as ghAuth from '../github/auth';
+import { githubCache } from './cache';
+import { newestFirstStrategy, oldestFirstStrategy, scaleDown } from './scale-down';
+import type { RunnerInfo, ScaleDownRunnerProvider } from './scale-down-provider';
+
+vi.mock('../github/auth', () => ({
+  createGithubAppAuth: vi.fn(),
+  createGithubInstallationAuth: vi.fn(),
+  createOctokitClient: vi.fn(),
+}));
+
+const mockOctokit = {
+  apps: {
+    getOrgInstallation: vi.fn(),
+    getRepoInstallation: vi.fn(),
+  },
+  actions: {
+    listSelfHostedRunnersForRepo: vi.fn(),
+    listSelfHostedRunnersForOrg: vi.fn(),
+    deleteSelfHostedRunnerFromOrg: vi.fn(),
+    deleteSelfHostedRunnerFromRepo: vi.fn(),
+    getSelfHostedRunnerForOrg: vi.fn(),
+    getSelfHostedRunnerForRepo: vi.fn(),
+  },
+  paginate: vi.fn(),
+};
+
+const mockRunnerProvider = {
+  type: 'ec2',
+  list: vi.fn(),
+  bootTimeExceeded: vi.fn(),
+  markOrphan: vi.fn(),
+  unmarkOrphan: vi.fn(),
+  terminate: vi.fn(),
+} satisfies ScaleDownRunnerProvider;
+
+const mockedResolveCapability = vi.spyOn(controlPlaneProviderRegistry, 'capability');
+const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
+const mockedInstallationAuth = vi.mocked(ghAuth.createGithubInstallationAuth);
+const mockCreateClient = vi.mocked(ghAuth.createOctokitClient);
+const mockListRunners = vi.mocked(mockRunnerProvider.list);
+const mockBootTimeExceeded = vi.mocked(mockRunnerProvider.bootTimeExceeded);
+const mockMarkOrphan = vi.mocked(mockRunnerProvider.markOrphan);
+const mockUnmarkOrphan = vi.mocked(mockRunnerProvider.unmarkOrphan);
+const mockTerminateRunners = vi.mocked(mockRunnerProvider.terminate);
+
+const cleanEnv = process.env;
+
+const ENVIRONMENT = 'unit-test-environment';
+const MINIMUM_TIME_RUNNING_IN_MINUTES = 30;
+const MINIMUM_BOOT_TIME = 5;
+const TEST_DATA = {
+  repositoryName: 'hello-world',
+  repositoryOwner: 'Codertocat',
+};
+
+interface RunnerTestItem extends RunnerInfo {
+  registered: boolean;
+  orphan: boolean;
+  shouldBeTerminated: boolean;
+}
 
 describe('When runners are sorted', () => {
   const runners: RunnerInfo[] = [
@@ -101,3 +163,591 @@ describe('When runners are sorted', () => {
     expect(runnersTest[2].launchTime).not.toBeDefined();
   });
 });
+
+describe('Scale down runners', () => {
+  beforeEach(() => {
+    process.env = { ...cleanEnv };
+    process.env.GITHUB_APP_KEY_BASE64 = 'TEST_CERTIFICATE_DATA';
+    process.env.GITHUB_APP_ID = '1337';
+    process.env.GITHUB_APP_CLIENT_ID = 'TEST_CLIENT_ID';
+    process.env.GITHUB_APP_CLIENT_SECRET = 'TEST_CLIENT_SECRET';
+    process.env.RUNNERS_MAXIMUM_COUNT = '3';
+    process.env.SCALE_DOWN_CONFIG = '[]';
+    process.env.ENVIRONMENT = ENVIRONMENT;
+    process.env.MINIMUM_RUNNING_TIME_IN_MINUTES = MINIMUM_TIME_RUNNING_IN_MINUTES.toString();
+    process.env.RUNNER_BOOT_TIME_IN_MINUTES = MINIMUM_BOOT_TIME.toString();
+    process.env.RUNNER_PROVIDER_TYPE = mockRunnerProvider.type;
+
+    vi.clearAllMocks();
+    githubCache.clients.clear();
+    githubCache.runners.clear();
+
+    mockedResolveCapability.mockReturnValue(() => mockRunnerProvider);
+    mockBootTimeExceeded.mockImplementation((runner) => {
+      const launchTimePlusBootTime = moment(runner.launchTime).utc().add(MINIMUM_BOOT_TIME, 'minutes');
+      return launchTimePlusBootTime < moment(new Date()).utc();
+    });
+    mockMarkOrphan.mockResolvedValue();
+    mockUnmarkOrphan.mockResolvedValue();
+    mockTerminateRunners.mockResolvedValue();
+
+    mockOctokit.apps.getOrgInstallation.mockImplementation(() => ({
+      data: {
+        id: 'ORG',
+      },
+    }));
+    mockOctokit.apps.getRepoInstallation.mockImplementation(() => ({
+      data: {
+        id: 'REPO',
+      },
+    }));
+
+    mockOctokit.paginate.mockResolvedValue([]);
+    mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation((repo) => {
+      if (repo.runner_id.includes('busy')) {
+        throw Error();
+      }
+      return { status: 204 };
+    });
+
+    mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation((repo) => {
+      if (repo.runner_id.includes('busy')) {
+        throw Error();
+      }
+      return { status: 204 };
+    });
+
+    mockOctokit.actions.getSelfHostedRunnerForRepo.mockImplementation((repo) => {
+      if (repo.runner_id.includes('busy')) {
+        return {
+          data: { busy: true },
+        };
+      }
+      return {
+        data: { busy: false },
+      };
+    });
+    mockOctokit.actions.getSelfHostedRunnerForOrg.mockImplementation((repo) => {
+      if (repo.runner_id.includes('busy')) {
+        return {
+          data: { busy: true },
+        };
+      }
+      return {
+        data: { busy: false },
+      };
+    });
+
+    mockedAppAuth.mockResolvedValue({
+      type: 'app',
+      token: 'token',
+      appId: 1,
+      expiresAt: 'some-date',
+    });
+    mockedInstallationAuth.mockResolvedValue({
+      type: 'token',
+      tokenType: 'installation',
+      token: 'token',
+      createdAt: 'some-date',
+      expiresAt: 'some-date',
+      permissions: {},
+      repositorySelection: 'all',
+      installationId: 0,
+    });
+    mockCreateClient.mockResolvedValue(mockOctokit as unknown as Octokit);
+  });
+
+  const endpoints = ['https://api.github.com', 'https://github.enterprise.something', 'https://companyname.ghe.com'];
+
+  describe.each(endpoints)('for %s', (endpoint) => {
+    beforeEach(() => {
+      if (endpoint.includes('enterprise') || endpoint.endsWith('.ghe.com')) {
+        process.env.GHES_URL = endpoint;
+      }
+    });
+
+    type RunnerType = 'Repo' | 'Org';
+    const runnerTypes: RunnerType[] = ['Org', 'Repo'];
+    describe.each(runnerTypes)('For %s runners.', (type) => {
+      it(`Should terminate runner without idle config ${type} runners.`, async () => {
+        const runners = [
+          createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES - 1, true, false, false),
+          createRunnerTestData('idle-2', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 4, true, false, true),
+          createRunnerTestData('busy-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 3, true, false, false),
+          createRunnerTestData('booting-1', type, MINIMUM_BOOT_TIME - 1, false, false, false),
+        ];
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        expect(mockListRunners).toHaveBeenCalledWith(ENVIRONMENT);
+
+        if (type === 'Repo') {
+          expect(mockOctokit.apps.getRepoInstallation).toHaveBeenCalled();
+        } else {
+          expect(mockOctokit.apps.getOrgInstallation).toHaveBeenCalled();
+        }
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it(`Should respect idle runner with minimum running time not exceeded.`, async () => {
+        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES - 1, true, false, false)];
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it(`Should respect busy runner.`, async () => {
+        const runners = [createRunnerTestData('busy-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it(`Should not terminate runner with bypass-removal tag set.`, async () => {
+        const runners = [
+          createRunnerTestData('idle-with-bypass', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 10, true, false, false),
+        ];
+        runners[0].bypassRemoval = true;
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        expect(mockTerminateRunners).not.toHaveBeenCalled();
+        checkNonTerminated(runners);
+      });
+
+      it(`Should not terminate orphaned runner with bypass-removal tag set.`, async () => {
+        const orphanRunner = createRunnerTestData('orphan-bypass', type, MINIMUM_BOOT_TIME + 1, false, false, false);
+        orphanRunner.bypassRemoval = true;
+
+        const idleRunner = createRunnerTestData('idle-1', type, MINIMUM_BOOT_TIME + 1, true, false, false);
+        const runners = [orphanRunner, idleRunner];
+
+        mockGitHubRunners([idleRunner]);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        orphanRunner.orphan = true;
+
+        await scaleDown();
+
+        expect(mockTerminateRunners).not.toHaveBeenCalledWith(orphanRunner.id);
+      });
+
+      it(`Should not terminate a runner that became busy just before deregister runner.`, async () => {
+        const runners = [
+          createRunnerTestData(
+            'job-just-start-at-deregister-1',
+            type,
+            MINIMUM_TIME_RUNNING_IN_MINUTES + 1,
+            true,
+            false,
+            false,
+          ),
+        ];
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
+          return { status: 500 };
+        });
+
+        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
+          return { status: 500 };
+        });
+
+        await expect(scaleDown()).resolves.not.toThrow();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it(`Should terminate orphan (Non JIT)`, async () => {
+        const orphanRunner = createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, false, false);
+        const idleRunner = createRunnerTestData('idle-1', type, MINIMUM_BOOT_TIME + 1, true, false, false);
+        const runners = [orphanRunner, idleRunner];
+
+        mockGitHubRunners([idleRunner]);
+        mockProviderRunners(runners);
+
+        await scaleDown();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+
+        expect(mockMarkOrphan).toHaveBeenCalledWith(orphanRunner.id);
+        expect(mockMarkOrphan).not.toHaveBeenCalledWith(idleRunner.id);
+
+        orphanRunner.orphan = true;
+        orphanRunner.shouldBeTerminated = true;
+
+        await scaleDown();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it('Should test if orphaned runner, untag if online and busy, else terminate (JIT)', async () => {
+        const orphanRunner = createRunnerTestData(
+          'orphan-jit',
+          type,
+          MINIMUM_BOOT_TIME + 1,
+          false,
+          true,
+          false,
+          undefined,
+          1234567890,
+        );
+        const runners = [orphanRunner];
+
+        mockGitHubRunners([]);
+        mockProviderRunners(runners);
+
+        if (type === 'Repo') {
+          mockOctokit.actions.getSelfHostedRunnerForRepo.mockResolvedValueOnce({
+            data: { id: 1234567890, name: orphanRunner.id, busy: true, status: 'online' },
+          });
+        } else {
+          mockOctokit.actions.getSelfHostedRunnerForOrg.mockResolvedValueOnce({
+            data: { id: 1234567890, name: orphanRunner.id, busy: true, status: 'online' },
+          });
+        }
+
+        await scaleDown();
+
+        expect(mockUnmarkOrphan).toHaveBeenCalledWith(orphanRunner.id);
+        expect(mockTerminateRunners).not.toHaveBeenCalledWith(orphanRunner.id);
+
+        if (type === 'Repo') {
+          mockOctokit.actions.getSelfHostedRunnerForRepo.mockResolvedValueOnce({
+            data: { runnerId: 1234567890, name: orphanRunner.id, busy: true, status: 'offline' },
+          });
+        } else {
+          mockOctokit.actions.getSelfHostedRunnerForOrg.mockResolvedValueOnce({
+            data: { runnerId: 1234567890, name: orphanRunner.id, busy: true, status: 'offline' },
+          });
+        }
+
+        await scaleDown();
+
+        expect(mockTerminateRunners).toHaveBeenCalledWith(orphanRunner.id);
+      });
+
+      it('Should handle 404 error when checking orphaned runner (JIT) - treat as orphaned', async () => {
+        const orphanRunner = createRunnerTestData(
+          'orphan-jit-404',
+          type,
+          MINIMUM_BOOT_TIME + 1,
+          false,
+          true,
+          true,
+          undefined,
+          1234567890,
+        );
+        const runners = [orphanRunner];
+
+        mockGitHubRunners([]);
+        mockProviderRunners(runners);
+
+        const error404 = new RequestError('Runner not found', 404, {
+          request: {
+            method: 'GET',
+            url: 'https://api.github.com/test',
+            headers: {},
+          },
+        });
+
+        if (type === 'Repo') {
+          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error404);
+        } else {
+          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error404);
+        }
+
+        await scaleDown();
+
+        expect(mockTerminateRunners).toHaveBeenCalledWith(orphanRunner.id);
+      });
+
+      it('Should handle 404 error when checking runner busy state - treat as not busy', async () => {
+        const runner = createRunnerTestData('runner-404', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, true);
+        const runners = [runner];
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        const error404 = new RequestError('Runner not found', 404, {
+          request: {
+            method: 'GET',
+            url: 'https://api.github.com/test',
+            headers: {},
+          },
+        });
+
+        if (type === 'Repo') {
+          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error404);
+        } else {
+          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error404);
+        }
+
+        await scaleDown();
+
+        checkTerminated(runners);
+      });
+
+      it('Should re-throw non-404 errors when checking runner state', async () => {
+        const orphanRunner = createRunnerTestData(
+          'orphan-error',
+          type,
+          MINIMUM_BOOT_TIME + 1,
+          false,
+          true,
+          false,
+          undefined,
+          1234567890,
+        );
+        const runners = [orphanRunner];
+
+        mockGitHubRunners([]);
+        mockProviderRunners(runners);
+
+        const error500 = new RequestError('Internal server error', 500, {
+          request: {
+            method: 'GET',
+            url: 'https://api.github.com/test',
+            headers: {},
+          },
+        });
+
+        if (type === 'Repo') {
+          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error500);
+        } else {
+          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error500);
+        }
+
+        await expect(scaleDown()).resolves.not.toThrow();
+
+        expect(mockTerminateRunners).not.toHaveBeenCalledWith(orphanRunner.id);
+      });
+
+      it(`Should ignore errors when termination orphan fails.`, async () => {
+        const orphanRunner = createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true);
+        const runners = [orphanRunner];
+
+        mockGitHubRunners([]);
+        mockProviderRunners(runners);
+        mockTerminateRunners.mockImplementation(() => {
+          throw new Error('Failed to terminate');
+        });
+
+        await scaleDown();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      describe('When orphan termination fails', () => {
+        it(`Should not throw in case of list runner exception.`, async () => {
+          const runners = [createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true)];
+
+          mockGitHubRunners([]);
+          mockProviderRunners(runners);
+          mockListRunners.mockRejectedValueOnce(new Error('Failed to list runners'));
+
+          await scaleDown();
+
+          checkNonTerminated(runners);
+        });
+
+        it(`Should not throw in case of terminate runner exception.`, async () => {
+          const runners = [createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true)];
+
+          mockGitHubRunners([]);
+          mockProviderRunners(runners);
+          mockTerminateRunners.mockRejectedValue(new Error('Failed to terminate'));
+
+          await scaleDown();
+
+          checkNonTerminated(runners);
+        });
+      });
+
+      it(`Should not terminate instance in case de-register fails.`, async () => {
+        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
+
+        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
+          return { status: 500 };
+        });
+        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
+          return { status: 500 };
+        });
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await expect(scaleDown()).resolves.not.toThrow();
+
+        checkTerminated(runners);
+        checkNonTerminated(runners);
+      });
+
+      it(`Should not throw an exception in case of failure during removing a runner.`, async () => {
+        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, true, false)];
+
+        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
+          throw new Error('Failed to delete runner');
+        });
+        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
+          throw new Error('Failed to delete runner');
+        });
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await expect(scaleDown()).resolves.not.toThrow();
+      });
+
+      it(`Should not terminate instance when de-registration throws an error.`, async () => {
+        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
+
+        const error502 = new RequestError('Server Error', 502, {
+          request: {
+            method: 'DELETE',
+            url: 'https://api.github.com/test',
+            headers: {},
+          },
+        });
+
+        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
+          throw error502;
+        });
+        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
+          throw error502;
+        });
+
+        mockGitHubRunners(runners);
+        mockProviderRunners(runners);
+
+        await expect(scaleDown()).resolves.not.toThrow();
+
+        expect(mockTerminateRunners).not.toHaveBeenCalled();
+      });
+
+      const evictionStrategies = ['oldest_first', 'newest_first'];
+      describe.each(evictionStrategies)('When idle config defined', (evictionStrategy) => {
+        const defaultConfig = {
+          idleCount: 1,
+          cron: '* * * * * *',
+          timeZone: 'Europe/Amsterdam',
+          evictionStrategy,
+        };
+
+        beforeEach(() => {
+          process.env.SCALE_DOWN_CONFIG = JSON.stringify([defaultConfig]);
+        });
+
+        it(`Should terminate based on the the idle config with ${evictionStrategy} eviction strategy`, async () => {
+          const runnerToTerminateTime =
+            evictionStrategy === 'oldest_first'
+              ? MINIMUM_TIME_RUNNING_IN_MINUTES + 5
+              : MINIMUM_TIME_RUNNING_IN_MINUTES + 1;
+          const runners = [
+            createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 4, true, false, false),
+            createRunnerTestData('idle-to-terminate', type, runnerToTerminateTime, true, false, true),
+          ];
+
+          mockGitHubRunners(runners);
+          mockProviderRunners(runners);
+
+          await scaleDown();
+
+          const runnersToTerminate = runners.filter((runner) => runner.shouldBeTerminated);
+          for (const toTerminate of runnersToTerminate) {
+            expect(mockTerminateRunners).toHaveBeenCalledWith(toTerminate.id);
+          }
+
+          const runnersNotToTerminate = runners.filter((runner) => !runner.shouldBeTerminated);
+          for (const notTerminated of runnersNotToTerminate) {
+            expect(mockTerminateRunners).not.toHaveBeenCalledWith(notTerminated.id);
+          }
+        });
+      });
+    });
+  });
+});
+
+function mockProviderRunners(runners: RunnerTestItem[]) {
+  mockListRunners.mockImplementation(async (_environment, orphan) => {
+    return runners.filter((runner) => !orphan || orphan === runner.orphan);
+  });
+}
+
+function checkNonTerminated(runners: RunnerTestItem[]) {
+  const notTerminated = runners.filter((runner) => !runner.shouldBeTerminated);
+  for (const runner of notTerminated) {
+    expect(mockTerminateRunners).not.toHaveBeenCalledWith(runner.id);
+  }
+}
+
+function checkTerminated(runners: RunnerTestItem[]) {
+  const runnersToTerminate = runners.filter((runner) => runner.shouldBeTerminated);
+  expect(mockTerminateRunners).toHaveBeenCalledTimes(runnersToTerminate.length);
+  for (const runner of runnersToTerminate) {
+    expect(mockTerminateRunners).toHaveBeenCalledWith(runner.id);
+  }
+}
+
+function mockGitHubRunners(runners: RunnerTestItem[]) {
+  mockOctokit.paginate.mockResolvedValue(
+    runners
+      .filter((runner) => runner.registered)
+      .map((runner) => {
+        return {
+          id: runner.id,
+          name: runner.id,
+        };
+      }),
+  );
+}
+
+function createRunnerTestData(
+  name: string,
+  type: 'Org' | 'Repo',
+  minutesLaunchedAgo: number,
+  registered: boolean,
+  orphan: boolean,
+  shouldBeTerminated: boolean,
+  owner?: string,
+  runnerId?: number,
+): RunnerTestItem {
+  return {
+    id: `i-${name}-${type.toLowerCase()}`,
+    launchTime: moment(new Date()).subtract(minutesLaunchedAgo, 'minutes').toDate(),
+    type,
+    owner:
+      owner ??
+      (type === 'Repo' ? `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}` : `${TEST_DATA.repositoryOwner}`),
+    registered,
+    orphan,
+    shouldBeTerminated,
+    githubRunnerId: runnerId !== undefined ? String(runnerId) : undefined,
+    bypassRemoval: false,
+  };
+}

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -1,32 +1,2175 @@
-import * as ghAuth from '../github/auth';
-import * as scaleUpModule from './scale-up';
-import type { ActionRequestMessageSQS } from './types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest/vitest';
+// Using vi.mocked instead of jest-mock
+import nock from 'nock';
+import { performance } from 'perf_hooks';
 
-vi.mock('../github/auth', () => ({
+import { controlPlaneProviderRegistry } from '../control-plane-providers';
+import * as ghAuth from '../github/auth';
+import { createStartRunnerConfig } from './github-runner';
+import { publishRetryMessage } from './job-retry';
+import * as scaleUpModule from './scale-up';
+import type { CreateScaleUpRunnersInput, CreateScaleUpRunnersResult, ScaleUpRunnerProvider } from './scale-up-provider';
+import type { ActionRequestMessageSQS } from './types';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+
+const mockOctokit = {
+  paginate: vi.fn(),
+  checks: { get: vi.fn() },
+  actions: {
+    createRegistrationTokenForOrg: vi.fn(),
+    createRegistrationTokenForRepo: vi.fn(),
+    getJobForWorkflowRun: vi.fn(),
+    generateRunnerJitconfigForOrg: vi.fn(),
+    generateRunnerJitconfigForRepo: vi.fn(),
+  },
+  apps: {
+    getOrgInstallation: vi.fn(),
+    getRepoInstallation: vi.fn(),
+  },
+};
+
+interface TestRunnerCreationInput {
+  environment: string;
+  runnerType: string;
+  runnerOwner: string;
+  numberOfRunners: number;
+}
+
+interface TestRunnerLookupInput {
+  environment: string;
+  runnerType: string;
+  runnerOwner: string;
+}
+
+const createRunner = vi.fn<(input: TestRunnerCreationInput) => Promise<CreateScaleUpRunnersResult>>();
+const listRunners = vi.fn<(input: TestRunnerLookupInput) => Promise<unknown[]>>();
+const mockCreateRunner = vi.mocked(createRunner);
+const mockListRunners = vi.mocked(listRunners);
+const mockSSMClient = mockClient(SSMClient);
+const mockSSMgetParameter = vi.mocked(getParameter);
+const mockPublishRetryMessage = vi.mocked(publishRetryMessage);
+const testProviderState = { provider: 'test' };
+const mockRunnerProvider: ScaleUpRunnerProvider = {
+  type: 'ec2',
+  prepareGroup: vi.fn(),
+  getCurrentRunners: vi.fn(),
+  createRunners: vi.fn(),
+};
+const mockPrepareGroup = vi.mocked(mockRunnerProvider.prepareGroup);
+const mockGetCurrentRunners = vi.mocked(mockRunnerProvider.getCurrentRunners);
+const mockCreateRunners = vi.mocked(mockRunnerProvider.createRunners);
+const mockedResolveCapability = vi.spyOn(controlPlaneProviderRegistry, 'capability');
+
+function createRunnerResult(instances: string[], retryableErrorCount = 0, nonRetryableErrorCount = 0) {
+  return { instances, retryableErrorCount, nonRetryableErrorCount };
+}
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn().mockImplementation(function () {
+    return mockOctokit;
+  }),
+}));
+
+vi.mock('../github/auth', async () => ({
   createGithubAppAuth: vi.fn(),
   createGithubInstallationAuth: vi.fn(),
   createOctokitClient: vi.fn(),
 }));
 
+vi.mock('@aws-github-runner/aws-ssm-util', async () => {
+  const actual = (await vi.importActual(
+    '@aws-github-runner/aws-ssm-util',
+  )) as typeof import('@aws-github-runner/aws-ssm-util');
+
+  return {
+    ...actual,
+    getParameter: vi.fn(),
+  };
+});
+
+vi.mock('./job-retry', () => ({
+  publishRetryMessage: vi.fn(),
+  checkAndRetryJob: vi.fn(),
+}));
+
+export type RunnerType = 'ephemeral' | 'non-ephemeral';
+
+// for ephemeral and non-ephemeral runners
+const RUNNER_TYPES: RunnerType[] = ['ephemeral', 'non-ephemeral'];
+
 const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
-const cleanEnv = process.env;
+const mockedInstallationAuth = vi.mocked(ghAuth.createGithubInstallationAuth);
+const mockCreateClient = vi.mocked(ghAuth.createOctokitClient);
+
+const TEST_DATA_SINGLE: ActionRequestMessageSQS = {
+  id: 1,
+  eventType: 'workflow_job',
+  repositoryName: 'hello-world',
+  repositoryOwner: 'Codertocat',
+  installationId: 2,
+  repoOwnerType: 'Organization',
+  messageId: 'foobar',
+};
 
 const TEST_DATA: ActionRequestMessageSQS[] = [
   {
-    id: 1,
-    eventType: 'workflow_job',
-    repositoryName: 'hello-world',
-    repositoryOwner: 'Codertocat',
-    installationId: 2,
-    repoOwnerType: 'Organization',
+    ...TEST_DATA_SINGLE,
     messageId: 'foobar',
   },
 ];
 
-beforeEach(() => {
-  vi.clearAllMocks();
+const cleanEnv = process.env;
+
+const EXPECTED_RUNNER_PARAMS = {
+  environment: 'unit-test-environment',
+  runnerType: 'Org',
+  runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+  numberOfRunners: 1,
+};
+let expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+
+function setDefaults() {
   process.env = { ...cleanEnv };
+  process.env.PARAMETER_GITHUB_APP_ID_NAME = 'github-app-id';
+  process.env.GITHUB_APP_KEY_BASE64 = 'TEST_CERTIFICATE_DATA';
+  process.env.GITHUB_APP_ID = '1337';
+  process.env.GITHUB_APP_CLIENT_ID = 'TEST_CLIENT_ID';
+  process.env.GITHUB_APP_CLIENT_SECRET = 'TEST_CLIENT_SECRET';
+  process.env.RUNNERS_MAXIMUM_COUNT = '3';
+  process.env.ENVIRONMENT = EXPECTED_RUNNER_PARAMS.environment;
+}
+
+async function createTestProviderRunners(
+  input: CreateScaleUpRunnersInput<unknown>,
+): Promise<CreateScaleUpRunnersResult> {
+  const result = await mockCreateRunner({
+    environment: process.env.ENVIRONMENT,
+    runnerType: input.githubRunnerConfig.runnerType,
+    runnerOwner: input.githubRunnerConfig.runnerOwner,
+    numberOfRunners: input.numberOfRunners,
+  });
+
+  if (result.instances.length === 0) {
+    return result;
+  }
+
+  let failedRunnerIds: string[];
+  try {
+    failedRunnerIds = await createStartRunnerConfig(
+      input.githubRunnerConfig,
+      result.instances,
+      input.githubInstallationClient,
+      {
+        getSsmParameterTags: (runnerId) => [{ Key: 'RunnerId', Value: runnerId }],
+      },
+    );
+  } catch {
+    failedRunnerIds = result.instances;
+  }
+
+  return {
+    instances: result.instances.filter((runnerId) => !failedRunnerIds.includes(runnerId)),
+    retryableErrorCount: result.retryableErrorCount + failedRunnerIds.length,
+    nonRetryableErrorCount: result.nonRetryableErrorCount,
+  };
+}
+
+beforeEach(() => {
+  nock.disableNetConnect();
+  vi.resetModules();
+  vi.clearAllMocks();
+  setDefaults();
+
+  defaultSSMGetParameterMockImpl();
+  defaultOctokitMockImpl();
+
+  mockedResolveCapability.mockReturnValue(() => mockRunnerProvider);
+  mockPrepareGroup.mockImplementation(async (labels) => ({
+    runnerLabels: labels.filter((label) => label.startsWith('ghr-')),
+    state: testProviderState,
+  }));
+  mockGetCurrentRunners.mockImplementation(async (_state, input) => {
+    return (
+      await mockListRunners({
+        environment: process.env.ENVIRONMENT,
+        runnerType: input.runnerType,
+        runnerOwner: input.runnerOwner,
+      })
+    ).length;
+  });
+  mockCreateRunners.mockImplementation(createTestProviderRunners);
+
+  mockCreateRunner.mockImplementation(async () => {
+    return createRunnerResult(['i-12345']);
+  });
+  mockListRunners.mockImplementation(async () => [
+    {
+      instanceId: 'i-1234',
+      launchTime: new Date(),
+      type: 'Org',
+      owner: TEST_DATA_SINGLE.repositoryOwner,
+    },
+  ]);
+
+  mockedAppAuth.mockResolvedValue({
+    type: 'app',
+    token: 'token',
+    appId: TEST_DATA_SINGLE.installationId,
+    expiresAt: 'some-date',
+  });
+  mockedInstallationAuth.mockResolvedValue({
+    type: 'token',
+    tokenType: 'installation',
+    token: 'token',
+    createdAt: 'some-date',
+    expiresAt: 'some-date',
+    permissions: {},
+    repositorySelection: 'all',
+    installationId: 0,
+  });
+
+  mockCreateClient.mockResolvedValue(mockOctokit as unknown as Octokit);
+});
+
+describe('scaleUp with GHES', () => {
+  beforeEach(() => {
+    process.env.GHES_URL = 'https://github.enterprise.something';
+  });
+
+  it('checks queued workflows', async () => {
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
+      job_id: TEST_DATA_SINGLE.id,
+      owner: TEST_DATA_SINGLE.repositoryOwner,
+      repo: TEST_DATA_SINGLE.repositoryName,
+    });
+  });
+
+  it('does not list runners when no workflows are queued', async () => {
+    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
+      data: { total_count: 0 },
+    }));
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(listRunners).not.toBeCalled();
+  });
+
+  describe('on org level', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test-';
+      process.env.RUNNER_GROUP_NAME = 'Default';
+      process.env.SSM_CONFIG_PATH = '/github-action-runners/default/runners/config';
+      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
+      process.env.RUNNER_LABELS = 'label1,label2';
+
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      mockSSMClient.reset();
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('does not create runners when current runners exceed maximum (race condition)', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '5';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      // Simulate race condition where pool lambda created more runners than max
+      mockListRunners.mockImplementation(async () =>
+        Array.from({ length: 10 }, (_, i) => ({
+          instanceId: `i-${i}`,
+          launchTime: new Date(),
+          type: 'Org',
+          owner: TEST_DATA_SINGLE.repositoryOwner,
+        })),
+      );
+      await scaleUpModule.scaleUp(TEST_DATA);
+      // Should not attempt to create runners (would be negative without fix)
+      expect(createRunner).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+    });
+
+    it('does create a runner if maximum is set to -1', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(listRunners).not.toHaveBeenCalled();
+      expect(createRunner).toHaveBeenCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+      });
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a runner with labels in a specific group', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('returns a retryable failure if runner group lookup fails for ephemeral runners', async () => {
+      process.env.RUNNER_GROUP_NAME = 'test-runner-group';
+      mockSSMgetParameter.mockImplementation(async () => {
+        throw new Error('ParameterNotFound');
+      });
+
+      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
+
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+    });
+
+    it('Discards event if it is a User repo and org level runners is enabled', async () => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
+      USER_REPO_TEST_DATA[0].repoOwnerType = 'User';
+      await scaleUpModule.scaleUp(USER_REPO_TEST_DATA);
+      expect(createRunner).not.toHaveBeenCalled();
+    });
+
+    it('create SSM parameter for runner group id if it does not exist', async () => {
+      mockSSMgetParameter.mockImplementation(async () => {
+        throw new Error('ParameterNotFound');
+      });
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 2);
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`,
+        Value: '1',
+        Type: 'String',
+      });
+    });
+
+    it('Does not create SSM parameter for runner group id if it exists', async () => {
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(0);
+      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 1);
+    });
+
+    it('create start runner config for ephemeral runners ', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toBeCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+        name: 'unit-test-i-12345',
+        runner_group_id: 1,
+        labels: ['label1', 'label2'],
+      });
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value: 'TEST_JIT_CONFIG_ORG',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('create start runner config for non-ephemeral runners ', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalled();
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value:
+          '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
+          '--labels label1,label2 --runnergroup Default',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('quotes runner labels with semicolon separators in non-ephemeral runner config', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+
+      await scaleUpModule.scaleUp([
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['ghr-provider-capability:intel;amd'],
+          messageId: 'test-semicolon-labels',
+        },
+      ]);
+
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value:
+          '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
+          "--labels 'label1,label2,ghr-provider-capability:intel;amd' --runnergroup Default",
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('should create JIT config for all remaining instances even when GitHub API fails for one instance', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '5';
+      mockCreateRunner.mockImplementation(async () => {
+        return createRunnerResult(['i-instance-1', 'i-instance-2', 'i-instance-3']);
+      });
+      mockListRunners.mockImplementation(async () => {
+        return [];
+      });
+
+      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
+        if (name === 'unit-test-i-instance-2') {
+          // Simulate a 503 Service Unavailable error from GitHub
+          const error = new Error('Service Unavailable') as Error & {
+            status: number;
+            response: { status: number; data: { message: string } };
+          };
+          error.status = 503;
+          error.response = {
+            status: 503,
+            data: { message: 'Service temporarily unavailable' },
+          };
+          throw error;
+        }
+        return {
+          data: {
+            runner: { id: 9876543210 },
+            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
+          },
+          headers: {},
+        };
+      });
+
+      const rejectedMessages = await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(rejectedMessages).toEqual(['foobar']);
+
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+        name: 'unit-test-i-instance-1',
+        runner_group_id: 1,
+        labels: ['label1', 'label2'],
+      });
+
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+        name: 'unit-test-i-instance-2',
+        runner_group_id: 1,
+        labels: ['label1', 'label2'],
+      });
+
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+        name: 'unit-test-i-instance-3',
+        runner_group_id: 1,
+        labels: ['label1', 'label2'],
+      });
+
+      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-1',
+        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-1',
+        Type: 'SecureString',
+        Tags: [{ Key: 'RunnerId', Value: 'i-instance-1' }],
+      });
+
+      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-3',
+        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-3',
+        Type: 'SecureString',
+        Tags: [{ Key: 'RunnerId', Value: 'i-instance-3' }],
+      });
+
+      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-2',
+      });
+    });
+
+    it('should handle retryable errors with error handling logic', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '5';
+      mockCreateRunner.mockImplementation(async () => {
+        return createRunnerResult(['i-instance-1', 'i-instance-2']);
+      });
+      mockListRunners.mockImplementation(async () => {
+        return [];
+      });
+
+      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
+        if (name === 'unit-test-i-instance-1') {
+          const error = new Error('Internal Server Error') as Error & {
+            status: number;
+            response: { status: number; data: { message: string } };
+          };
+          error.status = 500;
+          error.response = {
+            status: 500,
+            data: { message: 'Internal server error' },
+          };
+          throw error;
+        }
+        return {
+          data: {
+            runner: { id: 9876543210 },
+            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
+          },
+          headers: {},
+        };
+      });
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-2',
+        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-2',
+        Type: 'SecureString',
+        Tags: [{ Key: 'RunnerId', Value: 'i-instance-2' }],
+      });
+
+      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-1',
+      });
+    });
+
+    it('should handle non-retryable 4xx errors gracefully', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '5';
+      mockCreateRunner.mockImplementation(async () => {
+        return createRunnerResult(['i-instance-1', 'i-instance-2']);
+      });
+      mockListRunners.mockImplementation(async () => {
+        return [];
+      });
+
+      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
+        if (name === 'unit-test-i-instance-1') {
+          // 404 is not retryable - will fail immediately
+          const error = new Error('Not Found') as Error & {
+            status: number;
+            response: { status: number; data: { message: string } };
+          };
+          error.status = 404;
+          error.response = {
+            status: 404,
+            data: { message: 'Resource not found' },
+          };
+          throw error;
+        }
+        return {
+          data: {
+            runner: { id: 9876543210 },
+            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
+          },
+          headers: {},
+        };
+      });
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-2',
+        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-2',
+        Type: 'SecureString',
+        Tags: [{ Key: 'RunnerId', Value: 'i-instance-2' }],
+      });
+
+      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-instance-1',
+      });
+    });
+
+    it.each(RUNNER_TYPES)(
+      'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
+      async (type: RunnerType) => {
+        process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
+        process.env.RUNNERS_MAXIMUM_COUNT = '40';
+        mockCreateRunner.mockImplementation(async () => {
+          return createRunnerResult(instances);
+        });
+        mockListRunners.mockImplementation(async () => {
+          return [];
+        });
+        const startTime = performance.now();
+        const instances = [
+          'i-1234',
+          'i-5678',
+          'i-5567',
+          'i-5569',
+          'i-5561',
+          'i-5560',
+          'i-5566',
+          'i-5536',
+          'i-5526',
+          'i-5516',
+          'i-122',
+          'i-123',
+          'i-124',
+          'i-125',
+          'i-126',
+          'i-127',
+          'i-128',
+          'i-129',
+          'i-130',
+          'i-131',
+          'i-132',
+          'i-133',
+          'i-134',
+          'i-135',
+          'i-136',
+          'i-137',
+          'i-138',
+          'i-139',
+          'i-140',
+          'i-141',
+          'i-142',
+          'i-143',
+          'i-144',
+          'i-145',
+          'i-146',
+          'i-147',
+          'i-148',
+          'i-149',
+          'i-150',
+          'i-151',
+        ];
+        await scaleUpModule.scaleUp(TEST_DATA);
+        const endTime = performance.now();
+        expect(endTime - startTime).toBeGreaterThan(1000);
+        expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 40);
+      },
+      10000,
+    );
+  });
+
+  describe('dynamic label groups', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+      process.env.RUNNER_LABELS = 'base-label';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test';
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      mockSSMClient.reset();
+
+      mockPrepareGroup.mockImplementation(async (labels) => ({
+        runnerLabels: labels.filter((label) => label.startsWith('ghr-')),
+        state: testProviderState,
+      }));
+      mockGetCurrentRunners.mockResolvedValue(0);
+      mockCreateRunners.mockResolvedValue({
+        instances: ['runner'],
+        retryableErrorCount: 0,
+        nonRetryableErrorCount: 0,
+      });
+    });
+
+    it('does not accumulate labels across groups when multiple messages have different dynamic labels', async () => {
+      const testDataMultipleGroups = [
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-provider-size:large', 'ghr-job-id:run-1-inst-0'],
+          messageId: 'msg-1',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-provider-size:xlarge', 'ghr-job-id:run-1-inst-1'],
+          messageId: 'msg-2',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'linux', 'ghr-provider-size:compute', 'ghr-job-id:run-1-inst-2'],
+          messageId: 'msg-3',
+        },
+      ];
+
+      await scaleUpModule.scaleUp(testDataMultipleGroups);
+
+      expect(mockCreateRunners).toBeCalledTimes(3);
+
+      for (const [input] of mockCreateRunners.mock.calls) {
+        const labels = input.githubRunnerConfig.runnerLabels.split(',');
+
+        if (labels.includes('ghr-provider-size:large')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-provider-size:xlarge');
+          expect(labels).not.toContain('ghr-provider-size:compute');
+        } else if (labels.includes('ghr-provider-size:xlarge')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-provider-size:large');
+          expect(labels).not.toContain('ghr-provider-size:compute');
+        } else if (labels.includes('ghr-provider-size:compute')) {
+          expect(labels).toContain('ghr-job-id:run-1-inst-2');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
+          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
+          expect(labels).not.toContain('ghr-provider-size:large');
+          expect(labels).not.toContain('ghr-provider-size:xlarge');
+        } else {
+          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
+        }
+      }
+    });
+
+    it('preserves base RUNNER_LABELS for each group without mutation', async () => {
+      process.env.RUNNER_LABELS = 'ubuntu-2404,x64';
+
+      const testDataTwoGroups = [
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'ghr-provider-size:large', 'ghr-team:alpha'],
+          messageId: 'msg-a',
+        },
+        {
+          ...TEST_DATA_SINGLE,
+          labels: ['self-hosted', 'ghr-provider-size:compute', 'ghr-team:beta'],
+          messageId: 'msg-b',
+        },
+      ];
+
+      await scaleUpModule.scaleUp(testDataTwoGroups);
+
+      expect(mockCreateRunners).toBeCalledTimes(2);
+
+      for (const [input] of mockCreateRunners.mock.calls) {
+        const labels = input.githubRunnerConfig.runnerLabels.split(',');
+
+        expect(labels).toContain('ubuntu-2404');
+        expect(labels).toContain('x64');
+
+        if (labels.includes('ghr-team:alpha')) {
+          expect(labels).not.toContain('ghr-team:beta');
+          expect(labels).not.toContain('ghr-provider-size:compute');
+        } else if (labels.includes('ghr-team:beta')) {
+          expect(labels).not.toContain('ghr-team:alpha');
+          expect(labels).not.toContain('ghr-provider-size:large');
+        } else {
+          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
+        }
+      }
+    });
+  });
+
+  describe('on repo level', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test';
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      expectedRunnerParams.runnerType = 'Repo';
+      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
+      //   `--url https://github.enterprise.something/${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
+      //   `--token 1234abcd`,
+      // ];
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
+        owner: TEST_DATA_SINGLE.repositoryOwner,
+        repo: TEST_DATA_SINGLE.repositoryName,
+      });
+    });
+
+    it('uses the default runner max count', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = undefined;
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
+        owner: TEST_DATA_SINGLE.repositoryOwner,
+        repo: TEST_DATA_SINGLE.repositoryName,
+      });
+    });
+
+    it('creates a runner and ensure the group argument is ignored', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('converts an unexpected provider error into a retryable result', async () => {
+      vi.mocked(createRunner).mockResolvedValue(undefined as never);
+
+      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
+    });
+  });
+
+  describe('Batch processing', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.RUNNERS_MAXIMUM_COUNT = '10';
+    });
+
+    const createTestMessages = (
+      count: number,
+      overrides: Partial<ActionRequestMessageSQS>[] = [],
+    ): ActionRequestMessageSQS[] => {
+      return Array.from({ length: count }, (_, i) => ({
+        ...TEST_DATA_SINGLE,
+        id: i + 1,
+        messageId: `message-${i}`,
+        ...overrides[i],
+      }));
+    };
+
+    it('Should handle multiple messages for the same organization', async () => {
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(1);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 3,
+          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different organizations', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'org1' },
+        { repositoryOwner: 'org2' },
+        { repositoryOwner: 'org1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'org1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'org2',
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'owner1/repo1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'owner1/repo2',
+        }),
+      );
+    });
+
+    it('Should reject messages when maximum runners limit is reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
+      mockListRunners.mockImplementation(async () => [
+        {
+          instanceId: 'i-existing',
+          launchTime: new Date(),
+          type: 'Org',
+          owner: TEST_DATA_SINGLE.repositoryOwner,
+        },
+      ]);
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).not.toHaveBeenCalled(); // No runners should be created
+      expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
+    });
+
+    it('Should handle partial EC2 instance creation failures', async () => {
+      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should reject only retryable partial EC2 instance creation failures', async () => {
+      mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345'], 1, 1));
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(rejectedMessages).toEqual(['message-0']);
+    });
+
+    it('does not retry partial EC2 instance creation failures that are not retryable', async () => {
+      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 0, 2));
+
+      const rejectedMessages = await scaleUpModule.scaleUp(createTestMessages(3));
+
+      expect(rejectedMessages).toEqual([]);
+    });
+
+    it('Should filter out invalid event types for ephemeral runners', async () => {
+      const messages = createTestMessages(3, [
+        { eventType: 'workflow_job' },
+        { eventType: 'check_run' },
+        { eventType: 'workflow_job' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only workflow_job events processed
+        }),
+      );
+      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
+    });
+
+    it('Should skip invalid repo owner types but not reject them', async () => {
+      const messages = createTestMessages(3, [
+        { repoOwnerType: 'Organization' },
+        { repoOwnerType: 'User' }, // Invalid for org-level runners
+        { repoOwnerType: 'Organization' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only Organization events processed
+        }),
+      );
+      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
+    });
+
+    it('Should skip messages when jobs are not queued', async () => {
+      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
+        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
+        return {
+          data: {
+            status: isQueued ? 'queued' : 'completed',
+          },
+        };
+      });
+
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only queued jobs processed
+        }),
+      );
+    });
+
+    it('Should create separate GitHub clients for different installations', async () => {
+      // Override the default mock to return different installation IDs
+      mockOctokit.apps.getOrgInstallation.mockReset();
+      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
+        data: {
+          id: params.org === 'org1' ? 100 : 200,
+        },
+      }));
+
+      const messages = createTestMessages(2, [
+        { repositoryOwner: 'org1', installationId: 0 },
+        { repositoryOwner: 'org2', installationId: 0 },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, 'https://github.enterprise.something/api/v3');
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, 'https://github.enterprise.something/api/v3');
+    });
+
+    it('Should resolve installation again when event installation belongs to another app', async () => {
+      mockOctokit.apps.getOrgInstallation.mockReset();
+      mockOctokit.apps.getOrgInstallation.mockImplementation(() => ({
+        data: {
+          id: 123,
+        },
+      }));
+
+      mockedInstallationAuth.mockRejectedValueOnce({ status: 404 }).mockResolvedValueOnce({
+        type: 'token',
+        tokenType: 'installation',
+        token: 'token',
+        createdAt: 'some-date',
+        expiresAt: 'some-date',
+        permissions: {},
+        repositorySelection: 'all',
+        installationId: 123,
+      });
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+
+      expect(mockOctokit.apps.getOrgInstallation).toHaveBeenCalledWith({ org: TEST_DATA_SINGLE.repositoryOwner });
+      expect(mockedInstallationAuth).toHaveBeenNthCalledWith(
+        1,
+        TEST_DATA_SINGLE.installationId,
+        'https://github.enterprise.something/api/v3',
+      );
+      expect(mockedInstallationAuth).toHaveBeenNthCalledWith(2, 123, 'https://github.enterprise.something/api/v3');
+    });
+
+    it('Should reuse GitHub clients for same installation', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
+      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should return empty array when no valid messages to process', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      const messages = createTestMessages(2, [
+        { eventType: 'check_run' }, // Invalid for ephemeral
+        { eventType: 'check_run' }, // Invalid for ephemeral
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).not.toHaveBeenCalled();
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should handle unlimited runners configuration', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
+      const messages = createTestMessages(10);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(listRunners).not.toHaveBeenCalled(); // No need to check current runners
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 10, // All messages processed
+        }),
+      );
+    });
+
+    it('Should assume job is queued when isJobQueued throws (fail-open)', async () => {
+      mockOctokit.actions.getJobForWorkflowRun.mockRejectedValue(new Error('GitHub API 502'));
+
+      const messages = createTestMessages(2);
+      await scaleUpModule.scaleUp(messages);
+
+      // All messages processed despite API error — fail-open prevents job drops
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+        }),
+      );
+    });
+
+    it('Should skip unsupported event types without scaling up', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      const messages = createTestMessages(1).map((m) => ({ ...m, eventType: 'check_run' as const }));
+
+      await expect(scaleUpModule.scaleUp(messages)).resolves.toEqual([]);
+      expect(createRunner).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('scaleUp with public GH', () => {
+  it('checks queued workflows', async () => {
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
+      job_id: TEST_DATA_SINGLE.id,
+      owner: TEST_DATA_SINGLE.repositoryOwner,
+      repo: TEST_DATA_SINGLE.repositoryName,
+    });
+  });
+
+  it('not checking queued workflows', async () => {
+    process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
+  });
+
+  it('does not list runners when no workflows are queued', async () => {
+    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
+      data: { status: 'completed' },
+    }));
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(listRunners).not.toBeCalled();
+  });
+
+  describe('on org level', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test';
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+      });
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a runner with labels in s specific group', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+  });
+
+  describe('on repo level', () => {
+    beforeEach(() => {
+      mockSSMClient.reset();
+
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test';
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      expectedRunnerParams.runnerType = 'Repo';
+      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
+        owner: TEST_DATA_SINGLE.repositoryOwner,
+        repo: TEST_DATA_SINGLE.repositoryName,
+      });
+    });
+
+    it('creates a runner and ensure the group argument is ignored', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('ephemeral runners only run with workflow_job event, others should fail.', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+
+      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
+      USER_REPO_TEST_DATA[0].eventType = 'check_run';
+
+      await expect(scaleUpModule.scaleUp(USER_REPO_TEST_DATA)).resolves.toEqual(['foobar']);
+    });
+
+    it('creates a ephemeral runner with JIT config.', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value: 'TEST_JIT_CONFIG_REPO',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('creates a ephemeral runner with registration token.', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.ENABLE_JIT_CONFIG = 'false';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value: '--url https://github.com/Codertocat/hello-world --token 1234abcd --ephemeral',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('JIT config is ignored for non-ephemeral runners.', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      process.env.ENABLE_JIT_CONFIG = 'true';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+      process.env.RUNNER_LABELS = 'jit';
+      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value: '--url https://github.com/Codertocat/hello-world --token 1234abcd --labels jit',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('creates a ephemeral runner after checking job is queued.', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.ENABLE_JOB_QUEUED_CHECK = 'true';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalled();
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('disable auto update on the runner.', async () => {
+      process.env.DISABLE_RUNNER_AUTOUPDATE = 'true';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('Scaling error should return failed message IDs so retry can be triggered.', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
+    });
+  });
+
+  describe('Batch processing', () => {
+    const createTestMessages = (
+      count: number,
+      overrides: Partial<ActionRequestMessageSQS>[] = [],
+    ): ActionRequestMessageSQS[] => {
+      return Array.from({ length: count }, (_, i) => ({
+        ...TEST_DATA_SINGLE,
+        id: i + 1,
+        messageId: `message-${i}`,
+        ...overrides[i],
+      }));
+    };
+
+    beforeEach(() => {
+      setDefaults();
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.RUNNERS_MAXIMUM_COUNT = '10';
+    });
+
+    it('Should handle multiple messages for the same organization', async () => {
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(1);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 3,
+          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different organizations', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'org1' },
+        { repositoryOwner: 'org2' },
+        { repositoryOwner: 'org1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'org1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'org2',
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'owner1/repo1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'owner1/repo2',
+        }),
+      );
+    });
+
+    it('Should reject messages when maximum runners limit is reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
+      mockListRunners.mockImplementation(async () => [
+        {
+          instanceId: 'i-existing',
+          launchTime: new Date(),
+          type: 'Org',
+          owner: TEST_DATA_SINGLE.repositoryOwner,
+        },
+      ]);
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).not.toHaveBeenCalled(); // No runners should be created
+      expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
+    });
+
+    it('Should handle partial EC2 instance creation failures', async () => {
+      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should filter out invalid event types for ephemeral runners', async () => {
+      const messages = createTestMessages(3, [
+        { eventType: 'workflow_job' },
+        { eventType: 'check_run' },
+        { eventType: 'workflow_job' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only workflow_job events processed
+        }),
+      );
+      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
+    });
+
+    it('Should skip invalid repo owner types but not reject them', async () => {
+      const messages = createTestMessages(3, [
+        { repoOwnerType: 'Organization' },
+        { repoOwnerType: 'User' }, // Invalid for org-level runners
+        { repoOwnerType: 'Organization' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only Organization events processed
+        }),
+      );
+      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
+    });
+
+    it('Should skip messages when jobs are not queued', async () => {
+      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
+        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
+        return {
+          data: {
+            status: isQueued ? 'queued' : 'completed',
+          },
+        };
+      });
+
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only queued jobs processed
+        }),
+      );
+    });
+
+    it('Should create separate GitHub clients for different installations', async () => {
+      // Override the default mock to return different installation IDs
+      mockOctokit.apps.getOrgInstallation.mockReset();
+      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
+        data: {
+          id: params.org === 'org1' ? 100 : 200,
+        },
+      }));
+
+      const messages = createTestMessages(2, [
+        { repositoryOwner: 'org1', installationId: 0 },
+        { repositoryOwner: 'org2', installationId: 0 },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, '');
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, '');
+    });
+
+    it('Should reuse GitHub clients for same installation', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
+      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should return empty array when no valid messages to process', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      const messages = createTestMessages(2, [
+        { eventType: 'check_run' }, // Invalid for ephemeral
+        { eventType: 'check_run' }, // Invalid for ephemeral
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).not.toHaveBeenCalled();
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should handle unlimited runners configuration', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
+      const messages = createTestMessages(10);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(listRunners).not.toHaveBeenCalled(); // No need to check current runners
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 10, // All messages processed
+        }),
+      );
+    });
+  });
+});
+
+describe('scaleUp with Github Data Residency', () => {
+  beforeEach(() => {
+    process.env.GHES_URL = 'https://companyname.ghe.com';
+  });
+
+  it('checks queued workflows', async () => {
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
+      job_id: TEST_DATA_SINGLE.id,
+      owner: TEST_DATA_SINGLE.repositoryOwner,
+      repo: TEST_DATA_SINGLE.repositoryName,
+    });
+  });
+
+  it('does not list runners when no workflows are queued', async () => {
+    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
+      data: { total_count: 0 },
+    }));
+    await scaleUpModule.scaleUp(TEST_DATA);
+    expect(listRunners).not.toBeCalled();
+  });
+
+  describe('on org level', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test-';
+      process.env.RUNNER_GROUP_NAME = 'Default';
+      process.env.SSM_CONFIG_PATH = '/github-action-runners/default/runners/config';
+      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
+      process.env.RUNNER_LABELS = 'label1,label2';
+
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      mockSSMClient.reset();
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('does create a runner if maximum is set to -1', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(listRunners).not.toHaveBeenCalled();
+      expect(createRunner).toHaveBeenCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+      });
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a runner with labels in a specific group', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+
+    it('Discards event if it is a User repo and org level runners is enabled', async () => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
+      USER_REPO_TEST_DATA[0].repoOwnerType = 'User';
+      await scaleUpModule.scaleUp(USER_REPO_TEST_DATA);
+      expect(createRunner).not.toHaveBeenCalled();
+    });
+
+    it('create SSM parameter for runner group id if it does not exist', async () => {
+      mockSSMgetParameter.mockImplementation(async () => {
+        throw new Error('ParameterNotFound');
+      });
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 2);
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`,
+        Value: '1',
+        Type: 'String',
+      });
+    });
+
+    it('Does not create SSM parameter for runner group id if it exists', async () => {
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.paginate).toHaveBeenCalledTimes(0);
+      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 1);
+    });
+
+    it('create start runner config for ephemeral runners ', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toBeCalledWith({
+        org: TEST_DATA_SINGLE.repositoryOwner,
+        name: 'unit-test-i-12345',
+        runner_group_id: 1,
+        labels: ['label1', 'label2'],
+      });
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value: 'TEST_JIT_CONFIG_ORG',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+
+    it('create start runner config for non-ephemeral runners ', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalled();
+      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
+        Name: '/github-action-runners/default/runners/config/i-12345',
+        Value:
+          '--url https://companyname.ghe.com/Codertocat --token 1234abcd ' +
+          '--labels label1,label2 --runnergroup Default',
+        Type: 'SecureString',
+        Tags: [
+          {
+            Key: 'RunnerId',
+            Value: 'i-12345',
+          },
+        ],
+      });
+    });
+    it.each(RUNNER_TYPES)(
+      'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
+      async (type: RunnerType) => {
+        process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
+        process.env.RUNNERS_MAXIMUM_COUNT = '40';
+        mockCreateRunner.mockImplementation(async () => {
+          return createRunnerResult(instances);
+        });
+        mockListRunners.mockImplementation(async () => {
+          return [];
+        });
+        const startTime = performance.now();
+        const instances = [
+          'i-1234',
+          'i-5678',
+          'i-5567',
+          'i-5569',
+          'i-5561',
+          'i-5560',
+          'i-5566',
+          'i-5536',
+          'i-5526',
+          'i-5516',
+          'i-122',
+          'i-123',
+          'i-124',
+          'i-125',
+          'i-126',
+          'i-127',
+          'i-128',
+          'i-129',
+          'i-130',
+          'i-131',
+          'i-132',
+          'i-133',
+          'i-134',
+          'i-135',
+          'i-136',
+          'i-137',
+          'i-138',
+          'i-139',
+          'i-140',
+          'i-141',
+          'i-142',
+          'i-143',
+          'i-144',
+          'i-145',
+          'i-146',
+          'i-147',
+          'i-148',
+          'i-149',
+          'i-150',
+          'i-151',
+        ];
+        await scaleUpModule.scaleUp(TEST_DATA);
+        const endTime = performance.now();
+        expect(endTime - startTime).toBeGreaterThan(1000);
+        expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 40);
+      },
+      10000,
+    );
+  });
+  describe('on repo level', () => {
+    beforeEach(() => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      process.env.RUNNER_NAME_PREFIX = 'unit-test';
+      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+      expectedRunnerParams.runnerType = 'Repo';
+      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
+      //   `--url https://companyname.ghe.com${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
+      //   `--token 1234abcd`,
+      // ];
+    });
+
+    it('does not create a token when maximum runners has been reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '1';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+    });
+
+    it('creates a token when maximum runners has not been reached', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
+        owner: TEST_DATA_SINGLE.repositoryOwner,
+        repo: TEST_DATA_SINGLE.repositoryName,
+      });
+    });
+
+    it('uses the default runner max count', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = undefined;
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
+        owner: TEST_DATA_SINGLE.repositoryOwner,
+        repo: TEST_DATA_SINGLE.repositoryName,
+      });
+    });
+
+    it('creates a runner and ensure the group argument is ignored', async () => {
+      process.env.RUNNER_LABELS = 'label1,label2';
+      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
+      await scaleUpModule.scaleUp(TEST_DATA);
+      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+    });
+  });
+
+  describe('Batch processing', () => {
+    const createTestMessages = (
+      count: number,
+      overrides: Partial<ActionRequestMessageSQS>[] = [],
+    ): ActionRequestMessageSQS[] => {
+      return Array.from({ length: count }, (_, i) => ({
+        ...TEST_DATA_SINGLE,
+        id: i + 1,
+        messageId: `message-${i}`,
+        ...overrides[i],
+      }));
+    };
+
+    beforeEach(() => {
+      setDefaults();
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      process.env.RUNNERS_MAXIMUM_COUNT = '10';
+    });
+
+    it('Should handle multiple messages for the same organization', async () => {
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(1);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 3,
+          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different organizations', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'org1' },
+        { repositoryOwner: 'org2' },
+        { repositoryOwner: 'org1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'org1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'org2',
+        }),
+      );
+    });
+
+    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
+      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
+        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledTimes(2);
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2,
+          runnerOwner: 'owner1/repo1',
+        }),
+      );
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1,
+          runnerOwner: 'owner1/repo2',
+        }),
+      );
+    });
+
+    it('Should reject messages when maximum runners limit is reached', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '2';
+      mockListRunners.mockImplementation(async () => [
+        {
+          instanceId: 'i-existing',
+          launchTime: new Date(),
+          type: 'Org',
+          owner: TEST_DATA_SINGLE.repositoryOwner,
+        },
+      ]);
+
+      const messages = createTestMessages(5);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 1, // 2 max - 1 existing = 1 new
+        }),
+      );
+      expect(rejectedMessages).toHaveLength(4); // 5 requested - 1 created = 4 rejected
+    });
+
+    it('Should handle partial EC2 instance creation failures', async () => {
+      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
+
+      const messages = createTestMessages(3);
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should filter out invalid event types for ephemeral runners', async () => {
+      const messages = createTestMessages(3, [
+        { eventType: 'workflow_job' },
+        { eventType: 'check_run' },
+        { eventType: 'workflow_job' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only workflow_job events processed
+        }),
+      );
+      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
+    });
+
+    it('Should skip invalid repo owner types but not reject them', async () => {
+      const messages = createTestMessages(3, [
+        { repoOwnerType: 'Organization' },
+        { repoOwnerType: 'User' }, // Invalid for org-level runners
+        { repoOwnerType: 'Organization' },
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only Organization events processed
+        }),
+      );
+      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
+    });
+
+    it('Should skip messages when jobs are not queued', async () => {
+      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
+        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
+        return {
+          data: {
+            status: isQueued ? 'queued' : 'completed',
+          },
+        };
+      });
+
+      const messages = createTestMessages(3);
+      await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 2, // Only queued jobs processed
+        }),
+      );
+    });
+
+    it('Should create separate GitHub clients for different installations', async () => {
+      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
+        data: {
+          id: params.org === 'org1' ? 100 : 200,
+        },
+      }));
+
+      const messages = createTestMessages(2, [
+        { repositoryOwner: 'org1', installationId: 0 },
+        { repositoryOwner: 'org2', installationId: 0 },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, '');
+      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, '');
+    });
+
+    it('Should reuse GitHub clients for same installation', async () => {
+      const messages = createTestMessages(3, [
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+        { repositoryOwner: 'same-org' },
+      ]);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
+      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should return empty array when no valid messages to process', async () => {
+      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+      const messages = createTestMessages(2, [
+        { eventType: 'check_run' }, // Invalid for ephemeral
+        { eventType: 'check_run' }, // Invalid for ephemeral
+      ]);
+
+      const rejectedMessages = await scaleUpModule.scaleUp(messages);
+
+      expect(createRunner).not.toHaveBeenCalled();
+      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
+    });
+
+    it('Should handle unlimited runners configuration', async () => {
+      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
+      const messages = createTestMessages(10);
+
+      await scaleUpModule.scaleUp(messages);
+
+      expect(listRunners).not.toHaveBeenCalled(); // No need to check current runners
+      expect(createRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfRunners: 10, // All messages processed
+        }),
+      );
+    });
+  });
+});
+
+describe('Retry mechanism tests', () => {
+  beforeEach(() => {
+    process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
+    process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
+    process.env.ENABLE_JOB_QUEUED_CHECK = 'true';
+    process.env.RUNNERS_MAXIMUM_COUNT = '10';
+    expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
+    mockSSMClient.reset();
+  });
+
+  const createTestMessages = (
+    count: number,
+    overrides: Partial<ActionRequestMessageSQS>[] = [],
+  ): ActionRequestMessageSQS[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      ...TEST_DATA_SINGLE,
+      id: i + 1,
+      messageId: `message-${i + 1}`,
+      ...overrides[i],
+    }));
+  };
+
+  it('calls publishRetryMessage for each valid message when job is queued', async () => {
+    const messages = createTestMessages(3);
+    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890', 'i-abcdef'])); // Create all requested runners
+
+    await scaleUpModule.scaleUp(messages);
+
+    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(3);
+    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: 1,
+        messageId: 'message-1',
+      }),
+    );
+    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        id: 2,
+        messageId: 'message-2',
+      }),
+    );
+    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        id: 3,
+        messageId: 'message-3',
+      }),
+    );
+  });
+
+  it('does not call publishRetryMessage when job is not queued', async () => {
+    mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
+      const isQueued = params.job_id === 1; // Only job 1 is queued
+      return {
+        data: {
+          status: isQueued ? 'queued' : 'completed',
+        },
+      };
+    });
+
+    const messages = createTestMessages(3);
+
+    await scaleUpModule.scaleUp(messages);
+
+    // Only message with id 1 should trigger retry
+    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(1);
+    expect(mockPublishRetryMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 1,
+        messageId: 'message-1',
+      }),
+    );
+  });
+
+  it('does not call publishRetryMessage when maximum runners is reached and messages are marked invalid', async () => {
+    process.env.RUNNERS_MAXIMUM_COUNT = '0'; // No runners can be created
+
+    const messages = createTestMessages(2);
+
+    await scaleUpModule.scaleUp(messages);
+
+    // Verify the provider is asked for the current runner count.
+    expect(listRunners).toHaveBeenCalledWith({
+      environment: 'unit-test-environment',
+      runnerType: 'Org',
+      runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+    });
+
+    // publishRetryMessage should NOT be called because messages are marked as invalid
+    // Invalid messages go back to the SQS queue and will be retried there
+    expect(mockPublishRetryMessage).not.toHaveBeenCalled();
+    expect(createRunner).not.toHaveBeenCalled();
+  });
+
+  it('calls publishRetryMessage with correct message structure including retry counter', async () => {
+    const message = {
+      ...TEST_DATA_SINGLE,
+      messageId: 'test-message-id',
+      retryCounter: 2,
+    };
+
+    await scaleUpModule.scaleUp([message]);
+
+    expect(mockPublishRetryMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: message.id,
+        messageId: 'test-message-id',
+        retryCounter: 2,
+      }),
+    );
+  });
+
+  it('calls publishRetryMessage when ENABLE_JOB_QUEUED_CHECK is false', async () => {
+    process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
+    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890'])); // Create all requested runners
+
+    const messages = createTestMessages(2);
+
+    await scaleUpModule.scaleUp(messages);
+
+    // Should always call publishRetryMessage when queue check is disabled
+    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(2);
+    expect(mockOctokit.actions.getJobForWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('calls publishRetryMessage for each message in a multi-runner scenario', async () => {
+    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890', 'i-abcdef', 'i-11111', 'i-22222'])); // Create all requested runners
+    const messages = createTestMessages(5);
+
+    await scaleUpModule.scaleUp(messages);
+
+    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(5);
+    messages.forEach((msg, index) => {
+      expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
+        index + 1,
+        expect.objectContaining({
+          id: msg.id,
+          messageId: msg.messageId,
+        }),
+      );
+    });
+  });
+
+  it('calls publishRetryMessage after runner creation', async () => {
+    const messages = createTestMessages(1);
+    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345'])); // Create the requested runner
+
+    const callOrder: string[] = [];
+    mockPublishRetryMessage.mockImplementation(() => {
+      callOrder.push('publishRetryMessage');
+      return Promise.resolve();
+    });
+    mockCreateRunner.mockImplementation(async () => {
+      callOrder.push('createRunner');
+      return createRunnerResult(['i-12345']);
+    });
+
+    await scaleUpModule.scaleUp(messages);
+
+    expect(callOrder).toEqual(['createRunner', 'publishRetryMessage']);
+  });
 });
 
 describe('runner provider selection', () => {
@@ -37,3 +2180,67 @@ describe('runner provider selection', () => {
     expect(mockedAppAuth).not.toHaveBeenCalled();
   });
 });
+
+function defaultOctokitMockImpl() {
+  mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
+    data: {
+      status: 'queued',
+    },
+  }));
+  mockOctokit.paginate.mockImplementation(() => [
+    {
+      id: 1,
+      name: 'Default',
+    },
+  ]);
+  mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ labels }: { labels: string[] }) => ({
+    data: {
+      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
+      encoded_jit_config: 'TEST_JIT_CONFIG_ORG',
+    },
+  }));
+  mockOctokit.actions.generateRunnerJitconfigForRepo.mockImplementation(({ labels }: { labels: string[] }) => ({
+    data: {
+      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
+      encoded_jit_config: 'TEST_JIT_CONFIG_REPO',
+    },
+  }));
+  mockOctokit.checks.get.mockImplementation(() => ({
+    data: {
+      status: 'queued',
+    },
+  }));
+
+  const mockTokenReturnValue = {
+    data: {
+      token: '1234abcd',
+    },
+  };
+  const mockInstallationIdReturnValueOrgs = {
+    data: {
+      id: TEST_DATA_SINGLE.installationId,
+    },
+  };
+  const mockInstallationIdReturnValueRepos = {
+    data: {
+      id: TEST_DATA_SINGLE.installationId,
+    },
+  };
+
+  mockOctokit.actions.createRegistrationTokenForOrg.mockImplementation(() => mockTokenReturnValue);
+  mockOctokit.actions.createRegistrationTokenForRepo.mockImplementation(() => mockTokenReturnValue);
+  mockOctokit.apps.getOrgInstallation.mockImplementation(() => mockInstallationIdReturnValueOrgs);
+  mockOctokit.apps.getRepoInstallation.mockImplementation(() => mockInstallationIdReturnValueRepos);
+}
+
+function defaultSSMGetParameterMockImpl() {
+  mockSSMgetParameter.mockImplementation(async (name: string) => {
+    if (name === `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`) {
+      return '1';
+    } else if (name === `${process.env.PARAMETER_GITHUB_APP_ID_NAME}`) {
+      return `${process.env.GITHUB_APP_ID}`;
+    } else {
+      throw new Error(`ParameterNotFound: ${name}`);
+    }
+  });
+}

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.test.ts
@@ -1,792 +1,100 @@
-import { Octokit } from '@octokit/rest';
-import { RequestError } from '@octokit/request-error';
-import moment from 'moment';
-import nock from 'nock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as ghAuth from '../../../../../../functions/control-plane/src/github/auth';
-import { githubCache } from '../../../../../../functions/control-plane/src/scale-runners/cache';
-import { scaleDown } from '../../../../../../functions/control-plane/src/scale-runners/scale-down';
-import { listEC2Runners, terminateRunner, tag, untag } from './runners';
-import { RunnerList } from './runners.d';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-
-const mockOctokit = {
-  apps: {
-    getOrgInstallation: vi.fn(),
-    getRepoInstallation: vi.fn(),
-  },
-  actions: {
-    listSelfHostedRunnersForRepo: vi.fn(),
-    listSelfHostedRunnersForOrg: vi.fn(),
-    deleteSelfHostedRunnerFromOrg: vi.fn(),
-    deleteSelfHostedRunnerFromRepo: vi.fn(),
-    getSelfHostedRunnerForOrg: vi.fn(),
-    getSelfHostedRunnerForRepo: vi.fn(),
-  },
-  paginate: vi.fn(),
-};
-vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(function () {
-    return mockOctokit;
-  }),
-}));
+import { createEc2ScaleDownProvider } from './scale-down';
+import { listEC2Runners, tag, terminateRunner, untag } from './runners';
+import type { RunnerList } from './runners.d';
 
 vi.mock('./runners', async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof import('./runners')>();
   return {
     ...actual,
-    tag: vi.fn(),
-    untag: vi.fn(),
-    terminateRunner: vi.fn(),
     listEC2Runners: vi.fn(),
+    tag: vi.fn(),
+    terminateRunner: vi.fn(),
+    untag: vi.fn(),
   };
 });
-vi.mock('../../../../../../functions/control-plane/src/github/auth', async () => ({
-  createGithubAppAuth: vi.fn(),
-  createGithubInstallationAuth: vi.fn(),
-  createOctokitClient: vi.fn(),
-}));
 
-vi.mock('../../../../../../functions/control-plane/src/scale-runners/cache', async () => ({
-  githubCache: {
-    getRunner: vi.fn(),
-    addRunner: vi.fn(),
-    clients: new Map(),
-    runners: new Map(),
-    reset: vi.fn().mockImplementation(() => {
-      githubCache.clients.clear();
-      githubCache.runners.clear();
-    }),
-  },
-}));
-
-const mocktokit = Octokit as vi.MockedClass<typeof Octokit>;
-const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
-const mockedInstallationAuth = vi.mocked(ghAuth.createGithubInstallationAuth);
-const mockCreateClient = vi.mocked(ghAuth.createOctokitClient);
 const mockListRunners = vi.mocked(listEC2Runners);
-const mockTagRunners = vi.mocked(tag);
-const mockUntagRunners = vi.mocked(untag);
-const mockTerminateRunners = vi.mocked(terminateRunner);
-
-export interface TestData {
-  repositoryName: string;
-  repositoryOwner: string;
-}
-
-const cleanEnv = process.env;
-
-const ENVIRONMENT = 'unit-test-environment';
-const MINIMUM_TIME_RUNNING_IN_MINUTES = 30;
-const MINIMUM_BOOT_TIME = 5;
-const TEST_DATA: TestData = {
-  repositoryName: 'hello-world',
-  repositoryOwner: 'Codertocat',
-};
-
-interface RunnerTestItem extends RunnerList {
-  registered: boolean;
-  orphan: boolean;
-  shouldBeTerminated: boolean;
-}
+const mockTagRunner = vi.mocked(tag);
+const mockTerminateRunner = vi.mocked(terminateRunner);
+const mockUntagRunner = vi.mocked(untag);
 
 describe('Scale down runners', () => {
   beforeEach(() => {
-    process.env = { ...cleanEnv };
-    process.env.GITHUB_APP_KEY_BASE64 = 'TEST_CERTIFICATE_DATA';
-    process.env.GITHUB_APP_ID = '1337';
-    process.env.GITHUB_APP_CLIENT_ID = 'TEST_CLIENT_ID';
-    process.env.GITHUB_APP_CLIENT_SECRET = 'TEST_CLIENT_SECRET';
-    process.env.RUNNERS_MAXIMUM_COUNT = '3';
-    process.env.SCALE_DOWN_CONFIG = '[]';
-    process.env.ENVIRONMENT = ENVIRONMENT;
-    process.env.MINIMUM_RUNNING_TIME_IN_MINUTES = MINIMUM_TIME_RUNNING_IN_MINUTES.toString();
-    process.env.RUNNER_BOOT_TIME_IN_MINUTES = MINIMUM_BOOT_TIME.toString();
-
-    nock.disableNetConnect();
     vi.clearAllMocks();
-    vi.resetModules();
-    githubCache.clients.clear();
-    githubCache.runners.clear();
-    mockOctokit.apps.getOrgInstallation.mockImplementation(() => ({
-      data: {
-        id: 'ORG',
-      },
-    }));
-    mockOctokit.apps.getRepoInstallation.mockImplementation(() => ({
-      data: {
-        id: 'REPO',
-      },
-    }));
-
-    mockOctokit.paginate.mockResolvedValue([]);
-    mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation((repo) => {
-      // check if repo.runner_id contains the word "busy". If yes, throw an error else return 204
-      if (repo.runner_id.includes('busy')) {
-        throw Error();
-      } else {
-        return { status: 204 };
-      }
-    });
-
-    mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation((repo) => {
-      // check if repo.runner_id contains the word "busy". If yes, throw an error else return 204
-      if (repo.runner_id.includes('busy')) {
-        throw Error();
-      } else {
-        return { status: 204 };
-      }
-    });
-
-    mockOctokit.actions.getSelfHostedRunnerForRepo.mockImplementation((repo) => {
-      if (repo.runner_id.includes('busy')) {
-        return {
-          data: { busy: true },
-        };
-      } else {
-        return {
-          data: { busy: false },
-        };
-      }
-    });
-    mockOctokit.actions.getSelfHostedRunnerForOrg.mockImplementation((repo) => {
-      if (repo.runner_id.includes('busy')) {
-        return {
-          data: { busy: true },
-        };
-      } else {
-        return {
-          data: { busy: false },
-        };
-      }
-    });
-
-    mockTerminateRunners.mockImplementation(async () => {
-      return;
-    });
-    mockedAppAuth.mockResolvedValue({
-      type: 'app',
-      token: 'token',
-      appId: 1,
-      expiresAt: 'some-date',
-    });
-    mockedInstallationAuth.mockResolvedValue({
-      type: 'token',
-      tokenType: 'installation',
-      token: 'token',
-      createdAt: 'some-date',
-      expiresAt: 'some-date',
-      permissions: {},
-      repositorySelection: 'all',
-      installationId: 0,
-    });
-    mockCreateClient.mockResolvedValue(new mocktokit());
   });
 
   const endpoints = ['https://api.github.com', 'https://github.enterprise.something', 'https://companyname.ghe.com'];
 
-  describe.each(endpoints)('for %s', (endpoint) => {
-    beforeEach(() => {
-      if (endpoint.includes('enterprise') || endpoint.endsWith('.ghe.com')) {
-        process.env.GHES_URL = endpoint;
-      }
-    });
-
+  describe.each(endpoints)('for %s', () => {
     type RunnerType = 'Repo' | 'Org';
     const runnerTypes: RunnerType[] = ['Org', 'Repo'];
+
     describe.each(runnerTypes)('For %s runners.', (type) => {
+      const runner: RunnerList = {
+        instanceId: `i-runner-${type.toLowerCase()}`,
+        launchTime: new Date('2026-08-05T10:00:00.000Z'),
+        owner: type === 'Repo' ? 'Codertocat/hello-world' : 'Codertocat',
+        type,
+        repo: 'hello-world',
+        org: 'Codertocat',
+        orphan: true,
+        runnerId: '1234567890',
+        bypassRemoval: true,
+      };
+
       it('Should not call terminate when no runners online.', async () => {
-        // setup
-        mockAwsRunners([]);
+        mockListRunners.mockResolvedValueOnce([]).mockResolvedValueOnce([runner]);
+        mockTagRunner.mockResolvedValue();
+        mockUntagRunner.mockResolvedValue();
+        const provider = createEc2ScaleDownProvider();
 
-        // act
-        await scaleDown();
-
-        // assert
-        expect(listEC2Runners).toHaveBeenCalledWith({
-          environment: ENVIRONMENT,
+        await expect(provider.list('unit-test-environment')).resolves.toEqual([]);
+        await expect(provider.list('unit-test-environment', true)).resolves.toEqual([
+          {
+            id: runner.instanceId,
+            launchTime: runner.launchTime,
+            owner: runner.owner,
+            type: runner.type,
+            repo: runner.repo,
+            org: runner.org,
+            orphan: runner.orphan,
+            githubRunnerId: runner.runnerId,
+            bypassRemoval: runner.bypassRemoval,
+          },
+        ]);
+        expect(mockListRunners).toHaveBeenNthCalledWith(1, {
+          environment: 'unit-test-environment',
+          orphan: undefined,
         });
-        expect(terminateRunner).not.toHaveBeenCalled();
-        expect(mockOctokit.apps.getRepoInstallation).not.toHaveBeenCalled();
-        expect(mockOctokit.apps.getRepoInstallation).not.toHaveBeenCalled();
-      });
+        expect(mockListRunners).toHaveBeenNthCalledWith(2, { environment: 'unit-test-environment', orphan: true });
+        expect(mockTerminateRunner).not.toHaveBeenCalled();
 
-      it(`Should terminate runner without idle config ${type} runners.`, async () => {
-        // setup
-        const runners = [
-          createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES - 1, true, false, false),
-          createRunnerTestData('idle-2', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 4, true, false, true),
-          createRunnerTestData('busy-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 3, true, false, false),
-          createRunnerTestData('booting-1', type, MINIMUM_BOOT_TIME - 1, false, false, false),
-        ];
+        await provider.markOrphan(runner.instanceId);
+        await provider.unmarkOrphan(runner.instanceId);
 
-        mockGitHubRunners(runners);
-        mockListRunners.mockResolvedValue(runners);
-        mockAwsRunners(runners);
-
-        await scaleDown();
-
-        // assert
-        expect(listEC2Runners).toHaveBeenCalledWith({
-          environment: ENVIRONMENT,
-        });
-
-        if (type === 'Repo') {
-          expect(mockOctokit.apps.getRepoInstallation).toHaveBeenCalled();
-        } else {
-          expect(mockOctokit.apps.getOrgInstallation).toHaveBeenCalled();
-        }
-
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it(`Should respect idle runner with minimum running time not exceeded.`, async () => {
-        // setup
-        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES - 1, true, false, false)];
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
+        expect(mockTagRunner).toHaveBeenCalledWith(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
+        expect(mockUntagRunner).toHaveBeenCalledWith(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
       });
 
       it(`Should respect booting runner.`, async () => {
-        // setup
-        const runners = [createRunnerTestData('booting-1', type, MINIMUM_BOOT_TIME - 1, false, false, false)];
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it(`Should respect busy runner.`, async () => {
-        // setup
-        const runners = [createRunnerTestData('busy-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it(`Should not terminate runner with bypass-removal tag set.`, async () => {
-        // setup
-        const runners = [
-          createRunnerTestData('idle-with-bypass', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 10, true, false, false),
-        ];
-        // Set bypass-removal tag
-        runners[0].bypassRemoval = true;
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await scaleDown();
-
-        // assert
-        expect(terminateRunner).not.toHaveBeenCalled();
-        checkNonTerminated(runners);
-      });
-
-      it(`Should not terminate orphaned runner with bypass-removal tag set.`, async () => {
-        // setup - orphan runner with bypass-removal tag
-        const orphanRunner = createRunnerTestData('orphan-bypass', type, MINIMUM_BOOT_TIME + 1, false, false, false);
-        orphanRunner.bypassRemoval = true;
-
-        const idleRunner = createRunnerTestData('idle-1', type, MINIMUM_BOOT_TIME + 1, true, false, false);
-        const runners = [orphanRunner, idleRunner];
-
-        mockGitHubRunners([idleRunner]);
-        mockAwsRunners(runners);
-
-        // act - first cycle marks orphan
-        await scaleDown();
-
-        // mark as orphan for next cycle
-        orphanRunner.orphan = true;
-
-        // act - second cycle should skip termination due to bypass-removal
-        await scaleDown();
-
-        // assert - orphan runner should NOT be terminated
-        expect(terminateRunner).not.toHaveBeenCalledWith(orphanRunner.instanceId);
-      });
-
-      it(`Should not terminate a runner that became busy just before deregister runner.`, async () => {
-        // setup
-        const runners = [
-          createRunnerTestData(
-            'job-just-start-at-deregister-1',
-            type,
-            MINIMUM_TIME_RUNNING_IN_MINUTES + 1,
-            true,
-            false,
-            false,
-          ),
-        ];
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
-          return { status: 500 };
-        });
-
-        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
-          return { status: 500 };
-        });
-
-        // act and ensure no exception is thrown
-        await expect(scaleDown()).resolves.not.toThrow();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it(`Should terminate orphan (Non JIT)`, async () => {
-        // setup
-        const orphanRunner = createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, false, false);
-        const idleRunner = createRunnerTestData('idle-1', type, MINIMUM_BOOT_TIME + 1, true, false, false);
-        const runners = [orphanRunner, idleRunner];
-
-        mockGitHubRunners([idleRunner]);
-        mockAwsRunners(runners);
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-
-        expect(mockTagRunners).toHaveBeenCalledWith(orphanRunner.instanceId, [
-          {
-            Key: 'ghr:orphan',
-            Value: 'true',
-          },
-        ]);
-
-        expect(mockTagRunners).not.toHaveBeenCalledWith(idleRunner.instanceId, expect.anything());
-
-        // next cycle, update test data set orphan to true and terminate should be true
-        orphanRunner.orphan = true;
-        orphanRunner.shouldBeTerminated = true;
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it('Should test if orphaned runner, untag if online and busy, else terminate (JIT)', async () => {
-        // arrange
-        const orphanRunner = createRunnerTestData(
-          'orphan-jit',
-          type,
-          MINIMUM_BOOT_TIME + 1,
-          false,
-          true,
-          false,
-          undefined,
-          1234567890,
-        );
-        const runners = [orphanRunner];
-
-        mockGitHubRunners([]);
-        mockAwsRunners(runners);
-
-        if (type === 'Repo') {
-          mockOctokit.actions.getSelfHostedRunnerForRepo.mockResolvedValueOnce({
-            data: { id: 1234567890, name: orphanRunner.instanceId, busy: true, status: 'online' },
-          });
-        } else {
-          mockOctokit.actions.getSelfHostedRunnerForOrg.mockResolvedValueOnce({
-            data: { id: 1234567890, name: orphanRunner.instanceId, busy: true, status: 'online' },
-          });
-        }
-
-        // act
-        await scaleDown();
-
-        // assert
-        expect(mockUntagRunners).toHaveBeenCalledWith(orphanRunner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
-        expect(mockTerminateRunners).not.toHaveBeenCalledWith(orphanRunner.instanceId);
-
-        // arrange
-        if (type === 'Repo') {
-          mockOctokit.actions.getSelfHostedRunnerForRepo.mockResolvedValueOnce({
-            data: { runnerId: 1234567890, name: orphanRunner.instanceId, busy: true, status: 'offline' },
-          });
-        } else {
-          mockOctokit.actions.getSelfHostedRunnerForOrg.mockResolvedValueOnce({
-            data: { runnerId: 1234567890, name: orphanRunner.instanceId, busy: true, status: 'offline' },
-          });
-        }
-
-        // act
-        await scaleDown();
-
-        // assert
-        expect(mockTerminateRunners).toHaveBeenCalledWith(orphanRunner.instanceId);
-      });
-
-      it('Should handle 404 error when checking orphaned runner (JIT) - treat as orphaned', async () => {
-        // arrange
-        const orphanRunner = createRunnerTestData(
-          'orphan-jit-404',
-          type,
-          MINIMUM_BOOT_TIME + 1,
-          false,
-          true,
-          true, // should be terminated when 404
-          undefined,
-          1234567890,
-        );
-        const runners = [orphanRunner];
-
-        mockGitHubRunners([]);
-        mockAwsRunners(runners);
-
-        // Mock 404 error response
-        const error404 = new RequestError('Runner not found', 404, {
-          request: {
-            method: 'GET',
-            url: 'https://api.github.com/test',
-            headers: {},
-          },
-        });
-
-        if (type === 'Repo') {
-          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error404);
-        } else {
-          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error404);
-        }
-
-        // act
-        await scaleDown();
-
-        // assert - should terminate since 404 means runner doesn't exist on GitHub
-        expect(mockTerminateRunners).toHaveBeenCalledWith(orphanRunner.instanceId);
-      });
-
-      it('Should handle 404 error when checking runner busy state - treat as not busy', async () => {
-        // arrange
-        const runner = createRunnerTestData(
-          'runner-404',
-          type,
-          MINIMUM_TIME_RUNNING_IN_MINUTES + 1,
-          true,
-          false,
-          true, // should be terminated since not busy due to 404
-        );
-        const runners = [runner];
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // Mock 404 error response for busy state check
-        const error404 = new RequestError('Runner not found', 404, {
-          request: {
-            method: 'GET',
-            url: 'https://api.github.com/test',
-            headers: {},
-          },
-        });
-
-        if (type === 'Repo') {
-          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error404);
-        } else {
-          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error404);
-        }
-
-        // act
-        await scaleDown();
-
-        // assert - should terminate since 404 means runner is not busy
-        checkTerminated(runners);
-      });
-
-      it('Should re-throw non-404 errors when checking runner state', async () => {
-        // arrange
-        const orphanRunner = createRunnerTestData(
-          'orphan-error',
-          type,
-          MINIMUM_BOOT_TIME + 1,
-          false,
-          true,
-          false,
-          undefined,
-          1234567890,
-        );
-        const runners = [orphanRunner];
-
-        mockGitHubRunners([]);
-        mockAwsRunners(runners);
-
-        // Mock non-404 error response
-        const error500 = new RequestError('Internal server error', 500, {
-          request: {
-            method: 'GET',
-            url: 'https://api.github.com/test',
-            headers: {},
-          },
-        });
-
-        if (type === 'Repo') {
-          mockOctokit.actions.getSelfHostedRunnerForRepo.mockRejectedValueOnce(error500);
-        } else {
-          mockOctokit.actions.getSelfHostedRunnerForOrg.mockRejectedValueOnce(error500);
-        }
-
-        // act & assert - should not throw because error handling is in terminateOrphan
-        await expect(scaleDown()).resolves.not.toThrow();
-
-        // Should not terminate since the error was not a 404
-        expect(terminateRunner).not.toHaveBeenCalledWith(orphanRunner.instanceId);
-      });
-
-      it(`Should ignore errors when termination orphan fails.`, async () => {
-        // setup
-        const orphanRunner = createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true);
-        const runners = [orphanRunner];
-
-        mockGitHubRunners([]);
-        mockAwsRunners(runners);
-        mockTerminateRunners.mockImplementation(() => {
-          throw new Error('Failed to terminate');
-        });
-
-        // act
-        await scaleDown();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      describe('When orphan termination fails', () => {
-        it(`Should not throw in case of list runner exception.`, async () => {
-          // setup
-          const runners = [createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true)];
-
-          mockGitHubRunners([]);
-          mockListRunners.mockRejectedValueOnce(new Error('Failed to list runners'));
-          mockAwsRunners(runners);
-
-          // ac
-          await scaleDown();
-
-          // assert
-          checkNonTerminated(runners);
-        });
-
-        it(`Should not throw in case of terminate runner exception.`, async () => {
-          // setup
-          const runners = [createRunnerTestData('orphan-1', type, MINIMUM_BOOT_TIME + 1, false, true, true)];
-
-          mockGitHubRunners([]);
-          mockAwsRunners(runners);
-          mockTerminateRunners.mockRejectedValue(new Error('Failed to terminate'));
-
-          // act and ensure no exception is thrown
-          await scaleDown();
-
-          // assert
-          checkNonTerminated(runners);
-        });
-      });
-
-      it(`Should not terminate instance in case de-register fails.`, async () => {
-        // setup
-        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
-
-        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
-          return { status: 500 };
-        });
-        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
-          return { status: 500 };
-        });
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act and should resolve
-        await expect(scaleDown()).resolves.not.toThrow();
-
-        // assert
-        checkTerminated(runners);
-        checkNonTerminated(runners);
-      });
-
-      it(`Should not throw an exception in case of failure during removing a runner.`, async () => {
-        // setup
-        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, true, false)];
-
-        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
-          throw new Error('Failed to delete runner');
-        });
-        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
-          throw new Error('Failed to delete runner');
-        });
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await expect(scaleDown()).resolves.not.toThrow();
-      });
-
-      it(`Should not terminate instance when de-registration throws an error.`, async () => {
-        // setup - runner should NOT be terminated because de-registration fails
-        const runners = [createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 1, true, false, false)];
-
-        const error502 = new RequestError('Server Error', 502, {
-          request: {
-            method: 'DELETE',
-            url: 'https://api.github.com/test',
-            headers: {},
-          },
-        });
-
-        mockOctokit.actions.deleteSelfHostedRunnerFromOrg.mockImplementation(() => {
-          throw error502;
-        });
-        mockOctokit.actions.deleteSelfHostedRunnerFromRepo.mockImplementation(() => {
-          throw error502;
-        });
-
-        mockGitHubRunners(runners);
-        mockAwsRunners(runners);
-
-        // act
-        await expect(scaleDown()).resolves.not.toThrow();
-
-        // assert - should NOT terminate since de-registration failed
-        expect(terminateRunner).not.toHaveBeenCalled();
-      });
-
-      const evictionStrategies = ['oldest_first', 'newest_first'];
-      describe.each(evictionStrategies)('When idle config defined', (evictionStrategy) => {
-        const defaultConfig = {
-          idleCount: 1,
-          cron: '* * * * * *',
-          timeZone: 'Europe/Amsterdam',
-          evictionStrategy,
+        const scaleDownRunner = {
+          id: runner.instanceId,
+          launchTime: new Date(),
+          owner: runner.owner as string,
+          type: runner.type as string,
         };
+        process.env.RUNNER_BOOT_TIME_IN_MINUTES = '5';
+        const provider = createEc2ScaleDownProvider();
 
-        beforeEach(() => {
-          process.env.SCALE_DOWN_CONFIG = JSON.stringify([defaultConfig]);
-        });
+        expect(provider.bootTimeExceeded(scaleDownRunner)).toBe(false);
+        expect(mockTerminateRunner).not.toHaveBeenCalled();
+        mockTerminateRunner.mockResolvedValue();
+        await provider.terminate(runner.instanceId);
 
-        it(`Should terminate based on the the idle config with ${evictionStrategy} eviction strategy`, async () => {
-          // setup
-          const runnerToTerminateTime =
-            evictionStrategy === 'oldest_first'
-              ? MINIMUM_TIME_RUNNING_IN_MINUTES + 5
-              : MINIMUM_TIME_RUNNING_IN_MINUTES + 1;
-          const runners = [
-            createRunnerTestData('idle-1', type, MINIMUM_TIME_RUNNING_IN_MINUTES + 4, true, false, false),
-            createRunnerTestData('idle-to-terminate', type, runnerToTerminateTime, true, false, true),
-          ];
-
-          mockGitHubRunners(runners);
-          mockAwsRunners(runners);
-
-          // act
-          await scaleDown();
-
-          // assert
-          const runnersToTerminate = runners.filter((r) => r.shouldBeTerminated);
-          for (const toTerminate of runnersToTerminate) {
-            expect(terminateRunner).toHaveBeenCalledWith(toTerminate.instanceId);
-          }
-
-          const runnersNotToTerminate = runners.filter((r) => !r.shouldBeTerminated);
-          for (const notTerminated of runnersNotToTerminate) {
-            expect(terminateRunner).not.toHaveBeenCalledWith(notTerminated.instanceId);
-          }
-        });
+        expect(mockTerminateRunner).toHaveBeenCalledWith(runner.instanceId);
       });
     });
   });
 });
-
-function mockAwsRunners(runners: RunnerTestItem[]) {
-  mockListRunners.mockImplementation(async (filter) => {
-    return runners.filter((r) => !filter?.orphan || filter?.orphan === r.orphan);
-  });
-}
-
-function checkNonTerminated(runners: RunnerTestItem[]) {
-  const notTerminated = runners.filter((r) => !r.shouldBeTerminated);
-  for (const toTerminate of notTerminated) {
-    expect(terminateRunner).not.toHaveBeenCalledWith(toTerminate.instanceId);
-  }
-}
-
-function checkTerminated(runners: RunnerTestItem[]) {
-  const runnersToTerminate = runners.filter((r) => r.shouldBeTerminated);
-  expect(terminateRunner).toHaveBeenCalledTimes(runnersToTerminate.length);
-  for (const toTerminate of runnersToTerminate) {
-    expect(terminateRunner).toHaveBeenCalledWith(toTerminate.instanceId);
-  }
-}
-
-function mockGitHubRunners(runners: RunnerTestItem[]) {
-  mockOctokit.paginate.mockResolvedValue(
-    runners
-      .filter((r) => r.registered)
-      .map((r) => {
-        return {
-          id: r.instanceId,
-          name: r.instanceId,
-        };
-      }),
-  );
-}
-
-function createRunnerTestData(
-  name: string,
-  type: 'Org' | 'Repo',
-  minutesLaunchedAgo: number,
-  registered: boolean,
-  orphan: boolean,
-  shouldBeTerminated: boolean,
-  owner?: string,
-  runnerId?: number,
-): RunnerTestItem {
-  return {
-    instanceId: `i-${name}-${type.toLowerCase()}`,
-    launchTime: moment(new Date()).subtract(minutesLaunchedAgo, 'minutes').toDate(),
-    type,
-    owner: owner
-      ? owner
-      : type === 'Repo'
-        ? `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`
-        : `${TEST_DATA.repositoryOwner}`,
-    registered,
-    orphan,
-    shouldBeTerminated,
-    runnerId: runnerId !== undefined ? String(runnerId) : undefined,
-    bypassRemoval: false,
-  };
-}

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -1,324 +1,195 @@
+import type { CreateGitHubRunnerConfig, CreateStartRunnerConfig } from '../../../../core';
+import type { Octokit } from '@octokit/rest';
 import { DescribeLaunchTemplateVersionsCommand, EC2Client } from '@aws-sdk/client-ec2';
-import { PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest/vitest';
-// Using vi.mocked instead of jest-mock
-import nock from 'nock';
-import { performance } from 'perf_hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as ghAuth from '../../../../../../functions/control-plane/src/github/auth';
-import { publishRetryMessage } from '../../../../../../functions/control-plane/src/scale-runners/job-retry';
-import * as scaleUpModule from '../../../../../../functions/control-plane/src/scale-runners/scale-up';
-import type { ActionRequestMessageSQS } from '../../../../../../functions/control-plane/src/scale-runners/types';
 import { parseEc2OverrideConfig } from './dynamic-labels';
 import { EC2_TAG_VALUE_MAX_LENGTH, RUNNER_LABELS_TAG_MAX_COUNT } from './runner-config';
 import { createRunner, listEC2Runners, tag, terminateRunner } from './runners';
-import { RunnerInputParameters } from './runners.d';
-import { getParameter } from '@aws-github-runner/aws-ssm-util';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { Octokit } from '@octokit/rest';
+import type { RunnerInputParameters } from './runners.d';
+import { createEc2ScaleUpProvider } from './scale-up';
 
-const mockOctokit = {
-  paginate: vi.fn(),
-  checks: { get: vi.fn() },
-  actions: {
-    createRegistrationTokenForOrg: vi.fn(),
-    createRegistrationTokenForRepo: vi.fn(),
-    getJobForWorkflowRun: vi.fn(),
-    generateRunnerJitconfigForOrg: vi.fn(),
-    generateRunnerJitconfigForRepo: vi.fn(),
-  },
-  apps: {
-    getOrgInstallation: vi.fn(),
-    getRepoInstallation: vi.fn(),
-  },
-};
-
-const mockCreateRunner = vi.mocked(createRunner);
-const mockListRunners = vi.mocked(listEC2Runners);
-const mockTag = vi.mocked(tag);
-const mockTerminateRunner = vi.mocked(terminateRunner);
-const mockEC2Client = mockClient(EC2Client);
-const mockSSMClient = mockClient(SSMClient);
-const mockSSMgetParameter = vi.mocked(getParameter);
-const mockPublishRetryMessage = vi.mocked(publishRetryMessage);
-
-function createRunnerResult(instances: string[], retryableErrorCount = 0, nonRetryableErrorCount = 0) {
-  return { instances, retryableErrorCount, nonRetryableErrorCount };
-}
-
-vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(function () {
-    return mockOctokit;
-  }),
-}));
-
-vi.mock('./runners', async () => ({
+vi.mock('./runners', () => ({
   createRunner: vi.fn(),
   listEC2Runners: vi.fn(),
   tag: vi.fn(),
   terminateRunner: vi.fn(),
 }));
 
-vi.mock('../../../../../../functions/control-plane/src/github/auth', async () => ({
-  createGithubAppAuth: vi.fn(),
-  createGithubInstallationAuth: vi.fn(),
-  createOctokitClient: vi.fn(),
-}));
+const mockCreateRunner = vi.mocked(createRunner);
+const mockListRunners = vi.mocked(listEC2Runners);
+const mockTag = vi.mocked(tag);
+const mockTerminateRunner = vi.mocked(terminateRunner);
+const mockEC2Client = mockClient(EC2Client);
+const mockCreateStartRunnerConfig = vi.fn<CreateStartRunnerConfig>();
 
-vi.mock('@aws-github-runner/aws-ssm-util', async () => {
-  const actual = (await vi.importActual(
-    '@aws-github-runner/aws-ssm-util',
-  )) as typeof import('@aws-github-runner/aws-ssm-util');
-
-  return {
-    ...actual,
-    getParameter: vi.fn(),
-  };
-});
-
-vi.mock('../../../../../../functions/control-plane/src/scale-runners/job-retry', () => ({
-  publishRetryMessage: vi.fn(),
-  checkAndRetryJob: vi.fn(),
-}));
-
-export type RunnerType = 'ephemeral' | 'non-ephemeral';
-
-// for ephemeral and non-ephemeral runners
-const RUNNER_TYPES: RunnerType[] = ['ephemeral', 'non-ephemeral'];
-
-const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
-const mockedInstallationAuth = vi.mocked(ghAuth.createGithubInstallationAuth);
-const mockCreateClient = vi.mocked(ghAuth.createOctokitClient);
-
-const TEST_DATA_SINGLE: ActionRequestMessageSQS = {
-  id: 1,
-  eventType: 'workflow_job',
-  repositoryName: 'hello-world',
-  repositoryOwner: 'Codertocat',
-  installationId: 2,
-  repoOwnerType: 'Organization',
-  messageId: 'foobar',
-};
-
-const TEST_DATA: ActionRequestMessageSQS[] = [
-  {
-    ...TEST_DATA_SINGLE,
-    messageId: 'foobar',
-  },
-];
-
+const githubClient = {} as Octokit;
+const runnerOwner = 'Codertocat';
+const repositoryRunnerOwner = 'Codertocat/hello-world';
 const cleanEnv = process.env;
+const provider = createEc2ScaleUpProvider(mockCreateStartRunnerConfig);
 
-const EXPECTED_RUNNER_PARAMS: RunnerInputParameters = {
-  environment: 'unit-test-environment',
-  runnerType: 'Org',
-  runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-  numberOfRunners: 1,
-  launchTemplateName: 'lt-1',
-  ec2instanceCriteria: {
-    instanceTypes: ['m5.large'],
-    targetCapacityType: 'spot',
-    instanceAllocationStrategy: 'lowest-price',
-  },
-  subnets: ['subnet-123'],
-  tracingEnabled: false,
-  onDemandFailoverOnError: [],
-  scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'TargetCapacityLimitExceededException'],
-  source: 'scale-up-lambda',
-  useDedicatedHost: false,
-};
-let expectedRunnerParams: RunnerInputParameters;
+interface CreateProviderRunnersOptions {
+  labels?: string[];
+  baseRunnerLabels?: string;
+  githubRunnerConfig?: Partial<CreateGitHubRunnerConfig>;
+}
 
-function setDefaults() {
+function createRunnerResult(instances: string[], retryableErrorCount = 0, nonRetryableErrorCount = 0) {
+  return { instances, retryableErrorCount, nonRetryableErrorCount };
+}
+
+function runnerConfig(overrides: Partial<CreateGitHubRunnerConfig> = {}): CreateGitHubRunnerConfig {
+  return {
+    ephemeral: true,
+    enableJitConfig: true,
+    runnerLabels: 'label1,label2',
+    runnerGroup: 'Default',
+    runnerNamePrefix: 'unit-test-',
+    runnerOwner,
+    runnerType: 'Org',
+    disableAutoUpdate: false,
+    ssmTokenPath: '/github-action-runners/default/runners/config',
+    ssmConfigPath: '/github-action-runners/default/runners/config',
+    ssmParameterStoreTags: [],
+    ...overrides,
+  };
+}
+
+function expectedRunnerParams(
+  type: 'Org' | 'Repo' = 'Org',
+  owner = runnerOwner,
+  overrides: Partial<RunnerInputParameters> = {},
+): RunnerInputParameters {
+  return {
+    environment: 'unit-test-environment',
+    runnerType: type,
+    runnerOwner: owner,
+    numberOfRunners: 1,
+    launchTemplateName: 'lt-1',
+    ec2instanceCriteria: {
+      instanceTypes: ['m5.large'],
+      targetCapacityType: 'spot',
+      instanceAllocationStrategy: 'lowest-price',
+    },
+    subnets: ['subnet-123'],
+    tracingEnabled: false,
+    onDemandFailoverOnError: [],
+    scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'TargetCapacityLimitExceededException'],
+    source: 'scale-up-lambda',
+    useDedicatedHost: false,
+    ec2OverrideConfig: undefined,
+    ...overrides,
+  };
+}
+
+async function createProviderRunners(options: CreateProviderRunnersOptions = {}) {
+  const prepared = await provider.prepareGroup(options.labels ?? []);
+  const baseRunnerLabels = options.baseRunnerLabels ?? 'label1,label2';
+  const githubRunnerConfig = runnerConfig({
+    runnerLabels: [baseRunnerLabels, ...prepared.runnerLabels].filter(Boolean).join(','),
+    ...options.githubRunnerConfig,
+  });
+
+  return await provider.createRunners({
+    githubRunnerConfig,
+    numberOfRunners: 1,
+    githubInstallationClient: githubClient,
+    state: prepared.state,
+  });
+}
+
+async function expectCurrentRunners(runnerType: 'Org' | 'Repo', owner: string) {
+  const prepared = await provider.prepareGroup([]);
+
+  await expect(provider.getCurrentRunners(prepared.state, { runnerType, runnerOwner: owner })).resolves.toBe(1);
+  expect(mockListRunners).toHaveBeenCalledWith({
+    environment: 'unit-test-environment',
+    runnerType,
+    runnerOwner: owner,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
   process.env = { ...cleanEnv };
-  process.env.PARAMETER_GITHUB_APP_ID_NAME = 'github-app-id';
-  process.env.GITHUB_APP_KEY_BASE64 = 'TEST_CERTIFICATE_DATA';
-  process.env.GITHUB_APP_ID = '1337';
-  process.env.GITHUB_APP_CLIENT_ID = 'TEST_CLIENT_ID';
-  process.env.GITHUB_APP_CLIENT_SECRET = 'TEST_CLIENT_SECRET';
-  process.env.RUNNERS_MAXIMUM_COUNT = '3';
-  process.env.ENVIRONMENT = EXPECTED_RUNNER_PARAMS.environment;
+  process.env.ENVIRONMENT = 'unit-test-environment';
   process.env.LAUNCH_TEMPLATE_NAME = 'lt-1';
   process.env.SUBNET_IDS = 'subnet-123';
   process.env.INSTANCE_TYPES = 'm5.large';
   process.env.INSTANCE_TARGET_CAPACITY_TYPE = 'spot';
-  process.env.ENABLE_ON_DEMAND_FAILOVER = undefined;
   process.env.SCALE_ERRORS =
     '["UnfulfillableCapacity","MaxSpotInstanceCountExceeded","TargetCapacityLimitExceededException"]';
-}
-
-beforeEach(() => {
-  nock.disableNetConnect();
-  vi.resetModules();
-  vi.clearAllMocks();
-  setDefaults();
+  delete process.env.INSTANCE_TYPE_PRIORITIES;
+  delete process.env.INSTANCE_MAX_SPOT_PRICE;
+  delete process.env.INSTANCE_ALLOCATION_STRATEGY;
+  delete process.env.AMI_ID_SSM_PARAMETER_NAME;
+  delete process.env.POWERTOOLS_TRACE_ENABLED;
+  delete process.env.ENABLE_ON_DEMAND_FAILOVER_FOR_ERRORS;
+  delete process.env.USE_DEDICATED_HOST;
 
   mockEC2Client.reset();
   mockEC2Client.on(DescribeLaunchTemplateVersionsCommand).resolves({
     LaunchTemplateVersions: [
       {
         LaunchTemplateData: {
-          BlockDeviceMappings: [
-            {
-              DeviceName: '/dev/sda1',
-              Ebs: {},
-            },
-          ],
+          BlockDeviceMappings: [{ DeviceName: '/dev/sda1', Ebs: {} }],
         },
       },
     ],
   });
 
-  defaultSSMGetParameterMockImpl();
-  defaultOctokitMockImpl();
-
-  mockCreateRunner.mockImplementation(async () => {
-    return createRunnerResult(['i-12345']);
-  });
-  mockListRunners.mockImplementation(async () => [
+  mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345']));
+  mockListRunners.mockResolvedValue([
     {
       instanceId: 'i-1234',
       launchTime: new Date(),
       type: 'Org',
-      owner: TEST_DATA_SINGLE.repositoryOwner,
+      owner: runnerOwner,
     },
   ]);
-
-  mockedAppAuth.mockResolvedValue({
-    type: 'app',
-    token: 'token',
-    appId: TEST_DATA_SINGLE.installationId,
-    expiresAt: 'some-date',
+  mockTag.mockResolvedValue(undefined);
+  mockTerminateRunner.mockResolvedValue(undefined);
+  mockCreateStartRunnerConfig.mockImplementation(async (config, runnerIds, _client, options) => {
+    for (const runnerId of runnerIds) {
+      await options?.onJitConfigCreated?.(runnerId, {
+        githubRunnerId: '9876543210',
+        runnerLabels: config.runnerLabels ? config.runnerLabels.split(',') : [],
+      });
+    }
+    return [];
   });
-  mockedInstallationAuth.mockResolvedValue({
-    type: 'token',
-    tokenType: 'installation',
-    token: 'token',
-    createdAt: 'some-date',
-    expiresAt: 'some-date',
-    permissions: {},
-    repositorySelection: 'all',
-    installationId: 0,
-  });
-
-  mockCreateClient.mockResolvedValue(mockOctokit as unknown as Octokit);
 });
-
 describe('scaleUp with GHES', () => {
-  beforeEach(() => {
-    process.env.GHES_URL = 'https://github.enterprise.something';
-  });
-
-  it('checks queued workflows', async () => {
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
-      job_id: TEST_DATA_SINGLE.id,
-      owner: TEST_DATA_SINGLE.repositoryOwner,
-      repo: TEST_DATA_SINGLE.repositoryName,
-    });
-  });
-
-  it('does not list runners when no workflows are queued', async () => {
-    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
-      data: { total_count: 0 },
-    }));
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(listEC2Runners).not.toBeCalled();
-  });
-
   describe('on org level', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test-';
-      process.env.RUNNER_GROUP_NAME = 'Default';
-      process.env.SSM_CONFIG_PATH = '/github-action-runners/default/runners/config';
-      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-      process.env.RUNNER_LABELS = 'label1,label2';
-
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      mockSSMClient.reset();
-    });
-
     it('gets the current org level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Org',
-        runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('does not create runners when current runners exceed maximum (race condition)', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '5';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      // Simulate race condition where pool lambda created more runners than max
-      mockListRunners.mockImplementation(async () =>
-        Array.from({ length: 10 }, (_, i) => ({
-          instanceId: `i-${i}`,
-          launchTime: new Date(),
-          type: 'Org',
-          owner: TEST_DATA_SINGLE.repositoryOwner,
-        })),
-      );
-      await scaleUpModule.scaleUp(TEST_DATA);
-      // Should not attempt to create runners (would be negative without fix)
-      expect(createRunner).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-    });
-
-    it('does create a runner if maximum is set to -1', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).not.toHaveBeenCalled();
-      expect(createRunner).toHaveBeenCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-      });
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+      await expectCurrentRunners('Org', runnerOwner);
     });
 
     it('creates a runner with correct config', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      await createProviderRunners();
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams());
     });
 
     it('tags the EC2 runner with the GitHub runner metadata returned by JIT config', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
+      await createProviderRunners();
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
         { Key: 'ghr:runner_labels', Value: 'label1,label2' },
       ]);
+      const [, , , options] = mockCreateStartRunnerConfig.mock.calls[0];
+      expect(options?.getSsmParameterTags?.('i-12345')).toEqual([{ Key: 'InstanceId', Value: 'i-12345' }]);
     });
 
     it('chunks comma-joined GitHub runner labels by the EC2 tag value max length', async () => {
       const runnerLabels = ['a'.repeat(EC2_TAG_VALUE_MAX_LENGTH), 'b'].join(',');
-      process.env.RUNNER_LABELS = runnerLabels;
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-
+      await createProviderRunners({ baseRunnerLabels: runnerLabels });
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
         { Key: 'ghr:runner_labels', Value: runnerLabels.slice(0, EC2_TAG_VALUE_MAX_LENGTH) },
-        {
-          Key: 'ghr:runner_labels:2',
-          Value: runnerLabels.slice(EC2_TAG_VALUE_MAX_LENGTH),
-        },
+        { Key: 'ghr:runner_labels:2', Value: runnerLabels.slice(EC2_TAG_VALUE_MAX_LENGTH) },
       ]);
     });
 
@@ -326,31 +197,21 @@ describe('scaleUp with GHES', () => {
       const runnerLabels = Array.from({ length: RUNNER_LABELS_TAG_MAX_COUNT + 1 }, (_, index) =>
         String.fromCharCode('a'.charCodeAt(0) + index).repeat(EC2_TAG_VALUE_MAX_LENGTH),
       ).join(',');
-      process.env.RUNNER_LABELS = runnerLabels;
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-
+      await createProviderRunners({ baseRunnerLabels: runnerLabels });
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
         ...Array.from({ length: RUNNER_LABELS_TAG_MAX_COUNT }, (_, index) => ({
-          Key: index === 0 ? 'ghr:runner_labels' : `ghr:runner_labels:${index + 1}`,
+          Key: index === 0 ? 'ghr:runner_labels' : 'ghr:runner_labels:' + (index + 1),
           Value: runnerLabels.slice(index * EC2_TAG_VALUE_MAX_LENGTH, (index + 1) * EC2_TAG_VALUE_MAX_LENGTH),
         })),
       ]);
     });
 
     it('uses a reserved separator when packing GitHub runner labels into EC2 tags', async () => {
-      process.env.RUNNER_LABELS = ['label:with/slash', 'label+with+plus'].join(',');
-      const testDataWithSemicolonDynamicLabel = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-cpu-manufacturers:intel;amd'],
-          messageId: 'test-semicolon-dynamic-label',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithSemicolonDynamicLabel);
-
+      await createProviderRunners({
+        baseRunnerLabels: ['label:with/slash', 'label+with+plus'].join(','),
+        labels: ['ghr-ec2-cpu-manufacturers:intel;amd'],
+      });
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
         { Key: 'ghr:github_runner_id', Value: '9876543210' },
         {
@@ -360,397 +221,43 @@ describe('scaleUp with GHES', () => {
       ]);
     });
 
-    it('creates a runner with labels in a specific group', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
     it('creates a runner with ami id override from ssm parameter', async () => {
       process.env.AMI_ID_SSM_PARAMETER_NAME = 'my-ami-id-param';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith({ ...expectedRunnerParams, amiIdSsmParameterName: 'my-ami-id-param' });
+      await createProviderRunners();
+      expect(mockCreateRunner).toHaveBeenCalledWith(
+        expectedRunnerParams('Org', runnerOwner, { amiIdSsmParameterName: 'my-ami-id-param' }),
+      );
     });
 
     it('returns a retryable failure if runner group lookup fails for ephemeral runners', async () => {
-      process.env.RUNNER_GROUP_NAME = 'test-runner-group';
-      mockSSMgetParameter.mockImplementation(async () => {
-        throw new Error('ParameterNotFound');
+      mockCreateStartRunnerConfig.mockResolvedValueOnce(['i-12345']);
+      await expect(createProviderRunners()).resolves.toEqual({
+        instances: [],
+        retryableErrorCount: 1,
+        nonRetryableErrorCount: 0,
       });
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
       expect(mockTerminateRunner).toHaveBeenCalledWith('i-12345');
     });
-
-    it('Discards event if it is a User repo and org level runners is enabled', async () => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
-      USER_REPO_TEST_DATA[0].repoOwnerType = 'User';
-      await scaleUpModule.scaleUp(USER_REPO_TEST_DATA);
-      expect(createRunner).not.toHaveBeenCalled();
-    });
-
-    it('create SSM parameter for runner group id if it does not exist', async () => {
-      mockSSMgetParameter.mockImplementation(async () => {
-        throw new Error('ParameterNotFound');
-      });
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
-      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 2);
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`,
-        Value: '1',
-        Type: 'String',
-      });
-    });
-
-    it('Does not create SSM parameter for runner group id if it exists', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(0);
-      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 1);
-    });
-
-    it('create start runner config for ephemeral runners ', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toBeCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-        name: 'unit-test-i-12345',
-        runner_group_id: 1,
-        labels: ['label1', 'label2'],
-      });
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value: 'TEST_JIT_CONFIG_ORG',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('create start runner config for non-ephemeral runners ', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalled();
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value:
-          '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
-          '--labels label1,label2 --runnergroup Default',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('quotes runner labels with semicolon separators in non-ephemeral runner config', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-
-      await scaleUpModule.scaleUp([
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-cpu-manufacturers:intel;amd'],
-          messageId: 'test-semicolon-labels',
-        },
-      ]);
-
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value:
-          '--url https://github.enterprise.something/Codertocat --token 1234abcd ' +
-          "--labels 'label1,label2,ghr-ec2-cpu-manufacturers:intel;amd' --runnergroup Default",
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('should create JIT config for all remaining instances even when GitHub API fails for one instance', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '5';
-      mockCreateRunner.mockImplementation(async () => {
-        return createRunnerResult(['i-instance-1', 'i-instance-2', 'i-instance-3']);
-      });
-      mockListRunners.mockImplementation(async () => {
-        return [];
-      });
-
-      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
-        if (name === 'unit-test-i-instance-2') {
-          // Simulate a 503 Service Unavailable error from GitHub
-          const error = new Error('Service Unavailable') as Error & {
-            status: number;
-            response: { status: number; data: { message: string } };
-          };
-          error.status = 503;
-          error.response = {
-            status: 503,
-            data: { message: 'Service temporarily unavailable' },
-          };
-          throw error;
-        }
-        return {
-          data: {
-            runner: { id: 9876543210 },
-            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
-          },
-          headers: {},
-        };
-      });
-
-      const rejectedMessages = await scaleUpModule.scaleUp(TEST_DATA);
-
-      expect(rejectedMessages).toEqual(['foobar']);
-
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-        name: 'unit-test-i-instance-1',
-        runner_group_id: 1,
-        labels: ['label1', 'label2'],
-      });
-
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-        name: 'unit-test-i-instance-2',
-        runner_group_id: 1,
-        labels: ['label1', 'label2'],
-      });
-
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toHaveBeenCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-        name: 'unit-test-i-instance-3',
-        runner_group_id: 1,
-        labels: ['label1', 'label2'],
-      });
-
-      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-1',
-        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-1',
-        Type: 'SecureString',
-        Tags: [{ Key: 'InstanceId', Value: 'i-instance-1' }],
-      });
-
-      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-3',
-        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-3',
-        Type: 'SecureString',
-        Tags: [{ Key: 'InstanceId', Value: 'i-instance-3' }],
-      });
-
-      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-2',
-      });
-    });
-
-    it('should handle retryable errors with error handling logic', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '5';
-      mockCreateRunner.mockImplementation(async () => {
-        return createRunnerResult(['i-instance-1', 'i-instance-2']);
-      });
-      mockListRunners.mockImplementation(async () => {
-        return [];
-      });
-
-      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
-        if (name === 'unit-test-i-instance-1') {
-          const error = new Error('Internal Server Error') as Error & {
-            status: number;
-            response: { status: number; data: { message: string } };
-          };
-          error.status = 500;
-          error.response = {
-            status: 500,
-            data: { message: 'Internal server error' },
-          };
-          throw error;
-        }
-        return {
-          data: {
-            runner: { id: 9876543210 },
-            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
-          },
-          headers: {},
-        };
-      });
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-
-      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-2',
-        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-2',
-        Type: 'SecureString',
-        Tags: [{ Key: 'InstanceId', Value: 'i-instance-2' }],
-      });
-
-      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-1',
-      });
-    });
-
-    it('should handle non-retryable 4xx errors gracefully', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '5';
-      mockCreateRunner.mockImplementation(async () => {
-        return createRunnerResult(['i-instance-1', 'i-instance-2']);
-      });
-      mockListRunners.mockImplementation(async () => {
-        return [];
-      });
-
-      mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ name }) => {
-        if (name === 'unit-test-i-instance-1') {
-          // 404 is not retryable - will fail immediately
-          const error = new Error('Not Found') as Error & {
-            status: number;
-            response: { status: number; data: { message: string } };
-          };
-          error.status = 404;
-          error.response = {
-            status: 404,
-            data: { message: 'Resource not found' },
-          };
-          throw error;
-        }
-        return {
-          data: {
-            runner: { id: 9876543210 },
-            encoded_jit_config: `TEST_JIT_CONFIG_${name}`,
-          },
-          headers: {},
-        };
-      });
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-
-      expect(mockSSMClient).toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-2',
-        Value: 'TEST_JIT_CONFIG_unit-test-i-instance-2',
-        Type: 'SecureString',
-        Tags: [{ Key: 'InstanceId', Value: 'i-instance-2' }],
-      });
-
-      expect(mockSSMClient).not.toHaveReceivedCommandWith(PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-instance-1',
-      });
-    });
-
-    it.each(RUNNER_TYPES)(
-      'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
-      async (type: RunnerType) => {
-        process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
-        process.env.RUNNERS_MAXIMUM_COUNT = '40';
-        mockCreateRunner.mockImplementation(async () => {
-          return createRunnerResult(instances);
-        });
-        mockListRunners.mockImplementation(async () => {
-          return [];
-        });
-        const startTime = performance.now();
-        const instances = [
-          'i-1234',
-          'i-5678',
-          'i-5567',
-          'i-5569',
-          'i-5561',
-          'i-5560',
-          'i-5566',
-          'i-5536',
-          'i-5526',
-          'i-5516',
-          'i-122',
-          'i-123',
-          'i-124',
-          'i-125',
-          'i-126',
-          'i-127',
-          'i-128',
-          'i-129',
-          'i-130',
-          'i-131',
-          'i-132',
-          'i-133',
-          'i-134',
-          'i-135',
-          'i-136',
-          'i-137',
-          'i-138',
-          'i-139',
-          'i-140',
-          'i-141',
-          'i-142',
-          'i-143',
-          'i-144',
-          'i-145',
-          'i-146',
-          'i-147',
-          'i-148',
-          'i-149',
-          'i-150',
-          'i-151',
-        ];
-        await scaleUpModule.scaleUp(TEST_DATA);
-        const endTime = performance.now();
-        expect(endTime - startTime).toBeGreaterThan(1000);
-        expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 40);
-      },
-      10000,
-    );
   });
 
   describe('Dynamic EC2 Configuration', () => {
     beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-      process.env.RUNNER_LABELS = 'base-label';
       process.env.INSTANCE_TYPES = 't3.medium,t3.large';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test';
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      mockSSMClient.reset();
     });
 
     it('appends EC2 labels to existing runner labels when EC2 labels are present', async () => {
-      const testDataWithEc2Labels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-instance-type:c5.2xlarge', 'ghr-ec2-custom:value'],
-          messageId: 'test-1',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithEc2Labels);
-
-      // Verify createRunner was called with EC2 instance type in override config
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['ghr-ec2-instance-type:c5.2xlarge', 'ghr-ec2-custom:value'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
-          ec2OverrideConfig: expect.objectContaining({
-            InstanceType: 'c5.2xlarge',
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
+          ec2OverrideConfig: expect.objectContaining({ InstanceType: 'c5.2xlarge' }),
         }),
       );
       expect(mockTag).toHaveBeenCalledWith('i-12345', [
-        {
-          Key: 'ghr:github_runner_id',
-          Value: '9876543210',
-        },
+        { Key: 'ghr:github_runner_id', Value: '9876543210' },
         {
           Key: 'ghr:runner_labels',
           Value: 'base-label,ghr-ec2-instance-type:c5.2xlarge,ghr-ec2-custom:value',
@@ -759,22 +266,10 @@ describe('scaleUp with GHES', () => {
     });
 
     it('uses default instance types when no instance type EC2 label is provided', async () => {
-      const testDataWithEc2Labels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-custom:value'],
-          messageId: 'test-3',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithEc2Labels);
-
-      // Should use the default INSTANCE_TYPES from environment
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({ baseRunnerLabels: 'base-label', labels: ['ghr-ec2-custom:value'] });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
         }),
       );
     });
@@ -785,255 +280,142 @@ describe('scaleUp with GHES', () => {
           {
             LaunchTemplateData: {
               BlockDeviceMappings: [
-                {
-                  DeviceName: '/dev/sdb',
-                  VirtualName: 'ephemeral0',
-                },
-                {
-                  DeviceName: '/dev/sdf',
-                  Ebs: {},
-                },
+                { DeviceName: '/dev/sdb', VirtualName: 'ephemeral0' },
+                { DeviceName: '/dev/sdf', Ebs: {} },
               ],
             },
           },
         ],
       });
-
-      const testDataWithEbsLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-ebs-volume-size:100', 'ghr-ec2-ebs-volume-type:gp3'],
-          messageId: 'test-ebs-device-name',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithEbsLabels);
-
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['ghr-ec2-ebs-volume-size:100', 'ghr-ec2-ebs-volume-type:gp3'],
+      });
       expect(mockEC2Client).toHaveReceivedCommandWith(DescribeLaunchTemplateVersionsCommand, {
         LaunchTemplateName: 'lt-1',
         Versions: ['$Default'],
       });
-      expect(createRunner).toBeCalledWith(
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            BlockDeviceMappings: [
-              {
-                DeviceName: '/dev/sdf',
-                Ebs: {
-                  VolumeSize: 100,
-                  VolumeType: 'gp3',
-                },
-              },
-            ],
+            BlockDeviceMappings: [{ DeviceName: '/dev/sdf', Ebs: { VolumeSize: 100, VolumeType: 'gp3' } }],
           }),
         }),
       );
     });
 
     it('does not load launch template block device name when DeviceName is provided by labels', async () => {
-      const testDataWithEbsLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['ghr-ec2-block-device-name:/dev/sdg', 'ghr-ec2-ebs-volume-size:100', 'ghr-ec2-ebs-volume-type:gp3'],
-          messageId: 'test-explicit-ebs-device-name',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithEbsLabels);
-
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['ghr-ec2-block-device-name:/dev/sdg', 'ghr-ec2-ebs-volume-size:100', 'ghr-ec2-ebs-volume-type:gp3'],
+      });
       expect(mockEC2Client).not.toHaveReceivedCommand(DescribeLaunchTemplateVersionsCommand);
-      expect(createRunner).toBeCalledWith(
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            BlockDeviceMappings: [
-              {
-                DeviceName: '/dev/sdg',
-                Ebs: {
-                  VolumeSize: 100,
-                  VolumeType: 'gp3',
-                },
-              },
-            ],
+            BlockDeviceMappings: [{ DeviceName: '/dev/sdg', Ebs: { VolumeSize: 100, VolumeType: 'gp3' } }],
           }),
         }),
       );
     });
 
     it('handles messages with no labels gracefully', async () => {
-      const testDataWithNoLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: undefined,
-          messageId: 'test-5',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithNoLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({ baseRunnerLabels: 'base-label' });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
         }),
       );
     });
 
     it('handles empty labels array', async () => {
-      const testDataWithEmptyLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: [],
-          messageId: 'test-6',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithEmptyLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({ baseRunnerLabels: 'base-label', labels: [] });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
         }),
       );
     });
 
     it('handles multiple EC2 labels correctly', async () => {
-      const testDataWithMultipleEc2Labels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['regular-label', 'ghr-ec2-instance-type:r5.2xlarge', 'ghr-ec2-ami:custom-ami', 'ghr-ec2-disk:200'],
-          messageId: 'test-8',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithMultipleEc2Labels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['regular-label', 'ghr-ec2-instance-type:r5.2xlarge', 'ghr-ec2-ami:custom-ami', 'ghr-ec2-disk:200'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
-          ec2OverrideConfig: expect.objectContaining({
-            InstanceType: 'r5.2xlarge',
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
+          ec2OverrideConfig: expect.objectContaining({ InstanceType: 'r5.2xlarge' }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with VCpuCount requirements when specified', async () => {
-      const testDataWithVCpuLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-vcpu-count-min:4', 'ghr-ec2-vcpu-count-max:16'],
-          messageId: 'test-9',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithVCpuLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-vcpu-count-min:4', 'ghr-ec2-vcpu-count-max:16'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            InstanceRequirements: expect.objectContaining({
-              VCpuCount: {
-                Min: 4,
-                Max: 16,
-              },
-            }),
+            InstanceRequirements: expect.objectContaining({ VCpuCount: { Min: 4, Max: 16 } }),
           }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with MemoryMiB requirements when specified', async () => {
-      const testDataWithMemoryLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-memory-mib-min:8192', 'ghr-ec2-memory-mib-max:32768'],
-          messageId: 'test-10',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithMemoryLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-memory-mib-min:8192', 'ghr-ec2-memory-mib-max:32768'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            InstanceRequirements: expect.objectContaining({
-              MemoryMiB: {
-                Min: 8192,
-                Max: 32768,
-              },
-            }),
+            InstanceRequirements: expect.objectContaining({ MemoryMiB: { Min: 8192, Max: 32768 } }),
           }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with CPU manufacturers when specified', async () => {
-      const testDataWithCpuLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-cpu-manufacturers:intel;amd'],
-          messageId: 'test-11',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithCpuLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-cpu-manufacturers:intel;amd'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            InstanceRequirements: expect.objectContaining({
-              CpuManufacturers: ['intel', 'amd'],
-            }),
+            InstanceRequirements: expect.objectContaining({ CpuManufacturers: ['intel', 'amd'] }),
           }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with instance generations when specified', async () => {
-      const testDataWithGenerationLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-instance-generations:current'],
-          messageId: 'test-12',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithGenerationLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-instance-generations:current'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
-            InstanceRequirements: expect.objectContaining({
-              InstanceGenerations: ['current'],
-            }),
+            InstanceRequirements: expect.objectContaining({ InstanceGenerations: ['current'] }),
           }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with accelerator requirements when specified', async () => {
-      const testDataWithAcceleratorLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-accelerator-count-min:1', 'ghr-ec2-accelerator-types:gpu'],
-          messageId: 'test-13',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithAcceleratorLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-accelerator-count-min:1', 'ghr-ec2-accelerator-types:gpu'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
             InstanceRequirements: expect.objectContaining({
-              AcceleratorCount: {
-                Min: 1,
-              },
+              AcceleratorCount: { Min: 1 },
               AcceleratorTypes: ['gpu'],
             }),
           }),
@@ -1042,66 +424,41 @@ describe('scaleUp with GHES', () => {
     });
 
     it('includes ec2OverrideConfig with max price when specified', async () => {
-      const testDataWithMaxPrice = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-max-price:0.50'],
-          messageId: 'test-14',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithMaxPrice);
-
-      expect(createRunner).toBeCalledWith(
-        expect.objectContaining({
-          ec2OverrideConfig: expect.objectContaining({
-            MaxPrice: '0.50',
-          }),
-        }),
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-max-price:0.50'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
+        expect.objectContaining({ ec2OverrideConfig: expect.objectContaining({ MaxPrice: '0.50' }) }),
       );
     });
 
     it('includes ec2OverrideConfig with priority and weighted capacity when specified', async () => {
-      const testDataWithPriorityWeight = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-priority:1', 'ghr-ec2-weighted-capacity:2'],
-          messageId: 'test-15',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithPriorityWeight);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-priority:1', 'ghr-ec2-weighted-capacity:2'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2OverrideConfig: expect.objectContaining({
-            Priority: 1,
-            WeightedCapacity: 2,
-          }),
+          ec2OverrideConfig: expect.objectContaining({ Priority: 1, WeightedCapacity: 2 }),
         }),
       );
     });
 
     it('includes ec2OverrideConfig with combined requirements', async () => {
-      const testDataWithCombinedLabels = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: [
-            'self-hosted',
-            'linux',
-            'ghr-ec2-vcpu-count-min:8',
-            'ghr-ec2-memory-mib-min:16384',
-            'ghr-ec2-cpu-manufacturers:intel',
-            'ghr-ec2-instance-generations:current',
-            'ghr-ec2-max-price:1.00',
-          ],
-          messageId: 'test-16',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithCombinedLabels);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: [
+          'self-hosted',
+          'linux',
+          'ghr-ec2-vcpu-count-min:8',
+          'ghr-ec2-memory-mib-min:16384',
+          'ghr-ec2-cpu-manufacturers:intel',
+          'ghr-ec2-instance-generations:current',
+          'ghr-ec2-max-price:1.00',
+        ],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
           ec2OverrideConfig: expect.objectContaining({
             InstanceRequirements: expect.objectContaining({
@@ -1117,1738 +474,156 @@ describe('scaleUp with GHES', () => {
     });
 
     it('includes both instance type and ec2OverrideConfig when both specified', async () => {
-      const testDataWithBoth = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-instance-type:c5.xlarge', 'ghr-ec2-vcpu-count-min:4'],
-          messageId: 'test-18',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataWithBoth);
-
-      expect(createRunner).toBeCalledWith(
+      await createProviderRunners({
+        baseRunnerLabels: 'base-label',
+        labels: ['self-hosted', 'ghr-ec2-instance-type:c5.xlarge', 'ghr-ec2-vcpu-count-min:4'],
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
         expect.objectContaining({
-          ec2instanceCriteria: expect.objectContaining({
-            instanceTypes: ['t3.medium', 't3.large'],
-          }),
+          ec2instanceCriteria: expect.objectContaining({ instanceTypes: ['t3.medium', 't3.large'] }),
           ec2OverrideConfig: expect.objectContaining({
             InstanceType: 'c5.xlarge',
-            InstanceRequirements: expect.objectContaining({
-              VCpuCount: { Min: 4 },
-            }),
+            InstanceRequirements: expect.objectContaining({ VCpuCount: { Min: 4 } }),
           }),
         }),
       );
-    });
-
-    it('does not accumulate labels across groups when multiple messages have different dynamic labels', async () => {
-      const testDataMultipleGroups = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:m7a.large', 'ghr-job-id:run-1-inst-0'],
-          messageId: 'msg-1',
-        },
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:m7i.xlarge', 'ghr-job-id:run-1-inst-1'],
-          messageId: 'msg-2',
-        },
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'linux', 'ghr-ec2-instance-type:c7a.large', 'ghr-job-id:run-1-inst-2'],
-          messageId: 'msg-3',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataMultipleGroups);
-
-      expect(createRunner).toBeCalledTimes(3);
-
-      const jitCalls = mockOctokit.actions.generateRunnerJitconfigForOrg.mock.calls;
-      expect(jitCalls).toHaveLength(3);
-
-      for (const call of jitCalls) {
-        const labels = call[0].labels as string[];
-
-        if (labels.includes('ghr-ec2-instance-type:m7a.large')) {
-          expect(labels).toContain('ghr-job-id:run-1-inst-0');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
-          expect(labels).not.toContain('ghr-ec2-instance-type:m7i.xlarge');
-          expect(labels).not.toContain('ghr-ec2-instance-type:c7a.large');
-        } else if (labels.includes('ghr-ec2-instance-type:m7i.xlarge')) {
-          expect(labels).toContain('ghr-job-id:run-1-inst-1');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-2');
-          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
-          expect(labels).not.toContain('ghr-ec2-instance-type:c7a.large');
-        } else if (labels.includes('ghr-ec2-instance-type:c7a.large')) {
-          expect(labels).toContain('ghr-job-id:run-1-inst-2');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-0');
-          expect(labels).not.toContain('ghr-job-id:run-1-inst-1');
-          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
-          expect(labels).not.toContain('ghr-ec2-instance-type:m7i.xlarge');
-        } else {
-          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
-        }
-      }
-    });
-
-    it('preserves base RUNNER_LABELS for each group without mutation', async () => {
-      process.env.RUNNER_LABELS = 'ubuntu-2404,x64';
-
-      const testDataTwoGroups = [
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-instance-type:m7a.large', 'ghr-team:alpha'],
-          messageId: 'msg-a',
-        },
-        {
-          ...TEST_DATA_SINGLE,
-          labels: ['self-hosted', 'ghr-ec2-instance-type:c7i.large', 'ghr-team:beta'],
-          messageId: 'msg-b',
-        },
-      ];
-
-      await scaleUpModule.scaleUp(testDataTwoGroups);
-
-      expect(createRunner).toBeCalledTimes(2);
-
-      const jitCalls = mockOctokit.actions.generateRunnerJitconfigForOrg.mock.calls;
-      expect(jitCalls).toHaveLength(2);
-
-      for (const call of jitCalls) {
-        const labels = call[0].labels as string[];
-
-        expect(labels).toContain('ubuntu-2404');
-        expect(labels).toContain('x64');
-
-        if (labels.includes('ghr-team:alpha')) {
-          expect(labels).not.toContain('ghr-team:beta');
-          expect(labels).not.toContain('ghr-ec2-instance-type:c7i.large');
-        } else if (labels.includes('ghr-team:beta')) {
-          expect(labels).not.toContain('ghr-team:alpha');
-          expect(labels).not.toContain('ghr-ec2-instance-type:m7a.large');
-        } else {
-          throw new Error(`Unexpected labels combination: ${labels.join(',')}`);
-        }
-      }
     });
   });
 
   describe('on repo level', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test';
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      expectedRunnerParams.runnerType = 'Repo';
-      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
-      //   `--url https://github.enterprise.something/${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
-      //   `--token 1234abcd`,
-      // ];
-    });
-
     it('gets the current repo level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Repo',
-        runnerOwner: `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
-        owner: TEST_DATA_SINGLE.repositoryOwner,
-        repo: TEST_DATA_SINGLE.repositoryName,
-      });
-    });
-
-    it('uses the default runner max count', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = undefined;
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
-        owner: TEST_DATA_SINGLE.repositoryOwner,
-        repo: TEST_DATA_SINGLE.repositoryName,
-      });
+      await expectCurrentRunners('Repo', repositoryRunnerOwner);
     });
 
     it('creates a runner with correct config and labels', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('creates a runner and ensure the group argument is ignored', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      await createProviderRunners({
+        githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams('Repo', repositoryRunnerOwner));
     });
 
     it('converts an unexpected EC2 creation error into a retryable result', async () => {
       mockCreateRunner.mockRejectedValueOnce(new Error('unexpected EC2 error'));
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-    });
-
-    it('converts an unexpected provider error into a retryable result', async () => {
-      vi.mocked(createRunner).mockResolvedValue(undefined as never);
-
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-    });
-  });
-
-  describe('Batch processing', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.RUNNERS_MAXIMUM_COUNT = '10';
-    });
-
-    const createTestMessages = (
-      count: number,
-      overrides: Partial<ActionRequestMessageSQS>[] = [],
-    ): ActionRequestMessageSQS[] => {
-      return Array.from({ length: count }, (_, i) => ({
-        ...TEST_DATA_SINGLE,
-        id: i + 1,
-        messageId: `message-${i}`,
-        ...overrides[i],
-      }));
-    };
-
-    it('Should handle multiple messages for the same organization', async () => {
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(1);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 3,
-          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+      await expect(
+        createProviderRunners({
+          githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
         }),
-      );
-    });
-
-    it('Should handle multiple messages for different organizations', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'org1' },
-        { repositoryOwner: 'org2' },
-        { repositoryOwner: 'org1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'org1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'org2',
-        }),
-      );
-    });
-
-    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'owner1/repo1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'owner1/repo2',
-        }),
-      );
-    });
-
-    it('Should reject messages when maximum runners limit is reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
-      mockListRunners.mockImplementation(async () => [
-        {
-          instanceId: 'i-existing',
-          launchTime: new Date(),
-          type: 'Org',
-          owner: TEST_DATA_SINGLE.repositoryOwner,
-        },
-      ]);
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).not.toHaveBeenCalled(); // No runners should be created
-      expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
-    });
-
-    it('Should handle partial EC2 instance creation failures', async () => {
-      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should reject only retryable partial EC2 instance creation failures', async () => {
-      mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345'], 1, 1));
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(rejectedMessages).toEqual(['message-0']);
-    });
-
-    it('does not retry partial EC2 instance creation failures that are not retryable', async () => {
-      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 0, 2));
-
-      const rejectedMessages = await scaleUpModule.scaleUp(createTestMessages(3));
-
-      expect(rejectedMessages).toEqual([]);
-    });
-
-    it('Should filter out invalid event types for ephemeral runners', async () => {
-      const messages = createTestMessages(3, [
-        { eventType: 'workflow_job' },
-        { eventType: 'check_run' },
-        { eventType: 'workflow_job' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only workflow_job events processed
-        }),
-      );
-      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
-    });
-
-    it('Should skip invalid repo owner types but not reject them', async () => {
-      const messages = createTestMessages(3, [
-        { repoOwnerType: 'Organization' },
-        { repoOwnerType: 'User' }, // Invalid for org-level runners
-        { repoOwnerType: 'Organization' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only Organization events processed
-        }),
-      );
-      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
-    });
-
-    it('Should skip messages when jobs are not queued', async () => {
-      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
-        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
-        return {
-          data: {
-            status: isQueued ? 'queued' : 'completed',
-          },
-        };
-      });
-
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only queued jobs processed
-        }),
-      );
-    });
-
-    it('Should create separate GitHub clients for different installations', async () => {
-      // Override the default mock to return different installation IDs
-      mockOctokit.apps.getOrgInstallation.mockReset();
-      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
-        data: {
-          id: params.org === 'org1' ? 100 : 200,
-        },
-      }));
-
-      const messages = createTestMessages(2, [
-        { repositoryOwner: 'org1', installationId: 0 },
-        { repositoryOwner: 'org2', installationId: 0 },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, 'https://github.enterprise.something/api/v3');
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, 'https://github.enterprise.something/api/v3');
-    });
-
-    it('Should resolve installation again when event installation belongs to another app', async () => {
-      mockOctokit.apps.getOrgInstallation.mockReset();
-      mockOctokit.apps.getOrgInstallation.mockImplementation(() => ({
-        data: {
-          id: 123,
-        },
-      }));
-
-      mockedInstallationAuth.mockRejectedValueOnce({ status: 404 }).mockResolvedValueOnce({
-        type: 'token',
-        tokenType: 'installation',
-        token: 'token',
-        createdAt: 'some-date',
-        expiresAt: 'some-date',
-        permissions: {},
-        repositorySelection: 'all',
-        installationId: 123,
-      });
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-
-      expect(mockOctokit.apps.getOrgInstallation).toHaveBeenCalledWith({ org: TEST_DATA_SINGLE.repositoryOwner });
-      expect(mockedInstallationAuth).toHaveBeenNthCalledWith(
-        1,
-        TEST_DATA_SINGLE.installationId,
-        'https://github.enterprise.something/api/v3',
-      );
-      expect(mockedInstallationAuth).toHaveBeenNthCalledWith(2, 123, 'https://github.enterprise.something/api/v3');
-    });
-
-    it('Should reuse GitHub clients for same installation', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
-      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
-    });
-
-    it('Should return empty array when no valid messages to process', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      const messages = createTestMessages(2, [
-        { eventType: 'check_run' }, // Invalid for ephemeral
-        { eventType: 'check_run' }, // Invalid for ephemeral
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).not.toHaveBeenCalled();
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should handle unlimited runners configuration', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
-      const messages = createTestMessages(10);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(listEC2Runners).not.toHaveBeenCalled(); // No need to check current runners
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 10, // All messages processed
-        }),
-      );
-    });
-
-    it('Should assume job is queued when isJobQueued throws (fail-open)', async () => {
-      mockOctokit.actions.getJobForWorkflowRun.mockRejectedValue(new Error('GitHub API 502'));
-
-      const messages = createTestMessages(2);
-      await scaleUpModule.scaleUp(messages);
-
-      // All messages processed despite API error — fail-open prevents job drops
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-        }),
-      );
-    });
-
-    it('Should skip unsupported event types without scaling up', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      const messages = createTestMessages(1).map((m) => ({ ...m, eventType: 'check_run' as const }));
-
-      await expect(scaleUpModule.scaleUp(messages)).resolves.toEqual([]);
-      expect(createRunner).not.toHaveBeenCalled();
+      ).resolves.toEqual({ instances: [], retryableErrorCount: 1, nonRetryableErrorCount: 0 });
     });
   });
 });
 
 describe('scaleUp with public GH', () => {
-  it('checks queued workflows', async () => {
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
-      job_id: TEST_DATA_SINGLE.id,
-      owner: TEST_DATA_SINGLE.repositoryOwner,
-      repo: TEST_DATA_SINGLE.repositoryName,
-    });
-  });
-
-  it('not checking queued workflows', async () => {
-    process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
-  });
-
-  it('does not list runners when no workflows are queued', async () => {
-    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
-      data: { status: 'completed' },
-    }));
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(listEC2Runners).not.toBeCalled();
-  });
-
   describe('on org level', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test';
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-    });
-
     it('gets the current org level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Org',
-        runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-      });
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+      await expectCurrentRunners('Org', runnerOwner);
     });
 
     it('creates a runner with correct config', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('creates a runner with labels in s specific group', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      mockCreateRunner.mockResolvedValueOnce(createRunnerResult([]));
+      await createProviderRunners();
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams());
     });
   });
 
   describe('on repo level', () => {
-    beforeEach(() => {
-      mockSSMClient.reset();
-
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test';
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      expectedRunnerParams.runnerType = 'Repo';
-      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
-    });
-
     it('gets the current repo level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Repo',
-        runnerOwner: `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
-        owner: TEST_DATA_SINGLE.repositoryOwner,
-        repo: TEST_DATA_SINGLE.repositoryName,
-      });
+      await expectCurrentRunners('Repo', repositoryRunnerOwner);
     });
 
     it('creates a runner with correct config and labels', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      await createProviderRunners({
+        githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams('Repo', repositoryRunnerOwner));
     });
 
     it('creates a runner with correct config and labels and on demand failover enabled.', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.ENABLE_ON_DEMAND_FAILOVER_FOR_ERRORS = JSON.stringify(['InsufficientInstanceCapacity']);
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith({
-        ...expectedRunnerParams,
-        onDemandFailoverOnError: ['InsufficientInstanceCapacity'],
+      process.env.ENABLE_ON_DEMAND_FAILOVER_FOR_ERRORS = '["InsufficientInstanceCapacity"]';
+      await createProviderRunners({
+        githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
       });
+      expect(mockCreateRunner).toHaveBeenCalledWith(
+        expectedRunnerParams('Repo', repositoryRunnerOwner, {
+          onDemandFailoverOnError: ['InsufficientInstanceCapacity'],
+        }),
+      );
     });
 
     it('creates a runner with correct config and labels and custom scale errors enabled.', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.SCALE_ERRORS = JSON.stringify(['RequestLimitExceeded']);
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith({
-        ...expectedRunnerParams,
-        scaleErrors: ['RequestLimitExceeded'],
+      process.env.SCALE_ERRORS = '["RequestLimitExceeded"]';
+      await createProviderRunners({
+        githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
       });
-    });
-
-    it('creates a runner and ensure the group argument is ignored', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('ephemeral runners only run with workflow_job event, others should fail.', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-
-      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
-      USER_REPO_TEST_DATA[0].eventType = 'check_run';
-
-      await expect(scaleUpModule.scaleUp(USER_REPO_TEST_DATA)).resolves.toEqual(['foobar']);
-    });
-
-    it('creates a ephemeral runner with JIT config.', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value: 'TEST_JIT_CONFIG_REPO',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('creates a ephemeral runner with registration token.', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.ENABLE_JIT_CONFIG = 'false';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value: '--url https://github.com/Codertocat/hello-world --token 1234abcd --ephemeral',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('JIT config is ignored for non-ephemeral runners.', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      process.env.ENABLE_JIT_CONFIG = 'true';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-      process.env.RUNNER_LABELS = 'jit';
-      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.getJobForWorkflowRun).not.toBeCalled();
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value: '--url https://github.com/Codertocat/hello-world --token 1234abcd --labels jit',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('creates a ephemeral runner after checking job is queued.', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.ENABLE_JOB_QUEUED_CHECK = 'true';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalled();
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('disable auto update on the runner.', async () => {
-      process.env.DISABLE_RUNNER_AUTOUPDATE = 'true';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('Scaling error should return failed message IDs so retry can be triggered.', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-    });
-  });
-
-  describe('Batch processing', () => {
-    const createTestMessages = (
-      count: number,
-      overrides: Partial<ActionRequestMessageSQS>[] = [],
-    ): ActionRequestMessageSQS[] => {
-      return Array.from({ length: count }, (_, i) => ({
-        ...TEST_DATA_SINGLE,
-        id: i + 1,
-        messageId: `message-${i}`,
-        ...overrides[i],
-      }));
-    };
-
-    beforeEach(() => {
-      setDefaults();
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.RUNNERS_MAXIMUM_COUNT = '10';
-    });
-
-    it('Should handle multiple messages for the same organization', async () => {
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(1);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 3,
-          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-        }),
-      );
-    });
-
-    it('Should handle multiple messages for different organizations', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'org1' },
-        { repositoryOwner: 'org2' },
-        { repositoryOwner: 'org1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'org1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'org2',
-        }),
-      );
-    });
-
-    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'owner1/repo1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'owner1/repo2',
-        }),
-      );
-    });
-
-    it('Should reject messages when maximum runners limit is reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
-      mockListRunners.mockImplementation(async () => [
-        {
-          instanceId: 'i-existing',
-          launchTime: new Date(),
-          type: 'Org',
-          owner: TEST_DATA_SINGLE.repositoryOwner,
-        },
-      ]);
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).not.toHaveBeenCalled(); // No runners should be created
-      expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
-    });
-
-    it('Should handle partial EC2 instance creation failures', async () => {
-      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should filter out invalid event types for ephemeral runners', async () => {
-      const messages = createTestMessages(3, [
-        { eventType: 'workflow_job' },
-        { eventType: 'check_run' },
-        { eventType: 'workflow_job' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only workflow_job events processed
-        }),
-      );
-      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
-    });
-
-    it('Should skip invalid repo owner types but not reject them', async () => {
-      const messages = createTestMessages(3, [
-        { repoOwnerType: 'Organization' },
-        { repoOwnerType: 'User' }, // Invalid for org-level runners
-        { repoOwnerType: 'Organization' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only Organization events processed
-        }),
-      );
-      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
-    });
-
-    it('Should skip messages when jobs are not queued', async () => {
-      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
-        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
-        return {
-          data: {
-            status: isQueued ? 'queued' : 'completed',
-          },
-        };
-      });
-
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only queued jobs processed
-        }),
-      );
-    });
-
-    it('Should create separate GitHub clients for different installations', async () => {
-      // Override the default mock to return different installation IDs
-      mockOctokit.apps.getOrgInstallation.mockReset();
-      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
-        data: {
-          id: params.org === 'org1' ? 100 : 200,
-        },
-      }));
-
-      const messages = createTestMessages(2, [
-        { repositoryOwner: 'org1', installationId: 0 },
-        { repositoryOwner: 'org2', installationId: 0 },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, '');
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, '');
-    });
-
-    it('Should reuse GitHub clients for same installation', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
-      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
-    });
-
-    it('Should return empty array when no valid messages to process', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      const messages = createTestMessages(2, [
-        { eventType: 'check_run' }, // Invalid for ephemeral
-        { eventType: 'check_run' }, // Invalid for ephemeral
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).not.toHaveBeenCalled();
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should handle unlimited runners configuration', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
-      const messages = createTestMessages(10);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(listEC2Runners).not.toHaveBeenCalled(); // No need to check current runners
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 10, // All messages processed
-        }),
+      expect(mockCreateRunner).toHaveBeenCalledWith(
+        expectedRunnerParams('Repo', repositoryRunnerOwner, { scaleErrors: ['RequestLimitExceeded'] }),
       );
     });
   });
 });
 
 describe('scaleUp with Github Data Residency', () => {
-  beforeEach(() => {
-    process.env.GHES_URL = 'https://companyname.ghe.com';
-  });
-
-  it('checks queued workflows', async () => {
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(mockOctokit.actions.getJobForWorkflowRun).toBeCalledWith({
-      job_id: TEST_DATA_SINGLE.id,
-      owner: TEST_DATA_SINGLE.repositoryOwner,
-      repo: TEST_DATA_SINGLE.repositoryName,
-    });
-  });
-
-  it('does not list runners when no workflows are queued', async () => {
-    mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
-      data: { total_count: 0 },
-    }));
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(listEC2Runners).not.toBeCalled();
-  });
-
   describe('on org level', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test-';
-      process.env.RUNNER_GROUP_NAME = 'Default';
-      process.env.SSM_CONFIG_PATH = '/github-action-runners/default/runners/config';
-      process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-      process.env.RUNNER_LABELS = 'label1,label2';
-
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      mockSSMClient.reset();
-    });
-
     it('gets the current org level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Org',
-        runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('does create a runner if maximum is set to -1', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).not.toHaveBeenCalled();
-      expect(createRunner).toHaveBeenCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-      });
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
+      await expectCurrentRunners('Org', runnerOwner);
     });
 
     it('creates a runner with correct config', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('creates a runner with labels in a specific group', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      await createProviderRunners();
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams());
     });
 
     it('creates a runner with ami id override from ssm parameter', async () => {
       process.env.AMI_ID_SSM_PARAMETER_NAME = 'my-ami-id-param';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith({ ...expectedRunnerParams, amiIdSsmParameterName: 'my-ami-id-param' });
+      await createProviderRunners();
+      expect(mockCreateRunner).toHaveBeenCalledWith(
+        expectedRunnerParams('Org', runnerOwner, { amiIdSsmParameterName: 'my-ami-id-param' }),
+      );
     });
-
-    it('returns a retryable failure if runner group lookup fails for ephemeral runners', async () => {
-      process.env.RUNNER_GROUP_NAME = 'test-runner-group';
-      mockSSMgetParameter.mockImplementation(async () => {
-        throw new Error('ParameterNotFound');
-      });
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
-      expect(mockTerminateRunner).toHaveBeenCalledWith('i-12345');
-    });
-
-    it('Discards event if it is a User repo and org level runners is enabled', async () => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      const USER_REPO_TEST_DATA = structuredClone(TEST_DATA);
-      USER_REPO_TEST_DATA[0].repoOwnerType = 'User';
-      await scaleUpModule.scaleUp(USER_REPO_TEST_DATA);
-      expect(createRunner).not.toHaveBeenCalled();
-    });
-
-    it('create SSM parameter for runner group id if it does not exist', async () => {
-      mockSSMgetParameter.mockImplementation(async () => {
-        throw new Error('ParameterNotFound');
-      });
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
-      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 2);
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`,
-        Value: '1',
-        Type: 'String',
-      });
-    });
-
-    it('Does not create SSM parameter for runner group id if it exists', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.paginate).toHaveBeenCalledTimes(0);
-      expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 1);
-    });
-
-    it('create start runner config for ephemeral runners ', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).toBeCalledWith({
-        org: TEST_DATA_SINGLE.repositoryOwner,
-        name: 'unit-test-i-12345',
-        runner_group_id: 1,
-        labels: ['label1', 'label2'],
-      });
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value: 'TEST_JIT_CONFIG_ORG',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-
-    it('create start runner config for non-ephemeral runners ', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.generateRunnerJitconfigForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).toBeCalled();
-      expect(mockSSMClient).toHaveReceivedNthSpecificCommandWith(1, PutParameterCommand, {
-        Name: '/github-action-runners/default/runners/config/i-12345',
-        Value:
-          '--url https://companyname.ghe.com/Codertocat --token 1234abcd ' +
-          '--labels label1,label2 --runnergroup Default',
-        Type: 'SecureString',
-        Tags: [
-          {
-            Key: 'InstanceId',
-            Value: 'i-12345',
-          },
-        ],
-      });
-    });
-    it.each(RUNNER_TYPES)(
-      'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
-      async (type: RunnerType) => {
-        process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
-        process.env.RUNNERS_MAXIMUM_COUNT = '40';
-        mockCreateRunner.mockImplementation(async () => {
-          return createRunnerResult(instances);
-        });
-        mockListRunners.mockImplementation(async () => {
-          return [];
-        });
-        const startTime = performance.now();
-        const instances = [
-          'i-1234',
-          'i-5678',
-          'i-5567',
-          'i-5569',
-          'i-5561',
-          'i-5560',
-          'i-5566',
-          'i-5536',
-          'i-5526',
-          'i-5516',
-          'i-122',
-          'i-123',
-          'i-124',
-          'i-125',
-          'i-126',
-          'i-127',
-          'i-128',
-          'i-129',
-          'i-130',
-          'i-131',
-          'i-132',
-          'i-133',
-          'i-134',
-          'i-135',
-          'i-136',
-          'i-137',
-          'i-138',
-          'i-139',
-          'i-140',
-          'i-141',
-          'i-142',
-          'i-143',
-          'i-144',
-          'i-145',
-          'i-146',
-          'i-147',
-          'i-148',
-          'i-149',
-          'i-150',
-          'i-151',
-        ];
-        await scaleUpModule.scaleUp(TEST_DATA);
-        const endTime = performance.now();
-        expect(endTime - startTime).toBeGreaterThan(1000);
-        expect(mockSSMClient).toHaveReceivedCommandTimes(PutParameterCommand, 40);
-      },
-      10000,
-    );
   });
+
   describe('on repo level', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      process.env.RUNNER_NAME_PREFIX = 'unit-test';
-      expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-      expectedRunnerParams.runnerType = 'Repo';
-      expectedRunnerParams.runnerOwner = `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`;
-      //   `--url https://companyname.ghe.com${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
-      //   `--token 1234abcd`,
-      // ];
-    });
-
     it('gets the current repo level runners', async () => {
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(listEC2Runners).toBeCalledWith({
-        environment: 'unit-test-environment',
-        runnerType: 'Repo',
-        runnerOwner: `${TEST_DATA_SINGLE.repositoryOwner}/${TEST_DATA_SINGLE.repositoryName}`,
-      });
-    });
-
-    it('does not create a token when maximum runners has been reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '1';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).not.toBeCalled();
-    });
-
-    it('creates a token when maximum runners has not been reached', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'false';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForOrg).not.toBeCalled();
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
-        owner: TEST_DATA_SINGLE.repositoryOwner,
-        repo: TEST_DATA_SINGLE.repositoryName,
-      });
-    });
-
-    it('uses the default runner max count', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = undefined;
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(mockOctokit.actions.createRegistrationTokenForRepo).toBeCalledWith({
-        owner: TEST_DATA_SINGLE.repositoryOwner,
-        repo: TEST_DATA_SINGLE.repositoryName,
-      });
+      await expectCurrentRunners('Repo', repositoryRunnerOwner);
     });
 
     it('creates a runner with correct config and labels', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
-    });
-
-    it('creates a runner and ensure the group argument is ignored', async () => {
-      process.env.RUNNER_LABELS = 'label1,label2';
-      process.env.RUNNER_GROUP_NAME = 'TEST_GROUP_IGNORED';
-      await scaleUpModule.scaleUp(TEST_DATA);
-      expect(createRunner).toBeCalledWith(expectedRunnerParams);
+      await createProviderRunners({
+        githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
+      });
+      expect(mockCreateRunner).toHaveBeenCalledWith(expectedRunnerParams('Repo', repositoryRunnerOwner));
     });
 
     it('converts an unexpected EC2 creation error into a retryable result', async () => {
       mockCreateRunner.mockRejectedValueOnce(new Error('unexpected EC2 error'));
-      await expect(scaleUpModule.scaleUp(TEST_DATA)).resolves.toEqual(['foobar']);
-    });
-  });
-
-  describe('Batch processing', () => {
-    const createTestMessages = (
-      count: number,
-      overrides: Partial<ActionRequestMessageSQS>[] = [],
-    ): ActionRequestMessageSQS[] => {
-      return Array.from({ length: count }, (_, i) => ({
-        ...TEST_DATA_SINGLE,
-        id: i + 1,
-        messageId: `message-${i}`,
-        ...overrides[i],
-      }));
-    };
-
-    beforeEach(() => {
-      setDefaults();
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      process.env.RUNNERS_MAXIMUM_COUNT = '10';
-    });
-
-    it('Should handle multiple messages for the same organization', async () => {
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(1);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 3,
-          runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
+      await expect(
+        createProviderRunners({
+          githubRunnerConfig: { runnerType: 'Repo', runnerOwner: repositoryRunnerOwner },
         }),
-      );
+      ).resolves.toEqual({ instances: [], retryableErrorCount: 1, nonRetryableErrorCount: 0 });
     });
-
-    it('Should handle multiple messages for different organizations', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'org1' },
-        { repositoryOwner: 'org2' },
-        { repositoryOwner: 'org1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'org1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'org2',
-        }),
-      );
-    });
-
-    it('Should handle multiple messages for different repositories when org-level is disabled', async () => {
-      process.env.ENABLE_ORGANIZATION_RUNNERS = 'false';
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo2' },
-        { repositoryOwner: 'owner1', repositoryName: 'repo1' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledTimes(2);
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2,
-          runnerOwner: 'owner1/repo1',
-        }),
-      );
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1,
-          runnerOwner: 'owner1/repo2',
-        }),
-      );
-    });
-
-    it('Should reject messages when maximum runners limit is reached', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '2';
-      mockListRunners.mockImplementation(async () => [
-        {
-          instanceId: 'i-existing',
-          launchTime: new Date(),
-          type: 'Org',
-          owner: TEST_DATA_SINGLE.repositoryOwner,
-        },
-      ]);
-
-      const messages = createTestMessages(5);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 1, // 2 max - 1 existing = 1 new
-        }),
-      );
-      expect(rejectedMessages).toHaveLength(4); // 5 requested - 1 created = 4 rejected
-    });
-
-    it('Should handle partial EC2 instance creation failures', async () => {
-      mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
-
-      const messages = createTestMessages(3);
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(rejectedMessages).toHaveLength(2); // 3 requested - 1 created = 2 failed
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should filter out invalid event types for ephemeral runners', async () => {
-      const messages = createTestMessages(3, [
-        { eventType: 'workflow_job' },
-        { eventType: 'check_run' },
-        { eventType: 'workflow_job' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only workflow_job events processed
-        }),
-      );
-      expect(rejectedMessages).toContain('message-1'); // check_run event rejected
-    });
-
-    it('Should skip invalid repo owner types but not reject them', async () => {
-      const messages = createTestMessages(3, [
-        { repoOwnerType: 'Organization' },
-        { repoOwnerType: 'User' }, // Invalid for org-level runners
-        { repoOwnerType: 'Organization' },
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only Organization events processed
-        }),
-      );
-      expect(rejectedMessages).not.toContain('message-1'); // User repo not rejected, just skipped
-    });
-
-    it('Should skip messages when jobs are not queued', async () => {
-      mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
-        const isQueued = params.job_id === 1 || params.job_id === 3; // Only jobs 1 and 3 are queued
-        return {
-          data: {
-            status: isQueued ? 'queued' : 'completed',
-          },
-        };
-      });
-
-      const messages = createTestMessages(3);
-      await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 2, // Only queued jobs processed
-        }),
-      );
-    });
-
-    it('Should create separate GitHub clients for different installations', async () => {
-      mockOctokit.apps.getOrgInstallation.mockImplementation((params) => ({
-        data: {
-          id: params.org === 'org1' ? 100 : 200,
-        },
-      }));
-
-      const messages = createTestMessages(2, [
-        { repositoryOwner: 'org1', installationId: 0 },
-        { repositoryOwner: 'org2', installationId: 0 },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(3); // 1 app client, 2 repo installation clients
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(100, '');
-      expect(mockedInstallationAuth).toHaveBeenCalledWith(200, '');
-    });
-
-    it('Should reuse GitHub clients for same installation', async () => {
-      const messages = createTestMessages(3, [
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-        { repositoryOwner: 'same-org' },
-      ]);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(2); // 1 app client, 1 installation client
-      expect(mockedInstallationAuth).toHaveBeenCalledTimes(1);
-    });
-
-    it('Should return empty array when no valid messages to process', async () => {
-      process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-      const messages = createTestMessages(2, [
-        { eventType: 'check_run' }, // Invalid for ephemeral
-        { eventType: 'check_run' }, // Invalid for ephemeral
-      ]);
-
-      const rejectedMessages = await scaleUpModule.scaleUp(messages);
-
-      expect(createRunner).not.toHaveBeenCalled();
-      expect(rejectedMessages).toEqual(['message-0', 'message-1']);
-    });
-
-    it('Should handle unlimited runners configuration', async () => {
-      process.env.RUNNERS_MAXIMUM_COUNT = '-1';
-      const messages = createTestMessages(10);
-
-      await scaleUpModule.scaleUp(messages);
-
-      expect(listEC2Runners).not.toHaveBeenCalled(); // No need to check current runners
-      expect(createRunner).toHaveBeenCalledWith(
-        expect.objectContaining({
-          numberOfRunners: 10, // All messages processed
-        }),
-      );
-    });
-  });
-});
-
-describe('Retry mechanism tests', () => {
-  beforeEach(() => {
-    process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-    process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-    process.env.ENABLE_JOB_QUEUED_CHECK = 'true';
-    process.env.RUNNERS_MAXIMUM_COUNT = '10';
-    expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
-    mockSSMClient.reset();
-  });
-
-  const createTestMessages = (
-    count: number,
-    overrides: Partial<ActionRequestMessageSQS>[] = [],
-  ): ActionRequestMessageSQS[] => {
-    return Array.from({ length: count }, (_, i) => ({
-      ...TEST_DATA_SINGLE,
-      id: i + 1,
-      messageId: `message-${i + 1}`,
-      ...overrides[i],
-    }));
-  };
-
-  it('calls publishRetryMessage for each valid message when job is queued', async () => {
-    const messages = createTestMessages(3);
-    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890', 'i-abcdef'])); // Create all requested runners
-
-    await scaleUpModule.scaleUp(messages);
-
-    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(3);
-    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        id: 1,
-        messageId: 'message-1',
-      }),
-    );
-    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        id: 2,
-        messageId: 'message-2',
-      }),
-    );
-    expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({
-        id: 3,
-        messageId: 'message-3',
-      }),
-    );
-  });
-
-  it('does not call publishRetryMessage when job is not queued', async () => {
-    mockOctokit.actions.getJobForWorkflowRun.mockImplementation((params) => {
-      const isQueued = params.job_id === 1; // Only job 1 is queued
-      return {
-        data: {
-          status: isQueued ? 'queued' : 'completed',
-        },
-      };
-    });
-
-    const messages = createTestMessages(3);
-
-    await scaleUpModule.scaleUp(messages);
-
-    // Only message with id 1 should trigger retry
-    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(1);
-    expect(mockPublishRetryMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 1,
-        messageId: 'message-1',
-      }),
-    );
-  });
-
-  it('does not call publishRetryMessage when maximum runners is reached and messages are marked invalid', async () => {
-    process.env.RUNNERS_MAXIMUM_COUNT = '0'; // No runners can be created
-
-    const messages = createTestMessages(2);
-
-    await scaleUpModule.scaleUp(messages);
-
-    // Verify listEC2Runners is called to check current runner count
-    expect(listEC2Runners).toHaveBeenCalledWith({
-      environment: 'unit-test-environment',
-      runnerType: 'Org',
-      runnerOwner: TEST_DATA_SINGLE.repositoryOwner,
-    });
-
-    // publishRetryMessage should NOT be called because messages are marked as invalid
-    // Invalid messages go back to the SQS queue and will be retried there
-    expect(mockPublishRetryMessage).not.toHaveBeenCalled();
-    expect(createRunner).not.toHaveBeenCalled();
-  });
-
-  it('calls publishRetryMessage with correct message structure including retry counter', async () => {
-    const message = {
-      ...TEST_DATA_SINGLE,
-      messageId: 'test-message-id',
-      retryCounter: 2,
-    };
-
-    await scaleUpModule.scaleUp([message]);
-
-    expect(mockPublishRetryMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: message.id,
-        messageId: 'test-message-id',
-        retryCounter: 2,
-      }),
-    );
-  });
-
-  it('calls publishRetryMessage when ENABLE_JOB_QUEUED_CHECK is false', async () => {
-    process.env.ENABLE_JOB_QUEUED_CHECK = 'false';
-    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890'])); // Create all requested runners
-
-    const messages = createTestMessages(2);
-
-    await scaleUpModule.scaleUp(messages);
-
-    // Should always call publishRetryMessage when queue check is disabled
-    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(2);
-    expect(mockOctokit.actions.getJobForWorkflowRun).not.toHaveBeenCalled();
-  });
-
-  it('calls publishRetryMessage for each message in a multi-runner scenario', async () => {
-    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345', 'i-67890', 'i-abcdef', 'i-11111', 'i-22222'])); // Create all requested runners
-    const messages = createTestMessages(5);
-
-    await scaleUpModule.scaleUp(messages);
-
-    expect(mockPublishRetryMessage).toHaveBeenCalledTimes(5);
-    messages.forEach((msg, index) => {
-      expect(mockPublishRetryMessage).toHaveBeenNthCalledWith(
-        index + 1,
-        expect.objectContaining({
-          id: msg.id,
-          messageId: msg.messageId,
-        }),
-      );
-    });
-  });
-
-  it('calls publishRetryMessage after runner creation', async () => {
-    const messages = createTestMessages(1);
-    mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345'])); // Create the requested runner
-
-    const callOrder: string[] = [];
-    mockPublishRetryMessage.mockImplementation(() => {
-      callOrder.push('publishRetryMessage');
-      return Promise.resolve();
-    });
-    mockCreateRunner.mockImplementation(async () => {
-      callOrder.push('createRunner');
-      return createRunnerResult(['i-12345']);
-    });
-
-    await scaleUpModule.scaleUp(messages);
-
-    expect(callOrder).toEqual(['createRunner', 'publishRetryMessage']);
   });
 });
 
 describe('useDedicatedHost', () => {
-  beforeEach(() => {
-    process.env.ENABLE_ORGANIZATION_RUNNERS = 'true';
-    process.env.ENABLE_EPHEMERAL_RUNNERS = 'true';
-    process.env.RUNNER_NAME_PREFIX = 'unit-test-';
-    process.env.RUNNER_GROUP_NAME = 'Default';
-    process.env.SSM_CONFIG_PATH = '/github-action-runners/default/runners/config';
-    process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
-    process.env.RUNNER_LABELS = 'label1,label2';
-  });
-
   it('defaults to false when USE_DEDICATED_HOST env var is not set', async () => {
     delete process.env.USE_DEDICATED_HOST;
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(createRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: false }));
+    await createProviderRunners();
+    expect(mockCreateRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: false }));
   });
 
   it('is true when USE_DEDICATED_HOST is "true"', async () => {
     process.env.USE_DEDICATED_HOST = 'true';
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(createRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: true }));
+    await createProviderRunners();
+    expect(mockCreateRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: true }));
   });
 
   it('is false when USE_DEDICATED_HOST is "false"', async () => {
     process.env.USE_DEDICATED_HOST = 'false';
-    await scaleUpModule.scaleUp(TEST_DATA);
-    expect(createRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: false }));
+    await createProviderRunners();
+    expect(mockCreateRunner).toHaveBeenCalledWith(expect.objectContaining({ useDedicatedHost: false }));
   });
 });
-
-function defaultOctokitMockImpl() {
-  mockOctokit.actions.getJobForWorkflowRun.mockImplementation(() => ({
-    data: {
-      status: 'queued',
-    },
-  }));
-  mockOctokit.paginate.mockImplementation(() => [
-    {
-      id: 1,
-      name: 'Default',
-    },
-  ]);
-  mockOctokit.actions.generateRunnerJitconfigForOrg.mockImplementation(({ labels }: { labels: string[] }) => ({
-    data: {
-      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
-      encoded_jit_config: 'TEST_JIT_CONFIG_ORG',
-    },
-  }));
-  mockOctokit.actions.generateRunnerJitconfigForRepo.mockImplementation(({ labels }: { labels: string[] }) => ({
-    data: {
-      runner: { id: 9876543210, labels: labels.map((name: string) => ({ name })) },
-      encoded_jit_config: 'TEST_JIT_CONFIG_REPO',
-    },
-  }));
-  mockOctokit.checks.get.mockImplementation(() => ({
-    data: {
-      status: 'queued',
-    },
-  }));
-
-  const mockTokenReturnValue = {
-    data: {
-      token: '1234abcd',
-    },
-  };
-  const mockInstallationIdReturnValueOrgs = {
-    data: {
-      id: TEST_DATA_SINGLE.installationId,
-    },
-  };
-  const mockInstallationIdReturnValueRepos = {
-    data: {
-      id: TEST_DATA_SINGLE.installationId,
-    },
-  };
-
-  mockOctokit.actions.createRegistrationTokenForOrg.mockImplementation(() => mockTokenReturnValue);
-  mockOctokit.actions.createRegistrationTokenForRepo.mockImplementation(() => mockTokenReturnValue);
-  mockOctokit.apps.getOrgInstallation.mockImplementation(() => mockInstallationIdReturnValueOrgs);
-  mockOctokit.apps.getRepoInstallation.mockImplementation(() => mockInstallationIdReturnValueRepos);
-}
-
-function defaultSSMGetParameterMockImpl() {
-  mockSSMgetParameter.mockImplementation(async (name: string) => {
-    if (name === `${process.env.SSM_CONFIG_PATH}/runner-group/${process.env.RUNNER_GROUP_NAME}`) {
-      return '1';
-    } else if (name === `${process.env.PARAMETER_GITHUB_APP_ID_NAME}`) {
-      return `${process.env.GITHUB_APP_ID}`;
-    } else {
-      throw new Error(`ParameterNotFound: ${name}`);
-    }
-  });
-}
 
 describe('parseEc2OverrideConfig', () => {
   describe('Basic Fleet Overrides', () => {


### PR DESCRIPTION
## Description

- Move generic scale-up and scale-down orchestration tests from the EC2 provider package into the control-plane package.
- Test orchestration through the runner-provider interfaces and registry.
- Keep EC2 resource operations and dynamic configuration coverage beside the EC2 provider.
- Remove direct EC2 provider test imports and mocks of control-plane modules.

Production behavior is unchanged.

## Test Plan

- `cd lambdas && yarn test` (all 8 projects passed)
- Focused control-plane suites: 226 tests passed
- Focused EC2 provider suites: 158 tests passed
- ESLint and Prettier checks passed for control-plane and runner-providers
- Exact test-title inventory: 276 before and after, with no additions or removals
- `git diff --check`

## Related Issues

Closes #5236

Follow-up to #5234
