### PR TITLE
feat(runners): make the scale-up SQS event source mapping optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -224,6 +224,7 @@ module "runners" {
   lambda_runtime                                                 = var.lambda_runtime
   lambda_architecture                                            = var.lambda_architecture
   lambda_event_source_mapping_batch_size                         = var.lambda_event_source_mapping_batch_size
+  enable_scale_up_event_source_mapping                           = var.enable_scale_up_event_source_mapping
   lambda_event_source_mapping_maximum_batching_window_in_seconds = var.lambda_event_source_mapping_maximum_batching_window_in_seconds
   lambda_zip                                                     = var.runners_lambda_zip
   lambda_scale_up_memory_size                                    = var.runners_scale_up_lambda_memory_size

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -98,6 +98,7 @@ resource "aws_lambda_event_source_mapping" "scale_up" {
   function_response_types            = ["ReportBatchItemFailures"]
   batch_size                         = var.lambda_event_source_mapping_batch_size
   maximum_batching_window_in_seconds = var.lambda_event_source_mapping_maximum_batching_window_in_seconds
+  enabled                            = var.enable_scale_up_event_source_mapping
   tags                               = var.tags
 }
 

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -855,6 +855,12 @@ variable "lambda_event_source_mapping_batch_size" {
   }
 }
 
+variable "enable_scale_up_event_source_mapping" {
+  description = "Enable the SQS event source mapping that invokes the scale-up lambda. Disable to drive scale-up from an external consumer of the build queue, for example a rate limiter that paces CreateFleet calls. When disabled, nothing consumes the build queue unless you provide your own consumer."
+  type        = bool
+  default     = true
+}
+
 variable "lambda_event_source_mapping_maximum_batching_window_in_seconds" {
   description = "Maximum amount of time to gather records before invoking the lambda function, in seconds. AWS requires this to be greater than 0 if batch_size is greater than 10. Defaults to 0."
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -1152,6 +1152,12 @@ variable "lambda_event_source_mapping_batch_size" {
   default     = 10
 }
 
+variable "enable_scale_up_event_source_mapping" {
+  description = "Enable the SQS event source mapping that invokes the scale-up lambda. Disable to drive scale-up from an external consumer of the build queue, for example a rate limiter that paces CreateFleet calls. When disabled, nothing consumes the build queue unless you provide your own consumer."
+  type        = bool
+  default     = true
+}
+
 variable "lambda_event_source_mapping_maximum_batching_window_in_seconds" {
   description = "Maximum amount of time to gather records before invoking the lambda function, in seconds. AWS requires this to be greater than 0 if batch_size is greater than 10. Defaults to 0."
   type        = number


### PR DESCRIPTION
## Motivation

`CreateFleet` consumes the account's `ec2:RunInstances` request bucket, which AWS documents as **capacity 5, refill 2/sec**, per account per Region and adjustable only through a Support case. The module's own `docs/rate-limits-and-tuning.md` notes that `CreateFleet` "empirically throttles at low single-digit TPS".

When that limit is hit the failure does not settle on its own: a throttled call creates no instance, so the SQS message is never deleted, so it is redelivered, so more calls are made. We measured **6,833 scale-up invocations against 122 queued messages** with zero instances created — the retries manufacture the throttle that causes the retries.

The lever the module offers today is `scale_up_reserved_concurrent_executions`, but that bounds invocations **in flight**, not invocations **per second**. The two differ by the API's latency, so the same reservation of 5 yields ~2.5/sec at 2s per call and ~10/sec at 500ms. There is no setting that expresses a rate.

A rate limit needs a token bucket, and a token bucket needs a process that outlives a single event. Lambda invocations are independent processes with no shared state, so the counter has to live somewhere else — which means letting something else consume the build queue.

## What this changes

Adds `enable_scale_up_event_source_mapping` to the root module and to `modules/runners`, wired to the `enabled` argument of `aws_lambda_event_source_mapping.scale_up`.

Default is `true`, so **behaviour is unchanged for every existing configuration**. Setting it to `false` lets an external consumer drain the build queue at a controlled rate and invoke the scale-up lambda itself; the handler's contract is already suitable for that, since it takes a standard `SQSEvent` and returns `SQSBatchResponse`.

## Why a variable rather than doing it out of band

The resource does not set `enabled`, so the provider default (`true`) is what lands in state. Disabling the mapping with the AWS CLI therefore shows up as drift and is reverted by the next `apply` — silently re-enabling a second consumer of the queue.

## Related

- #5193 — visibility timeout tied to the lambda timeout; same area, not addressed here.
- The `docs/rate-limits-and-tuning.md` guidance on `batch_size` reduces `CreateFleet` calls per message but does not bound the call rate.

## Testing

`tofu fmt` and `tofu validate` pass. The change is inert at the default, and `terraform-docs` output is left to the `update-docs` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)