### PR TITLE
refactor(runner-providers): resolve labels for runners

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
@@ -46,7 +46,7 @@ const cleanEnv = process.env;
 const lanes = providerTypes.map((type) => ({
   provider: {
     type,
-    prepareGroup: vi.fn(),
+    resolveLabelsForRunners: vi.fn(),
     getCurrentRunners: vi.fn(),
     createRunners: vi.fn(),
   } satisfies ScaleUpRunnerProvider,

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -59,11 +59,11 @@ const mockPublishRetryMessage = vi.mocked(publishRetryMessage);
 const testProviderState = { provider: 'test' };
 const mockRunnerProvider: ScaleUpRunnerProvider = {
   type: 'ec2',
-  prepareGroup: vi.fn(),
+  resolveLabelsForRunners: vi.fn(),
   getCurrentRunners: vi.fn(),
   createRunners: vi.fn(),
 };
-const mockPrepareGroup = vi.mocked(mockRunnerProvider.prepareGroup);
+const mockResolveLabelsForRunners = vi.mocked(mockRunnerProvider.resolveLabelsForRunners);
 const mockGetCurrentRunners = vi.mocked(mockRunnerProvider.getCurrentRunners);
 const mockCreateRunners = vi.mocked(mockRunnerProvider.createRunners);
 const mockedResolveCapability = vi.spyOn(controlPlaneProviderRegistry, 'capability');
@@ -190,7 +190,7 @@ beforeEach(() => {
   defaultOctokitMockImpl();
 
   mockedResolveCapability.mockReturnValue(() => mockRunnerProvider);
-  mockPrepareGroup.mockImplementation(async (labels) => ({
+  mockResolveLabelsForRunners.mockImplementation(async (labels) => ({
     runnerLabels: labels.filter((label) => label.startsWith('ghr-')),
     state: testProviderState,
   }));
@@ -673,7 +673,7 @@ describe('scaleUp with GHES', () => {
       expectedRunnerParams = { ...EXPECTED_RUNNER_PARAMS };
       mockSSMClient.reset();
 
-      mockPrepareGroup.mockImplementation(async (labels) => ({
+      mockResolveLabelsForRunners.mockImplementation(async (labels) => ({
         runnerLabels: labels.filter((label) => label.startsWith('ghr-')),
         state: testProviderState,
       }));

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -193,14 +193,14 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
     let groupRunnerLabels = runnerLabels;
 
     const messageLabels = messages.length > 0 ? (messages[0].labels ?? []) : [];
-    const preparedRunnerGroup = await runnerProvider.prepareGroup(messageLabels);
-    const dynamicLabels = preparedRunnerGroup.runnerLabels;
+    const runnerLabelResolution = await runnerProvider.resolveLabelsForRunners(messageLabels);
+    const resolvedRunnerLabels = runnerLabelResolution.runnerLabels;
 
-    if (dynamicLabels.length > 0) {
-      logger.debug('Dynamic labels present on message', { labels: dynamicLabels });
+    if (resolvedRunnerLabels.length > 0) {
+      logger.debug('Dynamic labels present on message', { labels: resolvedRunnerLabels });
       groupRunnerLabels = groupRunnerLabels
-        ? `${groupRunnerLabels},${dynamicLabels.join(',')}`
-        : dynamicLabels.join(',');
+        ? `${groupRunnerLabels},${resolvedRunnerLabels.join(',')}`
+        : resolvedRunnerLabels.join(',');
       logger.debug('Updated runner labels', { runnerLabels: groupRunnerLabels });
     }
 
@@ -251,7 +251,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
     const currentRunners =
       maximumRunners === -1
         ? 0
-        : await runnerProvider.getCurrentRunners(preparedRunnerGroup.state, { runnerType, runnerOwner });
+        : await runnerProvider.getCurrentRunners(runnerLabelResolution.state, { runnerType, runnerOwner });
 
     logger.info('Current runners', {
       currentRunners,
@@ -319,7 +319,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
         githubRunnerConfig,
         numberOfRunners: newRunners,
         githubInstallationClient,
-        state: preparedRunnerGroup.state,
+        state: runnerLabelResolution.state,
       });
     } catch (error) {
       logger.error('Runner provider threw an unexpected error.', {

--- a/lambdas/functions/control-plane/src/scale-runners/types.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/types.ts
@@ -4,7 +4,7 @@ export type {
   CreateScaleUpRunnersInput,
   CurrentRunnersInput,
   LambdaRunnerSource,
-  PreparedScaleUpRunnerGroup,
+  RunnerLabelResolution,
   RunnerInfo,
   RunnerType,
   ScaleDownRunnerProvider,

--- a/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-up.ts
+++ b/lambdas/functions/control-plane/src/test/runner-provider-contracts/scale-up.ts
@@ -42,7 +42,7 @@ export function defineScaleUpContractTests<TType extends string>({
         process.env.RUNNER_PROVIDER_TYPE = provider.type;
 
         resolveCapability.mockReturnValue(() => provider);
-        vi.mocked(provider.prepareGroup).mockResolvedValue({ runnerLabels: [], state });
+        vi.mocked(provider.resolveLabelsForRunners).mockResolvedValue({ runnerLabels: [], state });
         vi.mocked(provider.getCurrentRunners).mockResolvedValue(0);
         vi.mocked(provider.createRunners).mockResolvedValue(createResult);
       });
@@ -54,7 +54,7 @@ export function defineScaleUpContractTests<TType extends string>({
         await scaleUp(payloads);
 
         expect(resolveCapability).toHaveBeenCalledWith(provider.type, 'scaleUp');
-        expect(provider.prepareGroup).toHaveBeenCalledWith(['lane-label']);
+        expect(provider.resolveLabelsForRunners).toHaveBeenCalledWith(['lane-label']);
         expect(provider.getCurrentRunners).toHaveBeenCalledWith(state, {
           runnerOwner: payloads[0].repositoryOwner,
           runnerType: 'Org',

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -86,10 +86,10 @@ function expectedRunnerParams(
 }
 
 async function createProviderRunners(options: CreateProviderRunnersOptions = {}) {
-  const prepared = await provider.prepareGroup(options.labels ?? []);
+  const runnerLabelResolution = await provider.resolveLabelsForRunners(options.labels ?? []);
   const baseRunnerLabels = options.baseRunnerLabels ?? 'label1,label2';
   const githubRunnerConfig = runnerConfig({
-    runnerLabels: [baseRunnerLabels, ...prepared.runnerLabels].filter(Boolean).join(','),
+    runnerLabels: [baseRunnerLabels, ...runnerLabelResolution.runnerLabels].filter(Boolean).join(','),
     ...options.githubRunnerConfig,
   });
 
@@ -97,14 +97,16 @@ async function createProviderRunners(options: CreateProviderRunnersOptions = {})
     githubRunnerConfig,
     numberOfRunners: 1,
     githubInstallationClient: githubClient,
-    state: prepared.state,
+    state: runnerLabelResolution.state,
   });
 }
 
 async function expectCurrentRunners(runnerType: RunnerType, owner: string) {
-  const prepared = await provider.prepareGroup([]);
+  const runnerLabelResolution = await provider.resolveLabelsForRunners([]);
 
-  await expect(provider.getCurrentRunners(prepared.state, { runnerType, runnerOwner: owner })).resolves.toBe(1);
+  await expect(
+    provider.getCurrentRunners(runnerLabelResolution.state, { runnerType, runnerOwner: owner }),
+  ).resolves.toBe(1);
   expect(mockListRunners).toHaveBeenCalledWith({
     environment: 'unit-test-environment',
     runnerType,

--- a/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.ts
+++ b/lambdas/libs/runner-providers/aws/ec2/src/control-plane/scale-up.ts
@@ -4,7 +4,7 @@ import type {
   CreateScaleUpRunnersInput,
   CreateStartRunnerConfig,
   CurrentRunnersInput,
-  PreparedScaleUpRunnerGroup,
+  RunnerLabelResolution,
   ScaleUpRunnerProvider,
 } from '../../../../core';
 import yn from 'yn';
@@ -32,7 +32,7 @@ function loadEc2ScaleUpProviderConfig(): CreateEC2RunnerConfig {
   };
 }
 
-async function prepareEc2ScaleUpGroup(messageLabels: string[]): Promise<PreparedScaleUpRunnerGroup<Ec2ScaleUpState>> {
+async function resolveEc2LabelsForRunners(messageLabels: string[]): Promise<RunnerLabelResolution<Ec2ScaleUpState>> {
   const trimmedLabels = messageLabels.map((label) => label.trim());
   const dynamicEC2Labels = trimmedLabels.filter((label) => label.startsWith('ghr-ec2-'));
   const nonEc2DynamicLabels = trimmedLabels.filter(
@@ -85,7 +85,7 @@ export function createEc2ScaleUpProvider(
   createStartRunnerConfig: CreateStartRunnerConfig,
 ): Omit<ScaleUpRunnerProvider<Ec2ScaleUpState>, 'type'> {
   return {
-    prepareGroup: prepareEc2ScaleUpGroup,
+    resolveLabelsForRunners: resolveEc2LabelsForRunners,
     getCurrentRunners: getCurrentEc2Runners,
     createRunners: (input) => createEc2ScaleUpRunners(input, createStartRunnerConfig),
   };

--- a/lambdas/libs/runner-providers/core/index.ts
+++ b/lambdas/libs/runner-providers/core/index.ts
@@ -53,7 +53,7 @@ export interface CreateScaleUpRunnersInput<TState = unknown> {
   state: TState;
 }
 
-export interface PreparedScaleUpRunnerGroup<TState = unknown> {
+export interface RunnerLabelResolution<TState = unknown> {
   runnerLabels: string[];
   state: TState;
 }
@@ -65,7 +65,7 @@ export interface CreateRunnerResult {
 }
 
 export interface ScaleUpRunnerProvider<TState = unknown> extends RunnerProvider {
-  prepareGroup(messageLabels: string[]): Promise<PreparedScaleUpRunnerGroup<TState>>;
+  resolveLabelsForRunners(messageLabels: string[]): Promise<RunnerLabelResolution<TState>>;
   getCurrentRunners(state: TState, input: CurrentRunnersInput): Promise<number>;
   createRunners(input: CreateScaleUpRunnersInput<TState>): Promise<CreateRunnerResult>;
 }

--- a/lambdas/libs/runner-providers/registry.test.ts
+++ b/lambdas/libs/runner-providers/registry.test.ts
@@ -22,7 +22,7 @@ it('exposes every configured provider through both capability registries', () =>
       createRunners: expect.any(Function),
     });
     expect(controlPlaneRegistry.capability(type, 'scaleUp')()).toEqual({
-      prepareGroup: expect.any(Function),
+      resolveLabelsForRunners: expect.any(Function),
       getCurrentRunners: expect.any(Function),
       createRunners: expect.any(Function),
     });

--- a/lambdas/libs/runner-providers/templates/provider/control-plane.ts
+++ b/lambdas/libs/runner-providers/templates/provider/control-plane.ts
@@ -35,9 +35,9 @@ export function createTemplateScaleUpProvider(
   createStartRunnerConfig: CreateStartRunnerConfig,
 ): Omit<ScaleUpRunnerProvider, 'type'> {
   return {
-    prepareGroup: async (messageLabels) => {
+    resolveLabelsForRunners: async (messageLabels) => {
       void messageLabels;
-      return notImplemented('scaleUp.prepareGroup');
+      return notImplemented('scaleUp.resolveLabelsForRunners');
     },
     getCurrentRunners: async (state, input) => {
       const templateState = state as TemplateScaleUpState;

--- a/lambdas/libs/runner-providers/templates/provider/provider.test.ts
+++ b/lambdas/libs/runner-providers/templates/provider/provider.test.ts
@@ -17,7 +17,7 @@ it('exposes every runner provider capability from its lane entry point', () => {
     createRunners: expect.any(Function),
   });
   expect(scaleUp).toEqual({
-    prepareGroup: expect.any(Function),
+    resolveLabelsForRunners: expect.any(Function),
     getCurrentRunners: expect.any(Function),
     createRunners: expect.any(Function),
   });


### PR DESCRIPTION
## Description

- Rename the scale-up provider hook from `prepareGroup` to `resolveLabelsForRunners`.
- Replace `PreparedScaleUpRunnerGroup` with `RunnerLabelResolution`, containing the resolved `runnerLabels` and provider-specific `state`.
- Update control-plane orchestration, the EC2 provider, the provider template, registry expectations, and existing tests in place.
- Preserve runtime behavior while making the plugin contract explicit: message labels are resolved into runner labels and state used for runner lookup and creation.

## Test Plan

- Control-plane suite: 14 test files / 326 tests passed
- Runner-provider suite: 10 test files / 270 tests passed
- ESLint and Prettier passed for all changed files
- Exact test-title inventory: 276 before and after, with no additions or removals
- `git diff --check`

Local TypeScript build validation remains blocked by the installed `@aws-sdk/client-ec2` declarations missing exports used throughout the existing EC2 sources; the same environment issue affects untouched code.

## Related Issues

Stacked on #5248
