### PR TITLE
refactor(runner-providers): centralize shared runner contracts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main", "develop", "v1" ]
   pull_request:
-    branches: [ "main", "develop", "v1" ]
     paths-ignore:
       - '**/*.md'
   schedule:

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -2,8 +2,6 @@ name: Build lambdas
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'lambdas/**'
       - '.github/workflows/lambda.yml'

--- a/.github/workflows/ovs.yml
+++ b/.github/workflows/ovs.yml
@@ -1,7 +1,6 @@
 name: OSV-Scanner
 on:
   pull_request:
-    branches: [main]
   merge_group:
     branches: [main]
 

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -64,25 +64,25 @@ const MINIMUM_TIME_RUNNING = 15;
 
 const ec2InstancesRegistered = [
   {
-    instanceId: 'i-1-idle',
+    id: 'i-1-idle',
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
   },
   {
-    instanceId: 'i-2-busy',
+    id: 'i-2-busy',
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
   },
   {
-    instanceId: 'i-3-offline',
+    id: 'i-3-offline',
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
   },
   {
-    instanceId: 'i-4-idle-older-than-minimum-time-running',
+    id: 'i-4-idle-older-than-minimum-time-running',
     launchTime: moment(new Date())
       .subtract(MINIMUM_TIME_RUNNING + 3, 'minutes')
       .toDate(),
@@ -258,7 +258,7 @@ describe('Test simple pool.', () => {
       mockListRunners.mockImplementation(async () => [
         ...ec2InstancesRegistered,
         {
-          instanceId: 'i-4-still-booting',
+          id: 'i-4-still-booting',
           launchTime: moment(new Date())
             .subtract(MINIMUM_TIME_RUNNING - 3, 'minutes')
             .toDate(),
@@ -266,7 +266,7 @@ describe('Test simple pool.', () => {
           owner: ORG,
         },
         {
-          instanceId: 'i-5-orphan',
+          id: 'i-5-orphan',
           launchTime: moment(new Date())
             .subtract(MINIMUM_TIME_RUNNING + 3, 'minutes')
             .toDate(),
@@ -289,7 +289,7 @@ describe('Test simple pool.', () => {
       mockListRunners.mockImplementation(async () => [
         ...ec2InstancesRegistered,
         {
-          instanceId: 'i-4-still-booting',
+          id: 'i-4-still-booting',
           launchTime: moment(new Date())
             .subtract(MINIMUM_TIME_RUNNING - 3, 'minutes')
             .toDate(),
@@ -297,7 +297,7 @@ describe('Test simple pool.', () => {
           owner: ORG,
         },
         {
-          instanceId: 'i-5-orphan',
+          id: 'i-5-orphan',
           launchTime: moment(new Date())
             .subtract(MINIMUM_TIME_RUNNING + 3, 'minutes')
             .toDate(),
@@ -386,13 +386,13 @@ describe('Test simple pool.', () => {
       mockListRunners.mockImplementation(async () => [
         ...ec2InstancesRegistered,
         {
-          instanceId: 'i-5-idle',
+          id: 'i-5-idle',
           launchTime: new Date(),
           type: 'Org',
           owner: ORG,
         },
         {
-          instanceId: 'i-6-idle',
+          id: 'i-6-idle',
           launchTime: new Date(),
           type: 'Org',
           owner: ORG,

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down-contract.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down-contract.test.ts
@@ -5,7 +5,7 @@ import { providerTypes } from '../test/runner-provider-contracts/provider-types'
 import { defineScaleDownContractTests } from '../test/runner-provider-contracts/scale-down';
 import { controlPlaneProviderRegistry } from '../control-plane-providers';
 import { scaleDown } from './scale-down';
-import type { ScaleDownRunnerProvider } from './scale-down-provider';
+import type { ScaleDownRunnerProvider } from './types';
 
 const mockedResolveCapability = vi.spyOn(controlPlaneProviderRegistry, 'capability');
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down-provider.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down-provider.ts
@@ -1,5 +1,0 @@
-export type {
-  ScaleDownRunnerInfo as RunnerInfo,
-  ScaleDownRunnerList as RunnerList,
-  ScaleDownRunnerProvider,
-} from '@aws-github-runner/runner-providers/core';

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
@@ -7,7 +7,7 @@ import { controlPlaneProviderRegistry } from '../control-plane-providers';
 import * as ghAuth from '../github/auth';
 import { githubCache } from './cache';
 import { newestFirstStrategy, oldestFirstStrategy, scaleDown } from './scale-down';
-import type { RunnerInfo, ScaleDownRunnerProvider } from './scale-down-provider';
+import type { RunnerInfo, RunnerType, ScaleDownRunnerProvider } from './types';
 
 vi.mock('../github/auth', () => ({
   createGithubAppAuth: vi.fn(),
@@ -72,25 +72,25 @@ describe('When runners are sorted', () => {
       id: '1',
       launchTime: moment(new Date()).subtract(1, 'minute').toDate(),
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     },
     {
       id: '3',
       launchTime: moment(new Date()).subtract(3, 'minute').toDate(),
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     },
     {
       id: '2',
       launchTime: moment(new Date()).subtract(2, 'minute').toDate(),
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     },
     {
       id: '0',
       launchTime: moment(new Date()).subtract(0, 'minute').toDate(),
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     },
   ];
 
@@ -117,13 +117,13 @@ describe('When runners are sorted', () => {
       id: '4',
       launchTime: same,
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     });
     runnersTest.push({
       id: '5',
       launchTime: same,
       owner: 'owner',
-      type: 'type',
+      type: 'Org',
     });
     runnersTest.sort(oldestFirstStrategy);
     expect(runnersTest[3].launchTime).not.toEqual(same);
@@ -142,19 +142,19 @@ describe('When runners are sorted', () => {
         id: '0',
         launchTime: undefined,
         owner: 'owner',
-        type: 'type',
+        type: 'Org',
       },
       {
         id: '1',
         launchTime: moment(new Date()).subtract(3, 'minute').toDate(),
         owner: 'owner',
-        type: 'type',
+        type: 'Org',
       },
       {
         id: '0',
         launchTime: undefined,
         owner: 'owner',
-        type: 'type',
+        type: 'Org',
       },
     ];
     runnersTest.sort(oldestFirstStrategy);
@@ -266,7 +266,6 @@ describe('Scale down runners', () => {
       }
     });
 
-    type RunnerType = 'Repo' | 'Org';
     const runnerTypes: RunnerType[] = ['Org', 'Repo'];
     describe.each(runnerTypes)('For %s runners.', (type) => {
       it(`Should terminate runner without idle config ${type} runners.`, async () => {
@@ -729,7 +728,7 @@ function mockGitHubRunners(runners: RunnerTestItem[]) {
 
 function createRunnerTestData(
   name: string,
-  type: 'Org' | 'Repo',
+  type: RunnerType,
   minutesLaunchedAgo: number,
   registered: boolean,
   orphan: boolean,

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
@@ -11,7 +11,7 @@ import { GhRunners, githubCache } from './cache';
 import { ScalingDownConfigList, getEvictionStrategy, getIdleRunnerCount } from './scale-down-config';
 import { metricGitHubAppRateLimit } from '../github/rate-limit';
 import { getGitHubEnterpriseApiUrl } from './github-runner';
-import type { RunnerInfo, RunnerList, ScaleDownRunnerProvider } from './scale-down-provider';
+import type { RunnerInfo, ScaleDownRunnerProvider } from './types';
 
 const logger = createChildLogger('scale-down');
 
@@ -93,7 +93,7 @@ async function getGitHubRunnerBusyState(client: Octokit, runner: RunnerInfo, run
 }
 
 async function listGitHubRunners(runner: RunnerInfo): Promise<GhRunners> {
-  const key = runner.owner as string;
+  const key = runner.owner;
   const cachedRunners = githubCache.runners.get(key);
   if (cachedRunners) {
     logger.debug(`[listGithubRunners] Cache hit for ${key}`);
@@ -278,11 +278,10 @@ async function unMarkOrphan(id: string, runnerProvider: ScaleDownRunnerProvider)
   }
 }
 
-async function lastChanceCheckOrphanRunner(runner: RunnerList): Promise<boolean> {
-  const registeredRunner = runner as RunnerInfo;
-  const client = await getOrCreateOctokit(registeredRunner);
+async function lastChanceCheckOrphanRunner(runner: RunnerInfo): Promise<boolean> {
+  const client = await getOrCreateOctokit(runner);
   const runnerId = parseInt(runner.githubRunnerId || '0');
-  const state = await getGitHubSelfHostedRunnerState(client, registeredRunner, runnerId);
+  const state = await getGitHubSelfHostedRunnerState(client, runner, runnerId);
   let isOrphan = false;
 
   if (state === null) {
@@ -343,10 +342,10 @@ async function listRunners(environment: string, runnerProvider: ScaleDownRunnerP
   return await runnerProvider.list(environment);
 }
 
-function filterRunners(runners: RunnerList[]): RunnerInfo[] {
+function filterRunners(runners: RunnerInfo[]): RunnerInfo[] {
   // Managed runners are launched with owner and type tags together. Exclude incomplete records because both
   // values are required to select the GitHub owner and runner API used during scale-down.
-  return runners.filter((runner) => runner.owner && runner.type && !runner.orphan) as RunnerInfo[];
+  return runners.filter((runner) => runner.owner && runner.type && !runner.orphan);
 }
 
 export async function scaleDown(): Promise<void> {

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
@@ -7,8 +7,7 @@ import * as ghAuth from '../github/auth';
 import { controlPlaneProviderRegistry } from '../control-plane-providers';
 import * as githubRunner from './github-runner';
 import { scaleUp } from './scale-up';
-import type { ScaleUpRunnerProvider } from './scale-up-provider';
-import type { ActionRequestMessageSQS } from './types';
+import type { ActionRequestMessageSQS, ScaleUpRunnerProvider } from './types';
 
 vi.mock('../github/auth', () => ({
   createGithubAppAuth: vi.fn(),

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up-provider.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up-provider.ts
@@ -1,7 +1,0 @@
-export type {
-  CreateScaleUpRunnersInput,
-  CreateScaleUpRunnersResult,
-  CurrentRunnersInput,
-  PreparedScaleUpRunnerGroup,
-  ScaleUpRunnerProvider,
-} from '@aws-github-runner/runner-providers/core';

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -10,8 +10,12 @@ import * as ghAuth from '../github/auth';
 import { createStartRunnerConfig } from './github-runner';
 import { publishRetryMessage } from './job-retry';
 import * as scaleUpModule from './scale-up';
-import type { CreateScaleUpRunnersInput, CreateScaleUpRunnersResult, ScaleUpRunnerProvider } from './scale-up-provider';
-import type { ActionRequestMessageSQS } from './types';
+import type {
+  ActionRequestMessageSQS,
+  CreateRunnerResult,
+  CreateScaleUpRunnersInput,
+  ScaleUpRunnerProvider,
+} from './types';
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Octokit } from '@octokit/rest';
@@ -45,7 +49,7 @@ interface TestRunnerLookupInput {
   runnerOwner: string;
 }
 
-const createRunner = vi.fn<(input: TestRunnerCreationInput) => Promise<CreateScaleUpRunnersResult>>();
+const createRunner = vi.fn<(input: TestRunnerCreationInput) => Promise<CreateRunnerResult>>();
 const listRunners = vi.fn<(input: TestRunnerLookupInput) => Promise<unknown[]>>();
 const mockCreateRunner = vi.mocked(createRunner);
 const mockListRunners = vi.mocked(listRunners);
@@ -96,10 +100,10 @@ vi.mock('./job-retry', () => ({
   checkAndRetryJob: vi.fn(),
 }));
 
-export type RunnerType = 'ephemeral' | 'non-ephemeral';
+export type RunnerLifecycle = 'ephemeral' | 'non-ephemeral';
 
 // for ephemeral and non-ephemeral runners
-const RUNNER_TYPES: RunnerType[] = ['ephemeral', 'non-ephemeral'];
+const RUNNER_TYPES: RunnerLifecycle[] = ['ephemeral', 'non-ephemeral'];
 
 const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
 const mockedInstallationAuth = vi.mocked(ghAuth.createGithubInstallationAuth);
@@ -143,9 +147,7 @@ function setDefaults() {
   process.env.ENVIRONMENT = EXPECTED_RUNNER_PARAMS.environment;
 }
 
-async function createTestProviderRunners(
-  input: CreateScaleUpRunnersInput<unknown>,
-): Promise<CreateScaleUpRunnersResult> {
+async function createTestProviderRunners(input: CreateScaleUpRunnersInput<unknown>): Promise<CreateRunnerResult> {
   const result = await mockCreateRunner({
     environment: process.env.ENVIRONMENT,
     runnerType: input.githubRunnerConfig.runnerType,
@@ -208,7 +210,7 @@ beforeEach(() => {
   });
   mockListRunners.mockImplementation(async () => [
     {
-      instanceId: 'i-1234',
+      id: 'i-1234',
       launchTime: new Date(),
       type: 'Org',
       owner: TEST_DATA_SINGLE.repositoryOwner,
@@ -285,7 +287,7 @@ describe('scaleUp with GHES', () => {
       // Simulate race condition where pool lambda created more runners than max
       mockListRunners.mockImplementation(async () =>
         Array.from({ length: 10 }, (_, i) => ({
-          instanceId: `i-${i}`,
+          id: `i-${i}`,
           launchTime: new Date(),
           type: 'Org',
           owner: TEST_DATA_SINGLE.repositoryOwner,
@@ -600,7 +602,7 @@ describe('scaleUp with GHES', () => {
 
     it.each(RUNNER_TYPES)(
       'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
-      async (type: RunnerType) => {
+      async (type: RunnerLifecycle) => {
         process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
         process.env.RUNNERS_MAXIMUM_COUNT = '40';
         mockCreateRunner.mockImplementation(async () => {
@@ -909,7 +911,7 @@ describe('scaleUp with GHES', () => {
       process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
       mockListRunners.mockImplementation(async () => [
         {
-          instanceId: 'i-existing',
+          id: 'i-existing',
           launchTime: new Date(),
           type: 'Org',
           owner: TEST_DATA_SINGLE.repositoryOwner,
@@ -1390,7 +1392,7 @@ describe('scaleUp with public GH', () => {
       process.env.RUNNERS_MAXIMUM_COUNT = '1'; // Set to 1 so with 1 existing, no new ones can be created
       mockListRunners.mockImplementation(async () => [
         {
-          instanceId: 'i-existing',
+          id: 'i-existing',
           launchTime: new Date(),
           type: 'Org',
           owner: TEST_DATA_SINGLE.repositoryOwner,
@@ -1672,7 +1674,7 @@ describe('scaleUp with Github Data Residency', () => {
     });
     it.each(RUNNER_TYPES)(
       'calls create start runner config of 40' + ' instances (ssm rate limit condition) to test time delay ',
-      async (type: RunnerType) => {
+      async (type: RunnerLifecycle) => {
         process.env.ENABLE_EPHEMERAL_RUNNERS = type === 'ephemeral' ? 'true' : 'false';
         process.env.RUNNERS_MAXIMUM_COUNT = '40';
         mockCreateRunner.mockImplementation(async () => {
@@ -1864,7 +1866,7 @@ describe('scaleUp with Github Data Residency', () => {
       process.env.RUNNERS_MAXIMUM_COUNT = '2';
       mockListRunners.mockImplementation(async () => [
         {
-          instanceId: 'i-existing',
+          id: 'i-existing',
           launchTime: new Date(),
           type: 'Org',
           owner: TEST_DATA_SINGLE.repositoryOwner,

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -14,12 +14,12 @@ import {
   validateSsmParameterStoreTags,
 } from './github-runner';
 import { publishRetryMessage } from './job-retry';
-import type { CreateScaleUpRunnersResult } from './scale-up-provider';
 import type {
   ActionRequestMessage,
   ActionRequestMessageRetry,
   ActionRequestMessageSQS,
   CreateGitHubRunnerConfig,
+  CreateRunnerResult,
 } from './types';
 
 const logger = createChildLogger('scale-up');
@@ -313,7 +313,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
       ssmParameterStoreTags,
     };
 
-    let createRunnersResult: CreateScaleUpRunnersResult;
+    let createRunnersResult: CreateRunnerResult;
     try {
       createRunnersResult = await runnerProvider.createRunners({
         githubRunnerConfig,

--- a/lambdas/functions/control-plane/src/scale-runners/types.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/types.ts
@@ -1,7 +1,14 @@
 export type {
   CreateGitHubRunnerConfig,
-  GitHubRunnerType,
+  CreateRunnerResult,
+  CreateScaleUpRunnersInput,
+  CurrentRunnersInput,
   LambdaRunnerSource,
+  PreparedScaleUpRunnerGroup,
+  RunnerInfo,
+  RunnerType,
+  ScaleDownRunnerProvider,
+  ScaleUpRunnerProvider,
 } from '@aws-github-runner/runner-providers/core';
 
 export interface RunnerGroup {

--- a/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-down.ts
+++ b/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-down.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import type { ScaleDownRunnerProvider } from '../../scale-runners/scale-down-provider';
+import type { ScaleDownRunnerProvider } from '../../scale-runners/types';
 
 type TestScaleDownProvider<TType extends string> = Omit<ScaleDownRunnerProvider, 'type'> & { type: TType };
 
@@ -47,7 +47,7 @@ export function defineScaleDownContractTests<TType extends string>({
 
       it('terminates an orphan that has no GitHub runner identity', async () => {
         vi.mocked(provider.list)
-          .mockResolvedValueOnce([{ id: 'orphan-runner', orphan: true }])
+          .mockResolvedValueOnce([{ id: 'orphan-runner', owner: 'owner', type: 'Org', orphan: true }])
           .mockResolvedValue([]);
 
         await scaleDown();
@@ -57,7 +57,9 @@ export function defineScaleDownContractTests<TType extends string>({
 
       it('does not terminate an orphan with bypass removal enabled', async () => {
         vi.mocked(provider.list)
-          .mockResolvedValueOnce([{ id: 'protected-runner', orphan: true, bypassRemoval: true }])
+          .mockResolvedValueOnce([
+            { id: 'protected-runner', owner: 'owner', type: 'Org', orphan: true, bypassRemoval: true },
+          ])
           .mockResolvedValue([]);
 
         await scaleDown();

--- a/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-up.ts
+++ b/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-up.ts
@@ -1,8 +1,7 @@
 import type { Octokit } from '@octokit/rest';
 import { beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import type { ScaleUpRunnerProvider } from '../../scale-runners/scale-up-provider';
-import type { ActionRequestMessageSQS } from '../../scale-runners/types';
+import type { ActionRequestMessageSQS, ScaleUpRunnerProvider } from '../../scale-runners/types';
 
 type TestScaleUpProvider<TType extends string> = Omit<ScaleUpRunnerProvider, 'type'> & { type: TType };
 

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/pool.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/pool.test.ts
@@ -1,5 +1,5 @@
+import type { RunnerInfo } from '../../../../core';
 import { bootTimeExceeded } from './runners';
-import type { RunnerList } from './runners.d';
 import { calculateEc2PoolSize } from './pool';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,7 +15,7 @@ describe('calculateEc2PoolSize', () => {
   });
 
   it('counts registered online idle runners', () => {
-    const runners: RunnerList[] = [{ instanceId: 'i-idle' }];
+    const runners: RunnerInfo[] = [{ id: 'i-idle', owner: 'owner', type: 'Org' }];
     const runnerStatus = new Map([['i-idle', { busy: false, status: 'online' }]]);
 
     expect(calculateEc2PoolSize(runners, runnerStatus)).toBe(1);
@@ -23,7 +23,10 @@ describe('calculateEc2PoolSize', () => {
   });
 
   it('does not count registered busy or offline runners', () => {
-    const runners: RunnerList[] = [{ instanceId: 'i-busy' }, { instanceId: 'i-offline' }];
+    const runners: RunnerInfo[] = [
+      { id: 'i-busy', owner: 'owner', type: 'Org' },
+      { id: 'i-offline', owner: 'owner', type: 'Org' },
+    ];
     const runnerStatus = new Map([
       ['i-busy', { busy: true, status: 'online' }],
       ['i-offline', { busy: false, status: 'offline' }],
@@ -34,14 +37,14 @@ describe('calculateEc2PoolSize', () => {
   });
 
   it('counts unregistered runners that are still booting', () => {
-    const runners: RunnerList[] = [{ instanceId: 'i-booting' }];
+    const runners: RunnerInfo[] = [{ id: 'i-booting', owner: 'owner', type: 'Org' }];
     mockBootTimeExceeded.mockReturnValue(false);
 
     expect(calculateEc2PoolSize(runners, new Map())).toBe(1);
   });
 
   it('does not count unregistered runners whose boot time expired', () => {
-    const runners: RunnerList[] = [{ instanceId: 'i-expired' }];
+    const runners: RunnerInfo[] = [{ id: 'i-expired', owner: 'owner', type: 'Org' }];
     mockBootTimeExceeded.mockReturnValue(true);
 
     expect(calculateEc2PoolSize(runners, new Map())).toBe(0);

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/pool.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/pool.ts
@@ -4,11 +4,11 @@ import type {
   CreatePoolRunnersInput,
   ListPoolRunnersInput,
   PoolRunnerProvider,
+  RunnerInfo,
   RunnerStatus,
 } from '../../../../core';
 import { createRunners, loadEc2ProviderConfig } from './runner-config';
 import { bootTimeExceeded, listEC2Runners } from './runners';
-import type { RunnerList } from './runners.d';
 
 const logger = createChildLogger('pool');
 
@@ -16,7 +16,7 @@ async function listEc2PoolRunners({
   environment,
   runnerOwner,
   runnerType,
-}: ListPoolRunnersInput): Promise<RunnerList[]> {
+}: ListPoolRunnersInput): Promise<RunnerInfo[]> {
   return await listEC2Runners({
     environment,
     runnerOwner,
@@ -53,7 +53,7 @@ async function createEc2PoolRunners(
 
 export function createEc2PoolProvider(
   createStartRunnerConfig: CreateStartRunnerConfig,
-): Omit<PoolRunnerProvider, 'type'> {
+): Omit<PoolRunnerProvider<RunnerInfo>, 'type'> {
   return {
     listRunners: listEc2PoolRunners,
     countAvailableRunners: calculateEc2PoolSize,
@@ -62,7 +62,7 @@ export function createEc2PoolProvider(
 }
 
 export function calculateEc2PoolSize(
-  ec2runners: RunnerList[],
+  ec2runners: RunnerInfo[],
   runnerStatus: Map<string, RunnerStatus>,
   includeBusyRunners = false,
 ): number {
@@ -70,20 +70,18 @@ export function calculateEc2PoolSize(
   let numberOfRunnersInPool = 0;
   for (const ec2Instance of ec2runners) {
     if (
-      (runnerStatus.get(ec2Instance.instanceId)?.busy === false || includeBusyRunners) &&
-      runnerStatus.get(ec2Instance.instanceId)?.status === 'online'
+      (runnerStatus.get(ec2Instance.id)?.busy === false || includeBusyRunners) &&
+      runnerStatus.get(ec2Instance.id)?.status === 'online'
     ) {
       numberOfRunnersInPool++;
-      logger.debug(`Runner ${ec2Instance.instanceId} is idle in GitHub and counted as part of the pool`);
-    } else if (runnerStatus.get(ec2Instance.instanceId) != null) {
-      logger.debug(`Runner ${ec2Instance.instanceId} is not idle in GitHub and NOT counted as part of the pool`);
+      logger.debug(`Runner ${ec2Instance.id} is idle in GitHub and counted as part of the pool`);
+    } else if (runnerStatus.get(ec2Instance.id) != null) {
+      logger.debug(`Runner ${ec2Instance.id} is not idle in GitHub and NOT counted as part of the pool`);
     } else if (!bootTimeExceeded(ec2Instance)) {
       numberOfRunnersInPool++;
-      logger.info(`Runner ${ec2Instance.instanceId} is still booting and counted as part of the pool`);
+      logger.info(`Runner ${ec2Instance.id} is still booting and counted as part of the pool`);
     } else {
-      logger.debug(
-        `Runner ${ec2Instance.instanceId} is not idle in GitHub nor booting and not counted as part of the pool`,
-      );
+      logger.debug(`Runner ${ec2Instance.id} is not idle in GitHub nor booting and not counted as part of the pool`);
     }
   }
   return numberOfRunnersInPool;

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runner-config.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runner-config.ts
@@ -1,7 +1,7 @@
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import type {
   CreateGitHubRunnerConfig,
-  CreateScaleUpRunnersResult,
+  CreateRunnerResult,
   CreateStartRunnerConfig,
   GitHubRunnerMetadata,
   LambdaRunnerSource,
@@ -67,8 +67,8 @@ export async function createRunners(
   ghClient: Octokit,
   createStartRunnerConfig: CreateStartRunnerConfig,
   source: LambdaRunnerSource = 'scale-up-lambda',
-): Promise<CreateScaleUpRunnersResult> {
-  let result: CreateScaleUpRunnersResult;
+): Promise<CreateRunnerResult> {
+  let result: CreateRunnerResult;
   try {
     result = await createRunner({
       runnerType: githubRunnerConfig.runnerType,

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.d.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.d.ts
@@ -7,34 +7,9 @@ import {
   Placement,
   FleetBlockDeviceMappingRequest,
 } from '@aws-sdk/client-ec2';
-import type { LambdaRunnerSource } from '../../../../core';
+import type { LambdaRunnerSource, ListRunnerFilters, RunnerType } from '../../../../core';
 
-export type RunnerType = 'Org' | 'Repo';
-
-export interface RunnerList {
-  instanceId: string;
-  launchTime?: Date;
-  owner?: string;
-  type?: string;
-  repo?: string;
-  org?: string;
-  orphan?: boolean;
-  runnerId?: string;
-  bypassRemoval?: boolean;
-}
-
-export interface RunnerInfo {
-  instanceId: string;
-  launchTime?: Date;
-  owner: string;
-  type: string;
-}
-
-export interface ListRunnerFilters {
-  runnerType?: RunnerType;
-  runnerOwner?: string;
-  environment?: string;
-  orphan?: boolean;
+export interface Ec2ListRunnerFilters extends ListRunnerFilters {
   statuses?: string[];
 }
 
@@ -73,10 +48,4 @@ export interface RunnerInputParameters {
   onDemandFailoverOnError?: string[];
   scaleErrors: string[];
   useDedicatedHost?: boolean;
-}
-
-export interface CreateRunnerResult {
-  instances: string[];
-  retryableErrorCount: number;
-  nonRetryableErrorCount: number;
 }

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.test.ts
@@ -21,9 +21,9 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest/vitest';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LambdaRunnerSource } from '../../../../core';
+import type { LambdaRunnerSource, RunnerInfo, RunnerType } from '../../../../core';
 import { createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
-import type { Ec2OverrideConfig, RunnerInfo, RunnerInputParameters, RunnerType } from './runners.d';
+import type { Ec2OverrideConfig, RunnerInputParameters } from './runners.d';
 
 process.env.AWS_REGION = 'eu-east-1';
 const mockEC2Client = mockClient(EC2Client);
@@ -89,7 +89,7 @@ describe('list instances', () => {
     const resp = await listEC2Runners();
     expect(resp.length).toBe(1);
     expect(resp).toContainEqual({
-      instanceId: 'i-1234',
+      id: 'i-1234',
       launchTime: new Date('2020-10-10T14:48:00.000+09:00'),
       type: 'Org',
       owner: 'CoderToCat',
@@ -103,12 +103,12 @@ describe('list instances', () => {
     const resp = await listEC2Runners();
     expect(resp.length).toBe(1);
     expect(resp).toContainEqual({
-      instanceId: 'i-1234',
+      id: 'i-1234',
       launchTime: new Date('2020-10-10T14:48:00.000+09:00'),
       type: 'Org',
       owner: 'CoderToCat',
       orphan: false,
-      runnerId: '9876543210',
+      githubRunnerId: '9876543210',
       bypassRemoval: false,
     });
   });
@@ -124,7 +124,7 @@ describe('list instances', () => {
     const resp = await listEC2Runners();
     expect(resp.length).toBe(1);
     expect(resp).toContainEqual({
-      instanceId: instances.Reservations![0].Instances![0].InstanceId!,
+      id: instances.Reservations![0].Instances![0].InstanceId!,
       launchTime: instances.Reservations![0].Instances![0].LaunchTime!,
       type: 'Org',
       owner: 'CoderToCat',
@@ -260,14 +260,14 @@ describe('terminate runner', () => {
   it('calls terminate instances with the right instance ids', async () => {
     mockEC2Client.on(TerminateInstancesCommand).resolves({});
     const runner: RunnerInfo = {
-      instanceId: 'instance-2',
+      id: 'instance-2',
       owner: 'owner-2',
       type: 'Repo',
     };
-    await terminateRunner(runner.instanceId);
+    await terminateRunner(runner.id);
 
     expect(mockEC2Client).toHaveReceivedCommandWith(TerminateInstancesCommand, {
-      InstanceIds: [runner.instanceId],
+      InstanceIds: [runner.id],
     });
   });
 });
@@ -279,14 +279,14 @@ describe('tag runner', () => {
   it('adding extra tag', async () => {
     mockEC2Client.on(CreateTagsCommand).resolves({});
     const runner: RunnerInfo = {
-      instanceId: 'instance-2',
+      id: 'instance-2',
       owner: 'owner-2',
       type: 'Repo',
     };
-    await tag(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
+    await tag(runner.id, [{ Key: 'ghr:orphan', Value: 'true' }]);
 
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateTagsCommand, {
-      Resources: [runner.instanceId],
+      Resources: [runner.id],
       Tags: [{ Key: 'ghr:orphan', Value: 'true' }],
     });
   });
@@ -299,18 +299,18 @@ describe('untag runner', () => {
   it('removing extra tag', async () => {
     mockEC2Client.on(DeleteTagsCommand).resolves({});
     const runner: RunnerInfo = {
-      instanceId: 'instance-2',
+      id: 'instance-2',
       owner: 'owner-2',
       type: 'Repo',
     };
-    await tag(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
+    await tag(runner.id, [{ Key: 'ghr:orphan', Value: 'true' }]);
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateTagsCommand, {
-      Resources: [runner.instanceId],
+      Resources: [runner.id],
       Tags: [{ Key: 'ghr:orphan', Value: 'true' }],
     });
-    await untag(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
+    await untag(runner.id, [{ Key: 'ghr:orphan', Value: 'true' }]);
     expect(mockEC2Client).toHaveReceivedCommandWith(DeleteTagsCommand, {
-      Resources: [runner.instanceId],
+      Resources: [runner.id],
       Tags: [{ Key: 'ghr:orphan', Value: 'true' }],
     });
   });
@@ -1201,7 +1201,7 @@ function createRunnerConfig(runnerConfig: RunnerConfig): RunnerInputParameters {
 }
 
 interface ExpectedFleetRequestValues {
-  type: 'Repo' | 'Org';
+  type: RunnerType;
   capacityType: DefaultTargetCapacityType;
   allocationStrategy: SpotAllocationStrategy | FleetOnDemandAllocationStrategy;
   instanceTypePriorities?: Record<string, number>;

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/runners.ts
@@ -22,7 +22,8 @@ import { getTracedAWSV3Client, tracer } from '@aws-github-runner/aws-powertools-
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import moment from 'moment';
 
-import * as Runners from './runners.d';
+import type { CreateRunnerResult, RunnerInfo } from '../../../../core';
+import type { Ec2ListRunnerFilters, Ec2OverrideConfig, RunnerInputParameters } from './runners.d';
 
 const logger = createChildLogger('runners');
 
@@ -33,18 +34,16 @@ interface Ec2Filter {
 
 type FleetError = NonNullable<CreateFleetResult['Errors']>[number];
 
-export async function listEC2Runners(
-  filters: Runners.ListRunnerFilters | undefined = undefined,
-): Promise<Runners.RunnerList[]> {
+export async function listEC2Runners(filters: Ec2ListRunnerFilters | undefined = undefined): Promise<RunnerInfo[]> {
   const ec2Filters = constructFilters(filters);
-  const runners: Runners.RunnerList[] = [];
+  const runners: RunnerInfo[] = [];
   for (const filter of ec2Filters) {
     runners.push(...(await getRunners(filter)));
   }
   return runners;
 }
 
-function constructFilters(filters?: Runners.ListRunnerFilters): Ec2Filter[][] {
+function constructFilters(filters?: Ec2ListRunnerFilters): Ec2Filter[][] {
   const ec2Statuses = filters?.statuses ? filters.statuses : ['running', 'pending'];
   const ec2Filters: Ec2Filter[][] = [];
   const ec2FiltersBase = [{ Name: 'instance-state-name', Values: ec2Statuses }];
@@ -69,9 +68,9 @@ function constructFilters(filters?: Runners.ListRunnerFilters): Ec2Filter[][] {
   return ec2Filters;
 }
 
-async function getRunners(ec2Filters: Ec2Filter[]): Promise<Runners.RunnerList[]> {
+async function getRunners(ec2Filters: Ec2Filter[]): Promise<RunnerInfo[]> {
   const ec2 = getTracedAWSV3Client(new EC2Client({ region: process.env.AWS_REGION }));
-  const runners: Runners.RunnerList[] = [];
+  const runners: RunnerInfo[] = [];
   let nextToken;
   let hasNext = true;
   while (hasNext) {
@@ -86,20 +85,20 @@ async function getRunners(ec2Filters: Ec2Filter[]): Promise<Runners.RunnerList[]
 }
 
 function getRunnerInfo(runningInstances: DescribeInstancesResult) {
-  const runners: Runners.RunnerList[] = [];
+  const runners: RunnerInfo[] = [];
   if (runningInstances.Reservations) {
     for (const r of runningInstances.Reservations) {
       if (r.Instances) {
         for (const i of r.Instances) {
           runners.push({
-            instanceId: i.InstanceId as string,
+            id: i.InstanceId as string,
             launchTime: i.LaunchTime,
             owner: i.Tags?.find((e) => e.Key === 'ghr:Owner')?.Value as string,
-            type: i.Tags?.find((e) => e.Key === 'ghr:Type')?.Value as string,
+            type: i.Tags?.find((e) => e.Key === 'ghr:Type')?.Value as RunnerInfo['type'],
             repo: i.Tags?.find((e) => e.Key === 'ghr:Repo')?.Value as string,
             org: i.Tags?.find((e) => e.Key === 'ghr:Org')?.Value as string,
             orphan: i.Tags?.find((e) => e.Key === 'ghr:orphan')?.Value === 'true',
-            runnerId: i.Tags?.find((e) => e.Key === 'ghr:github_runner_id')?.Value as string,
+            githubRunnerId: i.Tags?.find((e) => e.Key === 'ghr:github_runner_id')?.Value as string,
             bypassRemoval: i.Tags?.find((e) => e.Key === 'ghr:bypass-removal')?.Value === 'true',
           });
         }
@@ -215,7 +214,7 @@ function generateFleetOverrides(
   subnetIds: string[],
   instancesTypes: string[],
   amiId?: string,
-  ec2OverrideConfig?: Runners.Ec2OverrideConfig,
+  ec2OverrideConfig?: Ec2OverrideConfig,
   allocationStrategy?: string,
   instanceTypePriorities?: Record<string, number>,
 ): FleetLaunchTemplateOverridesRequest[] {
@@ -258,7 +257,7 @@ interface RunInstancesLaunchDefaults {
 }
 
 function buildRunInstancesOverrides(
-  ec2OverrideConfig: Runners.Ec2OverrideConfig | undefined,
+  ec2OverrideConfig: Ec2OverrideConfig | undefined,
   defaults: RunInstancesLaunchDefaults,
 ): RunInstancesLaunchOverrides {
   const imageIdToUse = ec2OverrideConfig?.ImageId ?? defaults.imageId;
@@ -299,9 +298,7 @@ function buildRunInstancesOverrides(
   return overrides;
 }
 
-export async function createRunner(
-  runnerParameters: Runners.RunnerInputParameters,
-): Promise<Runners.CreateRunnerResult> {
+export async function createRunner(runnerParameters: RunnerInputParameters): Promise<CreateRunnerResult> {
   logger.debug('Runner configuration.', {
     runner: {
       configuration: {
@@ -351,8 +348,8 @@ export async function createRunner(
 
 async function processFleetResult(
   fleet: CreateFleetResult,
-  runnerParameters: Runners.RunnerInputParameters,
-): Promise<Runners.CreateRunnerResult> {
+  runnerParameters: RunnerInputParameters,
+): Promise<CreateRunnerResult> {
   const instances: string[] = fleet.Instances?.flatMap((i) => i.InstanceIds?.flatMap((j) => j) || []) || [];
 
   if (instances.length === runnerParameters.numberOfRunners) {
@@ -441,8 +438,8 @@ function classifyFleetErrors(
 
 function processRunInstanceResult(
   result: RunInstancesCommandOutput,
-  runnerParameters: Runners.RunnerInputParameters,
-): Runners.CreateRunnerResult {
+  runnerParameters: RunnerInputParameters,
+): CreateRunnerResult {
   const instances = result.Instances?.map((i) => i.InstanceId!).filter(Boolean) || [];
 
   if (instances.length === runnerParameters.numberOfRunners) {
@@ -465,11 +462,11 @@ function processRunInstanceResult(
   return { instances, retryableErrorCount: 0, nonRetryableErrorCount };
 }
 
-function successfulCreateRunnerResult(instances: string[]): Runners.CreateRunnerResult {
+function successfulCreateRunnerResult(instances: string[]): CreateRunnerResult {
   return { instances, retryableErrorCount: 0, nonRetryableErrorCount: 0 };
 }
 
-function failedCreateRunnerResult(failedInstanceCount: number, isRetryable: boolean): Runners.CreateRunnerResult {
+function failedCreateRunnerResult(failedInstanceCount: number, isRetryable: boolean): CreateRunnerResult {
   return {
     instances: [],
     retryableErrorCount: isRetryable ? failedInstanceCount : 0,
@@ -477,7 +474,7 @@ function failedCreateRunnerResult(failedInstanceCount: number, isRetryable: bool
   };
 }
 
-async function getAmiIdOverride(runnerParameters: Runners.RunnerInputParameters): Promise<string | undefined> {
+async function getAmiIdOverride(runnerParameters: RunnerInputParameters): Promise<string | undefined> {
   if (!runnerParameters.amiIdSsmParameterName) {
     return undefined;
   }
@@ -497,7 +494,7 @@ async function getAmiIdOverride(runnerParameters: Runners.RunnerInputParameters)
 }
 
 async function createInstances(
-  runnerParameters: Runners.RunnerInputParameters,
+  runnerParameters: RunnerInputParameters,
   amiIdOverride: string | undefined,
   ec2Client: EC2Client,
 ) {
@@ -581,10 +578,10 @@ async function createInstances(
 }
 
 async function createInstancesWithRunInstances(
-  runnerParameters: Runners.RunnerInputParameters,
+  runnerParameters: RunnerInputParameters,
   amiIdOverride: string | undefined,
   ec2Client: EC2Client,
-): Promise<Runners.CreateRunnerResult> {
+): Promise<CreateRunnerResult> {
   const tags = [
     { Key: 'ghr:Application', Value: 'github-action-runner' },
     { Key: 'ghr:created_by', Value: runnerParameters.numberOfRunners === 1 ? 'scale-up-lambda' : 'pool-lambda' },

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { RunnerInfo, RunnerType } from '../../../../core';
 import { createEc2ScaleDownProvider } from './scale-down';
 import { listEC2Runners, tag, terminateRunner, untag } from './runners';
-import type { RunnerList } from './runners.d';
 
 vi.mock('./runners', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./runners')>();
@@ -28,19 +28,18 @@ describe('Scale down runners', () => {
   const endpoints = ['https://api.github.com', 'https://github.enterprise.something', 'https://companyname.ghe.com'];
 
   describe.each(endpoints)('for %s', () => {
-    type RunnerType = 'Repo' | 'Org';
     const runnerTypes: RunnerType[] = ['Org', 'Repo'];
 
     describe.each(runnerTypes)('For %s runners.', (type) => {
-      const runner: RunnerList = {
-        instanceId: `i-runner-${type.toLowerCase()}`,
+      const runner: RunnerInfo = {
+        id: `i-runner-${type.toLowerCase()}`,
         launchTime: new Date('2026-08-05T10:00:00.000Z'),
         owner: type === 'Repo' ? 'Codertocat/hello-world' : 'Codertocat',
         type,
         repo: 'hello-world',
         org: 'Codertocat',
         orphan: true,
-        runnerId: '1234567890',
+        githubRunnerId: '1234567890',
         bypassRemoval: true,
       };
 
@@ -51,19 +50,7 @@ describe('Scale down runners', () => {
         const provider = createEc2ScaleDownProvider();
 
         await expect(provider.list('unit-test-environment')).resolves.toEqual([]);
-        await expect(provider.list('unit-test-environment', true)).resolves.toEqual([
-          {
-            id: runner.instanceId,
-            launchTime: runner.launchTime,
-            owner: runner.owner,
-            type: runner.type,
-            repo: runner.repo,
-            org: runner.org,
-            orphan: runner.orphan,
-            githubRunnerId: runner.runnerId,
-            bypassRemoval: runner.bypassRemoval,
-          },
-        ]);
+        await expect(provider.list('unit-test-environment', true)).resolves.toEqual([runner]);
         expect(mockListRunners).toHaveBeenNthCalledWith(1, {
           environment: 'unit-test-environment',
           orphan: undefined,
@@ -71,19 +58,17 @@ describe('Scale down runners', () => {
         expect(mockListRunners).toHaveBeenNthCalledWith(2, { environment: 'unit-test-environment', orphan: true });
         expect(mockTerminateRunner).not.toHaveBeenCalled();
 
-        await provider.markOrphan(runner.instanceId);
-        await provider.unmarkOrphan(runner.instanceId);
+        await provider.markOrphan(runner.id);
+        await provider.unmarkOrphan(runner.id);
 
-        expect(mockTagRunner).toHaveBeenCalledWith(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
-        expect(mockUntagRunner).toHaveBeenCalledWith(runner.instanceId, [{ Key: 'ghr:orphan', Value: 'true' }]);
+        expect(mockTagRunner).toHaveBeenCalledWith(runner.id, [{ Key: 'ghr:orphan', Value: 'true' }]);
+        expect(mockUntagRunner).toHaveBeenCalledWith(runner.id, [{ Key: 'ghr:orphan', Value: 'true' }]);
       });
 
       it(`Should respect booting runner.`, async () => {
-        const scaleDownRunner = {
-          id: runner.instanceId,
+        const scaleDownRunner: RunnerInfo = {
+          ...runner,
           launchTime: new Date(),
-          owner: runner.owner as string,
-          type: runner.type as string,
         };
         process.env.RUNNER_BOOT_TIME_IN_MINUTES = '5';
         const provider = createEc2ScaleDownProvider();
@@ -91,9 +76,9 @@ describe('Scale down runners', () => {
         expect(provider.bootTimeExceeded(scaleDownRunner)).toBe(false);
         expect(mockTerminateRunner).not.toHaveBeenCalled();
         mockTerminateRunner.mockResolvedValue();
-        await provider.terminate(runner.instanceId);
+        await provider.terminate(runner.id);
 
-        expect(mockTerminateRunner).toHaveBeenCalledWith(runner.instanceId);
+        expect(mockTerminateRunner).toHaveBeenCalledWith(runner.id);
       });
     });
   });

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-down.ts
@@ -1,9 +1,8 @@
-import type { ScaleDownRunnerList, ScaleDownRunnerProvider } from '../../../../core';
+import type { RunnerInfo, ScaleDownRunnerProvider } from '../../../../core';
 import { bootTimeExceeded, listEC2Runners, tag, terminateRunner, untag } from './runners';
-import type { RunnerList } from './runners.d';
 
-async function listEc2ScaleDownRunners(environment: string, orphan?: boolean): Promise<ScaleDownRunnerList[]> {
-  return (await listEC2Runners({ environment, orphan })).map(toScaleDownRunner);
+async function listEc2ScaleDownRunners(environment: string, orphan?: boolean): Promise<RunnerInfo[]> {
+  return await listEC2Runners({ environment, orphan });
 }
 
 async function markEc2RunnerOrphan(id: string): Promise<void> {
@@ -21,19 +20,5 @@ export function createEc2ScaleDownProvider(): Omit<ScaleDownRunnerProvider, 'typ
     markOrphan: markEc2RunnerOrphan,
     unmarkOrphan: unmarkEc2RunnerOrphan,
     terminate: terminateRunner,
-  };
-}
-
-function toScaleDownRunner(runner: RunnerList): ScaleDownRunnerList {
-  return {
-    id: runner.instanceId,
-    launchTime: runner.launchTime,
-    owner: runner.owner,
-    type: runner.type,
-    repo: runner.repo,
-    org: runner.org,
-    orphan: runner.orphan,
-    githubRunnerId: runner.runnerId,
-    bypassRemoval: runner.bypassRemoval,
   };
 }

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -1,4 +1,4 @@
-import type { CreateGitHubRunnerConfig, CreateStartRunnerConfig } from '../../../../core';
+import type { CreateGitHubRunnerConfig, CreateStartRunnerConfig, RunnerType } from '../../../../core';
 import type { Octokit } from '@octokit/rest';
 import { DescribeLaunchTemplateVersionsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -59,7 +59,7 @@ function runnerConfig(overrides: Partial<CreateGitHubRunnerConfig> = {}): Create
 }
 
 function expectedRunnerParams(
-  type: 'Org' | 'Repo' = 'Org',
+  type: RunnerType = 'Org',
   owner = runnerOwner,
   overrides: Partial<RunnerInputParameters> = {},
 ): RunnerInputParameters {
@@ -101,7 +101,7 @@ async function createProviderRunners(options: CreateProviderRunnersOptions = {})
   });
 }
 
-async function expectCurrentRunners(runnerType: 'Org' | 'Repo', owner: string) {
+async function expectCurrentRunners(runnerType: RunnerType, owner: string) {
   const prepared = await provider.prepareGroup([]);
 
   await expect(provider.getCurrentRunners(prepared.state, { runnerType, runnerOwner: owner })).resolves.toBe(1);
@@ -144,7 +144,7 @@ beforeEach(() => {
   mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345']));
   mockListRunners.mockResolvedValue([
     {
-      instanceId: 'i-1234',
+      id: 'i-1234',
       launchTime: new Date(),
       type: 'Org',
       owner: runnerOwner,

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.ts
@@ -1,7 +1,7 @@
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import type {
+  CreateRunnerResult,
   CreateScaleUpRunnersInput,
-  CreateScaleUpRunnersResult,
   CreateStartRunnerConfig,
   CurrentRunnersInput,
   PreparedScaleUpRunnerGroup,
@@ -65,7 +65,7 @@ async function getCurrentEc2Runners(
 async function createEc2ScaleUpRunners(
   { githubRunnerConfig, numberOfRunners, githubInstallationClient, state }: CreateScaleUpRunnersInput<Ec2ScaleUpState>,
   createStartRunnerConfig: CreateStartRunnerConfig,
-): Promise<CreateScaleUpRunnersResult> {
+): Promise<CreateRunnerResult> {
   const config = loadEc2ScaleUpProviderConfig();
 
   return await createRunners(

--- a/lambdas/libs/runner-providers/core/index.ts
+++ b/lambdas/libs/runner-providers/core/index.ts
@@ -7,7 +7,7 @@ export interface RunnerProvider {
 }
 
 export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
-export type GitHubRunnerType = 'Org' | 'Repo';
+export type RunnerType = 'Org' | 'Repo';
 
 export interface CreateGitHubRunnerConfig {
   ephemeral: boolean;
@@ -17,7 +17,7 @@ export interface CreateGitHubRunnerConfig {
   runnerGroup: string;
   runnerNamePrefix: string;
   runnerOwner: string;
-  runnerType: GitHubRunnerType;
+  runnerType: RunnerType;
   disableAutoUpdate: boolean;
   ssmTokenPath: string;
   ssmConfigPath: string;
@@ -42,7 +42,7 @@ export type CreateStartRunnerConfig = (
 ) => Promise<string[]>;
 
 export interface CurrentRunnersInput {
-  runnerType: GitHubRunnerType;
+  runnerType: RunnerType;
   runnerOwner: string;
 }
 
@@ -58,7 +58,7 @@ export interface PreparedScaleUpRunnerGroup<TState = unknown> {
   state: TState;
 }
 
-export interface CreateScaleUpRunnersResult {
+export interface CreateRunnerResult {
   instances: string[];
   retryableErrorCount: number;
   nonRetryableErrorCount: number;
@@ -67,14 +67,14 @@ export interface CreateScaleUpRunnersResult {
 export interface ScaleUpRunnerProvider<TState = unknown> extends RunnerProvider {
   prepareGroup(messageLabels: string[]): Promise<PreparedScaleUpRunnerGroup<TState>>;
   getCurrentRunners(state: TState, input: CurrentRunnersInput): Promise<number>;
-  createRunners(input: CreateScaleUpRunnersInput<TState>): Promise<CreateScaleUpRunnersResult>;
+  createRunners(input: CreateScaleUpRunnersInput<TState>): Promise<CreateRunnerResult>;
 }
 
-export interface ScaleDownRunnerList {
+export interface RunnerInfo {
   id: string;
   launchTime?: Date;
-  owner?: string;
-  type?: string;
+  owner: string;
+  type: RunnerType;
   repo?: string;
   org?: string;
   orphan?: boolean;
@@ -82,14 +82,16 @@ export interface ScaleDownRunnerList {
   bypassRemoval?: boolean;
 }
 
-export interface ScaleDownRunnerInfo extends ScaleDownRunnerList {
-  owner: string;
-  type: string;
+export interface ListRunnerFilters {
+  runnerType?: RunnerType;
+  runnerOwner?: string;
+  environment?: string;
+  orphan?: boolean;
 }
 
 export interface ScaleDownRunnerProvider extends RunnerProvider {
-  list(environment: string, orphan?: boolean): Promise<ScaleDownRunnerList[]>;
-  bootTimeExceeded(runner: ScaleDownRunnerInfo): boolean;
+  list(environment: string, orphan?: boolean): Promise<RunnerInfo[]>;
+  bootTimeExceeded(runner: RunnerInfo): boolean;
   markOrphan(id: string): Promise<void>;
   unmarkOrphan(id: string): Promise<void>;
   terminate(id: string): Promise<void>;
@@ -103,7 +105,7 @@ export interface RunnerStatus {
 export interface ListPoolRunnersInput {
   environment: string;
   runnerOwner: string;
-  runnerType: GitHubRunnerType;
+  runnerType: RunnerType;
 }
 
 export interface CreatePoolRunnersInput {


### PR DESCRIPTION
## Description

- Define the provider-neutral `RunnerType`, `RunnerInfo`, `ListRunnerFilters`, and `CreateRunnerResult` contracts in runner-provider core.
- Use one `RunnerInfo` shape across control-plane and EC2, with `id`, `githubRunnerId`, and required `owner` and `type` fields.
- Keep EC2-specific inputs and the EC2 status-filter extension in `runners.d.ts`.
- Consolidate control-plane type re-exports in `scale-runners/types.ts` and remove the redundant scale-up and scale-down provider type shims.
- Update the existing tests in place without adding or removing test cases.

### Compatibility note

This PR intentionally normalizes the exported `listEC2Runners` result fields from `instanceId`/`runnerId` to `id`/`githubRunnerId` and removes the legacy core type aliases. This differs from the compatibility approach initially described in #5247 and is included explicitly for review.

## Test Plan

- `cd lambdas && NX_DAEMON=false yarn test` (all 8 projects passed)
- Control-plane suite: 14 test files / 326 tests passed
- Runner-provider suite: 10 test files / 270 tests passed
- Focused scale-down contract, EC2 listing, and pool tests passed after the final type tightening
- ESLint and Prettier passed for control-plane and runner-providers
- Exact test-title inventory: 276 before and after, with no additions or removals
- `git diff --check`

Local TypeScript build validation remains blocked by the installed `@aws-sdk/client-ec2` declarations missing exports used throughout the existing EC2 sources; the same environment issue affects untouched code.

## Related Issues

Closes #5247

Stacked on #5246
