### PR TITLE
refactor(storage): make runner config store provider-neutral

### DIFF
--- a/lambdas/functions/control-plane/package.json
+++ b/lambdas/functions/control-plane/package.json
@@ -33,6 +33,7 @@
     "@aws-github-runner/aws-powertools-util": "*",
     "@aws-github-runner/aws-ssm-util": "*",
     "@aws-github-runner/compute-providers": "*",
+    "@aws-github-runner/storage-providers": "*",
     "@aws-lambda-powertools/parameters": "^2.31.0",
     "@aws-sdk/client-ec2": "^3.1009.0",
     "@aws-sdk/client-sqs": "^3.1009.0",

--- a/lambdas/functions/control-plane/src/modules.d.ts
+++ b/lambdas/functions/control-plane/src/modules.d.ts
@@ -18,7 +18,6 @@ declare namespace NodeJS {
     RUNNER_OWNER: string;
     COMPUTE_PROVIDER_TYPE?: string;
     SCALE_DOWN_CONFIG: string;
-    SSM_TOKEN_PATH: string;
     SSM_CLEANUP_CONFIG: string;
     SUBNET_IDS: string;
     INSTANCE_TYPES: string;

--- a/lambdas/functions/control-plane/src/pool/pool-contract.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool-contract.test.ts
@@ -1,6 +1,5 @@
 import type { Octokit } from '@octokit/rest';
 import type { ComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
-import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, vi } from 'vitest';
 
 import { definePoolContractTests } from '../test/compute-provider-contracts/pool';
@@ -50,7 +49,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
   process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';
-  resetRunnerConfigStore();
 
   mockedAppAuth.mockResolvedValue({ type: 'app', token: 'app-token', appId: 1, expiresAt: 'some-date' });
   mockedInstallationAuth.mockResolvedValue({

--- a/lambdas/functions/control-plane/src/pool/pool-contract.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool-contract.test.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 import type { ComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
+import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, vi } from 'vitest';
 
 import { definePoolContractTests } from '../test/compute-provider-contracts/pool';
@@ -48,6 +49,8 @@ const computeProviders = providerTypes.map((type) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
+  process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';
+  resetRunnerConfigStore();
 
   mockedAppAuth.mockResolvedValue({ type: 'app', token: 'app-token', appId: 1, expiresAt: 'some-date' });
   mockedInstallationAuth.mockResolvedValue({

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -166,17 +166,6 @@ describe('pool adjustment', () => {
 
       expect(poolProvider.createRunners).not.toHaveBeenCalled();
     });
-
-    it('rejects an unsupported runner config store before GitHub or runner lookups', async () => {
-      process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'unsupported-provider';
-
-      await expect(adjust({ poolSize: 10 })).rejects.toThrow(
-        "Unsupported runner config storage provider 'unsupported-provider'",
-      );
-
-      expect(mockedAppAuth).not.toHaveBeenCalled();
-      expect(poolProvider.listRunners).not.toHaveBeenCalled();
-    });
   });
 
   describe('With GHES', () => {

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
+import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as ghAuth from '../github/auth';
@@ -90,6 +91,7 @@ const githubRunnersRegistered = [
 beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
+  resetRunnerConfigStore();
   process.env.RUNNERS_MAXIMUM_COUNT = '-1';
   process.env.ENVIRONMENT = 'unit-test-environment';
   process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';
@@ -165,6 +167,17 @@ describe('pool adjustment', () => {
       await adjust({ poolSize: 1 });
 
       expect(poolProvider.createRunners).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported runner config store before GitHub or runner lookups', async () => {
+      process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'unsupported-provider';
+
+      await expect(adjust({ poolSize: 10 })).rejects.toThrow(
+        "Unsupported runner config storage provider 'unsupported-provider'",
+      );
+
+      expect(mockedAppAuth).not.toHaveBeenCalled();
+      expect(poolProvider.listRunners).not.toHaveBeenCalled();
     });
   });
 

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -1,6 +1,5 @@
 import type { Octokit } from '@octokit/rest';
 import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
-import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as ghAuth from '../github/auth';
@@ -91,7 +90,6 @@ const githubRunnersRegistered = [
 beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
-  resetRunnerConfigStore();
   process.env.RUNNERS_MAXIMUM_COUNT = '-1';
   process.env.ENVIRONMENT = 'unit-test-environment';
   process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';

--- a/lambdas/functions/control-plane/src/pool/pool.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.ts
@@ -1,6 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { resolveComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
+import { getRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import yn from 'yn';
 
 import {
@@ -31,7 +32,6 @@ export async function adjust(event: PoolEvent): Promise<void> {
   const runnerGroup = process.env.RUNNER_GROUP_NAME || '';
   const runnerNamePrefix = process.env.RUNNER_NAME_PREFIX || '';
   const environment = process.env.ENVIRONMENT;
-  const ssmTokenPath = process.env.SSM_TOKEN_PATH;
   const ssmConfigPath = process.env.SSM_CONFIG_PATH || '';
   const ephemeral = yn(process.env.ENABLE_EPHEMERAL_RUNNERS, { default: false });
   const enableJitConfig = yn(process.env.ENABLE_JIT_CONFIG, { default: ephemeral });
@@ -41,6 +41,7 @@ export async function adjust(event: PoolEvent): Promise<void> {
     process.env.SSM_PARAMETER_STORE_TAGS && process.env.SSM_PARAMETER_STORE_TAGS.trim() !== ''
       ? validateSsmParameterStoreTags(process.env.SSM_PARAMETER_STORE_TAGS)
       : [];
+  getRunnerConfigStore();
   // -1 disables the maximum check, matching the scale-up lambda's semantics. Defaults to unlimited
   // when unset so the pool keeps its previous behavior on stacks that do not provide the variable.
   const maximumRunners = parseInt(process.env.RUNNERS_MAXIMUM_COUNT || '-1');
@@ -103,7 +104,6 @@ export async function adjust(event: PoolEvent): Promise<void> {
         runnerNamePrefix,
         runnerType: 'Org',
         disableAutoUpdate: disableAutoUpdate,
-        ssmTokenPath,
         ssmConfigPath,
         ssmParameterStoreTags,
       },

--- a/lambdas/functions/control-plane/src/pool/pool.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.ts
@@ -1,7 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { resolveComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
-import { getRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import yn from 'yn';
 
 import {
@@ -41,7 +40,6 @@ export async function adjust(event: PoolEvent): Promise<void> {
     process.env.SSM_PARAMETER_STORE_TAGS && process.env.SSM_PARAMETER_STORE_TAGS.trim() !== ''
       ? validateSsmParameterStoreTags(process.env.SSM_PARAMETER_STORE_TAGS)
       : [];
-  getRunnerConfigStore();
   // -1 disables the maximum check, matching the scale-up lambda's semantics. Defaults to unlimited
   // when unset so the pool keeps its previous behavior on stacks that do not provide the variable.
   const maximumRunners = parseInt(process.env.RUNNERS_MAXIMUM_COUNT || '-1');

--- a/lambdas/functions/control-plane/src/scale-runners/github-runner.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/github-runner.ts
@@ -1,5 +1,10 @@
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { getParameter, putParameter } from '@aws-github-runner/aws-ssm-util';
+import {
+  getRunnerConfigStore,
+  type RunnerConfigMetadataTag,
+  type RunnerConfigStore,
+} from '@aws-github-runner/storage-providers';
 import { Octokit } from '@octokit/rest';
 
 import { getStoredInstallationId } from '../github/auth';
@@ -14,7 +19,7 @@ export interface GitHubRunnerMetadata {
 }
 
 export interface StartRunnerConfigOptions {
-  getSsmParameterTags?: (runnerId: string) => { Key: string; Value: string }[];
+  getRunnerConfigMetadataTags?: (runnerId: string) => RunnerConfigMetadataTag[];
   onJitConfigCreated?: (runnerId: string, metadata: GitHubRunnerMetadata) => Promise<void>;
 }
 
@@ -250,18 +255,20 @@ export async function createStartRunnerConfig(
   ghClient: Octokit,
   options: StartRunnerConfigOptions = {},
 ): Promise<string[]> {
+  const runnerConfigStore = getRunnerConfigStore();
   if (githubRunnerConfig.enableJitConfig && githubRunnerConfig.ephemeral) {
-    return await createJitConfig(githubRunnerConfig, runnerIds, ghClient, options);
+    return await createJitConfig(githubRunnerConfig, runnerIds, ghClient, runnerConfigStore, options);
   } else {
-    return await createRegistrationTokenConfig(githubRunnerConfig, runnerIds, ghClient, options);
+    return await createRegistrationTokenConfig(githubRunnerConfig, runnerIds, ghClient, runnerConfigStore, options);
   }
 }
 
-function addDelay(runnerIds: string[]) {
+function addDelay(runnerIds: string[], runnerConfigStore: RunnerConfigStore) {
   const delay = async (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-  const ssmParameterStoreMaxThroughput = 40;
-  const isDelay = runnerIds.length >= ssmParameterStoreMaxThroughput;
-  return { isDelay, delay };
+  const maxWritesPerSecond = runnerConfigStore.maxWritesPerSecond;
+  const isDelay = maxWritesPerSecond !== undefined && runnerIds.length >= maxWritesPerSecond;
+  const delayMilliseconds = maxWritesPerSecond === undefined ? 0 : 1000 / maxWritesPerSecond;
+  return { isDelay, delay, delayMilliseconds };
 }
 
 /**
@@ -273,9 +280,10 @@ async function createRegistrationTokenConfig(
   githubRunnerConfig: CreateGitHubRunnerConfig,
   runnerIds: string[],
   ghClient: Octokit,
+  runnerConfigStore: RunnerConfigStore,
   options: StartRunnerConfigOptions,
 ): Promise<string[]> {
-  const { isDelay, delay } = addDelay(runnerIds);
+  const { isDelay, delay, delayMilliseconds } = addDelay(runnerIds, runnerConfigStore);
   const token = await getGithubRunnerRegistrationToken(githubRunnerConfig, ghClient);
   const runnerServiceConfig = generateRunnerServiceConfig(githubRunnerConfig, token);
 
@@ -284,12 +292,13 @@ async function createRegistrationTokenConfig(
   });
 
   for (const runnerId of runnerIds) {
-    await putParameter(`${githubRunnerConfig.ssmTokenPath}/${runnerId}`, runnerServiceConfig.join(' '), true, {
-      tags: [...(options.getSsmParameterTags?.(runnerId) ?? []), ...githubRunnerConfig.ssmParameterStoreTags],
-    });
+    await runnerConfigStore.create(
+      { runnerId, value: runnerServiceConfig.join(' ') },
+      { metadataTags: options.getRunnerConfigMetadataTags?.(runnerId) },
+    );
     if (isDelay) {
-      // Delay to prevent AWS ssm rate limits by being within the max throughput limit
-      await delay(25);
+      // Delay to stay within the selected store's maximum write throughput.
+      await delay(delayMilliseconds);
     }
   }
 
@@ -306,10 +315,11 @@ async function createJitConfig(
   githubRunnerConfig: CreateGitHubRunnerConfig,
   runnerIds: string[],
   ghClient: Octokit,
+  runnerConfigStore: RunnerConfigStore,
   options: StartRunnerConfigOptions,
 ): Promise<string[]> {
   const runnerGroupId = await getRunnerGroupId(githubRunnerConfig, ghClient);
-  const { isDelay, delay } = addDelay(runnerIds);
+  const { isDelay, delay, delayMilliseconds } = addDelay(runnerIds, runnerConfigStore);
   const runnerLabels = githubRunnerConfig.runnerLabels.split(',');
   const failedRunnerIds: string[] = [];
 
@@ -347,16 +357,16 @@ async function createJitConfig(
         runnerLabels,
       });
 
-      // store jit config in ssm parameter store
       logger.debug('Runner JIT config for ephemeral runner generated.', {
         instance: runnerId,
       });
-      await putParameter(`${githubRunnerConfig.ssmTokenPath}/${runnerId}`, runnerConfig.data.encoded_jit_config, true, {
-        tags: [...(options.getSsmParameterTags?.(runnerId) ?? []), ...githubRunnerConfig.ssmParameterStoreTags],
-      });
+      await runnerConfigStore.create(
+        { runnerId, value: runnerConfig.data.encoded_jit_config },
+        { metadataTags: options.getRunnerConfigMetadataTags?.(runnerId) },
+      );
       if (isDelay) {
-        // Delay to prevent AWS ssm rate limits by being within the max throughput limit
-        await delay(25);
+        // Delay to stay within the selected store's maximum write throughput.
+        await delay(delayMilliseconds);
       }
     } catch (error) {
       failedRunnerIds.push(runnerId);

--- a/lambdas/functions/control-plane/src/scale-runners/github-runner.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/github-runner.ts
@@ -1,8 +1,8 @@
 import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { getParameter, putParameter } from '@aws-github-runner/aws-ssm-util';
 import {
-  getRunnerConfigStore,
-  type RunnerConfigMetadataTag,
+  createRunnerConfigStore,
+  type RunnerConfigMetadata,
   type RunnerConfigStore,
 } from '@aws-github-runner/storage-providers';
 import { Octokit } from '@octokit/rest';
@@ -19,7 +19,7 @@ export interface GitHubRunnerMetadata {
 }
 
 export interface StartRunnerConfigOptions {
-  getRunnerConfigMetadataTags?: (runnerId: string) => RunnerConfigMetadataTag[];
+  getRunnerConfigMetadata?: (runnerId: string) => RunnerConfigMetadata[];
   onJitConfigCreated?: (runnerId: string, metadata: GitHubRunnerMetadata) => Promise<void>;
 }
 
@@ -255,7 +255,7 @@ export async function createStartRunnerConfig(
   ghClient: Octokit,
   options: StartRunnerConfigOptions = {},
 ): Promise<string[]> {
-  const runnerConfigStore = getRunnerConfigStore();
+  const runnerConfigStore = createRunnerConfigStore();
   if (githubRunnerConfig.enableJitConfig && githubRunnerConfig.ephemeral) {
     return await createJitConfig(githubRunnerConfig, runnerIds, ghClient, runnerConfigStore, options);
   } else {
@@ -294,7 +294,7 @@ async function createRegistrationTokenConfig(
   for (const runnerId of runnerIds) {
     await runnerConfigStore.create(
       { runnerId, value: runnerServiceConfig.join(' ') },
-      { metadataTags: options.getRunnerConfigMetadataTags?.(runnerId) },
+      { metadata: options.getRunnerConfigMetadata?.(runnerId) },
     );
     if (isDelay) {
       // Delay to stay within the selected store's maximum write throughput.
@@ -362,7 +362,7 @@ async function createJitConfig(
       });
       await runnerConfigStore.create(
         { runnerId, value: runnerConfig.data.encoded_jit_config },
-        { metadataTags: options.getRunnerConfigMetadataTags?.(runnerId) },
+        { metadata: options.getRunnerConfigMetadata?.(runnerId) },
       );
       if (isDelay) {
         // Delay to stay within the selected store's maximum write throughput.

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
@@ -1,5 +1,4 @@
 import type { Octokit } from '@octokit/rest';
-import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, vi } from 'vitest';
 
 import { providerTypes } from '../test/compute-provider-contracts/provider-types';
@@ -58,7 +57,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
   process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';
-  resetRunnerConfigStore();
 
   mockedAppAuth.mockResolvedValue({ type: 'app', token: 'app-token', appId: 1, expiresAt: 'some-date' });
   mockedInstallationAuth.mockResolvedValue({

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up-contract.test.ts
@@ -1,4 +1,5 @@
 import type { Octokit } from '@octokit/rest';
+import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, vi } from 'vitest';
 
 import { providerTypes } from '../test/compute-provider-contracts/provider-types';
@@ -56,6 +57,8 @@ const computeProviders = providerTypes.map((type) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   process.env = { ...cleanEnv };
+  process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/tokens';
+  resetRunnerConfigStore();
 
   mockedAppAuth.mockResolvedValue({ type: 'app', token: 'app-token', appId: 1, expiresAt: 'some-date' });
   mockedInstallationAuth.mockResolvedValue({

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -2167,19 +2167,6 @@ describe('compute provider selection', () => {
   });
 });
 
-describe('runner config store preflight', () => {
-  it('rejects an unsupported store before resolving compute or GitHub providers', async () => {
-    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'unsupported-provider';
-
-    await expect(scaleUpModule.scaleUp(TEST_DATA)).rejects.toThrow(
-      "Unsupported runner config storage provider 'unsupported-provider'",
-    );
-
-    expect(mockedResolveCapability).not.toHaveBeenCalled();
-    expect(mockedAppAuth).not.toHaveBeenCalled();
-  });
-});
-
 describe('Multi-app round-robin', () => {
   const mockedGetAppCount = vi.mocked(ghAuth.getAppCount);
   const mockedGetStoredInstallationId = vi.mocked(ghAuth.getStoredInstallationId);

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -18,7 +18,6 @@ import type {
 } from './types';
 import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
-import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Octokit } from '@octokit/rest';
 
@@ -170,7 +169,7 @@ async function createTestProviderRunners(input: CreateScaleUpRunnersInput<unknow
       result.instances,
       input.githubInstallationClient,
       {
-        getRunnerConfigMetadataTags: (runnerId) => [{ key: 'RunnerId', value: runnerId }],
+        getRunnerConfigMetadata: (runnerId) => [{ key: 'RunnerId', value: runnerId }],
       },
     );
   } catch {
@@ -189,7 +188,6 @@ beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   setDefaults();
-  resetRunnerConfigStore();
 
   defaultSSMGetParameterMockImpl();
   defaultOctokitMockImpl();

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -18,6 +18,7 @@ import type {
 } from './types';
 import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
+import { resetRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Octokit } from '@octokit/rest';
 
@@ -147,6 +148,7 @@ function setDefaults() {
   process.env.GITHUB_APP_CLIENT_SECRET = 'TEST_CLIENT_SECRET';
   process.env.RUNNERS_MAXIMUM_COUNT = '3';
   process.env.ENVIRONMENT = EXPECTED_RUNNER_PARAMS.environment;
+  process.env.SSM_TOKEN_PATH = '/github-action-runners/default/runners/config';
 }
 
 async function createTestProviderRunners(input: CreateScaleUpRunnersInput<unknown>): Promise<CreateRunnerResult> {
@@ -168,7 +170,7 @@ async function createTestProviderRunners(input: CreateScaleUpRunnersInput<unknow
       result.instances,
       input.githubInstallationClient,
       {
-        getSsmParameterTags: (runnerId) => [{ Key: 'RunnerId', Value: runnerId }],
+        getRunnerConfigMetadataTags: (runnerId) => [{ key: 'RunnerId', value: runnerId }],
       },
     );
   } catch {
@@ -187,6 +189,7 @@ beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   setDefaults();
+  resetRunnerConfigStore();
 
   defaultSSMGetParameterMockImpl();
   defaultOctokitMockImpl();
@@ -2162,6 +2165,19 @@ describe('compute provider selection', () => {
     await expect(scaleUpModule.scaleUp(TEST_DATA)).rejects.toThrow(
       "Unsupported compute provider type 'unsupported-provider'",
     );
+    expect(mockedAppAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe('runner config store preflight', () => {
+  it('rejects an unsupported store before resolving compute or GitHub providers', async () => {
+    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'unsupported-provider';
+
+    await expect(scaleUpModule.scaleUp(TEST_DATA)).rejects.toThrow(
+      "Unsupported runner config storage provider 'unsupported-provider'",
+    );
+
+    expect(mockedResolveCapability).not.toHaveBeenCalled();
     expect(mockedAppAuth).not.toHaveBeenCalled();
   });
 });

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -1,5 +1,6 @@
 import { addPersistentContextToChildLogger, createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { resolveComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
+import { getRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { Octokit } from '@octokit/rest';
 import yn from 'yn';
 
@@ -80,7 +81,6 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
   const maximumRunners = parseInt(process.env.RUNNERS_MAXIMUM_COUNT || '3');
   const runnerLabels = process.env.RUNNER_LABELS || '';
   const runnerGroup = process.env.RUNNER_GROUP_NAME || 'Default';
-  const ssmTokenPath = process.env.SSM_TOKEN_PATH;
   const ephemeralEnabled = yn(process.env.ENABLE_EPHEMERAL_RUNNERS, { default: false });
   const enableJitConfig = yn(process.env.ENABLE_JIT_CONFIG, { default: ephemeralEnabled });
   const disableAutoUpdate = yn(process.env.DISABLE_RUNNER_AUTOUPDATE, { default: false });
@@ -91,6 +91,7 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
     process.env.SSM_PARAMETER_STORE_TAGS && process.env.SSM_PARAMETER_STORE_TAGS.trim() !== ''
       ? validateSsmParameterStoreTags(process.env.SSM_PARAMETER_STORE_TAGS)
       : [];
+  getRunnerConfigStore();
   const computeProviderType = resolveComputeProviderType(process.env.COMPUTE_PROVIDER_TYPE);
   const computeProvider = {
     ...controlPlaneProviderRegistry.capability(computeProviderType, 'scaleUp')(),
@@ -318,7 +319,6 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
       runnerOwner: runnerOwner,
       runnerType,
       disableAutoUpdate,
-      ssmTokenPath,
       ssmConfigPath,
       ssmParameterStoreTags,
     };

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -1,6 +1,5 @@
 import { addPersistentContextToChildLogger, createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { resolveComputeProviderType } from '@aws-github-runner/compute-providers/provider-types';
-import { getRunnerConfigStore } from '@aws-github-runner/storage-providers';
 import { Octokit } from '@octokit/rest';
 import yn from 'yn';
 
@@ -91,7 +90,6 @@ export async function scaleUp(payloads: ActionRequestMessageSQS[]): Promise<stri
     process.env.SSM_PARAMETER_STORE_TAGS && process.env.SSM_PARAMETER_STORE_TAGS.trim() !== ''
       ? validateSsmParameterStoreTags(process.env.SSM_PARAMETER_STORE_TAGS)
       : [];
-  getRunnerConfigStore();
   const computeProviderType = resolveComputeProviderType(process.env.COMPUTE_PROVIDER_TYPE);
   const computeProvider = {
     ...controlPlaneProviderRegistry.capability(computeProviderType, 'scaleUp')(),

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
@@ -148,8 +148,9 @@ async function terminateFailedInstances(
 
 function createEc2StartRunnerConfigOptions(ec2Operations: Ec2RunnerResourceOperations): StartRunnerConfigOptions {
   return {
-    getSsmParameterTags: (instanceId) => [{ Key: 'InstanceId', Value: instanceId }],
-    onJitConfigCreated: async (instanceId, metadata) => await tagEc2RunnerMetadata(ec2Operations, instanceId, metadata),
+    getRunnerConfigMetadataTags: (instanceId) => [{ key: 'InstanceId', value: instanceId }],
+    onJitConfigCreated: async (instanceId, metadata) =>
+      await tagEc2RunnerMetadata(ec2Operations, instanceId, metadata),
   };
 }
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
@@ -148,7 +148,7 @@ async function terminateFailedInstances(
 
 function createEc2StartRunnerConfigOptions(ec2Operations: Ec2RunnerResourceOperations): StartRunnerConfigOptions {
   return {
-    getRunnerConfigMetadataTags: (instanceId) => [{ key: 'InstanceId', value: instanceId }],
+    getRunnerConfigMetadata: (instanceId) => [{ key: 'InstanceId', value: instanceId }],
     onJitConfigCreated: async (instanceId, metadata) =>
       await tagEc2RunnerMetadata(ec2Operations, instanceId, metadata),
   };

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-creation.ts
@@ -149,8 +149,7 @@ async function terminateFailedInstances(
 function createEc2StartRunnerConfigOptions(ec2Operations: Ec2RunnerResourceOperations): StartRunnerConfigOptions {
   return {
     getRunnerConfigMetadata: (instanceId) => [{ key: 'InstanceId', value: instanceId }],
-    onJitConfigCreated: async (instanceId, metadata) =>
-      await tagEc2RunnerMetadata(ec2Operations, instanceId, metadata),
+    onJitConfigCreated: async (instanceId, metadata) => await tagEc2RunnerMetadata(ec2Operations, instanceId, metadata),
   };
 }
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -51,7 +51,6 @@ function runnerConfig(overrides: Partial<CreateGitHubRunnerConfig> = {}): Create
     runnerOwner,
     runnerType: 'Org',
     disableAutoUpdate: false,
-    ssmTokenPath: '/github-action-runners/default/runners/config',
     ssmConfigPath: '/github-action-runners/default/runners/config',
     ssmParameterStoreTags: [],
     ...overrides,
@@ -175,7 +174,7 @@ describe('scaleUp with GHES', () => {
         { Key: 'ghr:runner_labels', Value: 'label1,label2' },
       ]);
       const [, , , options] = mockCreateStartRunnerConfig.mock.calls[0];
-      expect(options?.getSsmParameterTags?.('i-12345')).toEqual([{ Key: 'InstanceId', Value: 'i-12345' }]);
+      expect(options?.getRunnerConfigMetadataTags?.('i-12345')).toEqual([{ key: 'InstanceId', value: 'i-12345' }]);
     });
 
     it('chunks comma-joined GitHub runner labels by the EC2 tag value max length', async () => {

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -174,7 +174,7 @@ describe('scaleUp with GHES', () => {
         { Key: 'ghr:runner_labels', Value: 'label1,label2' },
       ]);
       const [, , , options] = mockCreateStartRunnerConfig.mock.calls[0];
-      expect(options?.getRunnerConfigMetadataTags?.('i-12345')).toEqual([{ key: 'InstanceId', value: 'i-12345' }]);
+      expect(options?.getRunnerConfigMetadata?.('i-12345')).toEqual([{ key: 'InstanceId', value: 'i-12345' }]);
     });
 
     it('chunks comma-joined GitHub runner labels by the EC2 tag value max length', async () => {

--- a/lambdas/libs/compute-providers/core/index.ts
+++ b/lambdas/libs/compute-providers/core/index.ts
@@ -31,7 +31,7 @@ export interface GitHubRunnerMetadata {
 }
 
 export interface StartRunnerConfigOptions {
-  getRunnerConfigMetadataTags?: (runnerId: string) => { key: string; value: string }[];
+  getRunnerConfigMetadata?: (runnerId: string) => { key: string; value: string }[];
   onJitConfigCreated?: (runnerId: string, metadata: GitHubRunnerMetadata) => Promise<void>;
 }
 

--- a/lambdas/libs/compute-providers/core/index.ts
+++ b/lambdas/libs/compute-providers/core/index.ts
@@ -21,7 +21,6 @@ export interface CreateGitHubRunnerConfig {
   runnerOwner: string;
   runnerType: RunnerType;
   disableAutoUpdate: boolean;
-  ssmTokenPath: string;
   ssmConfigPath: string;
   ssmParameterStoreTags: { Key: string; Value: string }[];
 }
@@ -32,7 +31,7 @@ export interface GitHubRunnerMetadata {
 }
 
 export interface StartRunnerConfigOptions {
-  getSsmParameterTags?: (runnerId: string) => { Key: string; Value: string }[];
+  getRunnerConfigMetadataTags?: (runnerId: string) => { key: string; value: string }[];
   onJitConfigCreated?: (runnerId: string, metadata: GitHubRunnerMetadata) => Promise<void>;
 }
 

--- a/lambdas/libs/compute-providers/package.json
+++ b/lambdas/libs/compute-providers/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@aws-github-runner/aws-powertools-util": "*",
     "@aws-github-runner/aws-ssm-util": "*",
+    "@aws-github-runner/storage-providers": "*",
     "@aws-sdk/client-ec2": "^3.1009.0",
     "@octokit/rest": "22.0.1",
     "moment": "2.29.4",

--- a/lambdas/libs/storage-providers/aws/ssm/environment.d.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/environment.d.ts
@@ -1,0 +1,10 @@
+export {};
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      SSM_PARAMETER_STORE_TAGS?: string;
+      SSM_TOKEN_PATH?: string;
+    }
+  }
+}

--- a/lambdas/libs/storage-providers/aws/ssm/parameter-store-tags.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/parameter-store-tags.ts
@@ -1,0 +1,42 @@
+interface SsmParameterStoreTag {
+  Key: string;
+  Value: string;
+}
+
+export function loadSsmParameterStoreTagsFromEnvironment(): SsmParameterStoreTag[] {
+  return process.env.SSM_PARAMETER_STORE_TAGS && process.env.SSM_PARAMETER_STORE_TAGS.trim() !== ''
+    ? validateSsmParameterStoreTags(process.env.SSM_PARAMETER_STORE_TAGS)
+    : [];
+}
+
+function validateSsmParameterStoreTags(tagsJson: string): SsmParameterStoreTag[] {
+  try {
+    const tags: unknown = JSON.parse(tagsJson);
+
+    if (!Array.isArray(tags)) {
+      throw new Error('Tags must be an array');
+    }
+
+    if (tags.length === 0) {
+      return [];
+    }
+
+    tags.forEach((tag: unknown, index: number) => {
+      if (typeof tag !== 'object' || tag === null) {
+        throw new Error(`Tag at index ${index} must be an object`);
+      }
+
+      const candidate = tag as Record<string, unknown>;
+      if (!candidate.Key || typeof candidate.Key !== 'string' || candidate.Key.trim() === '') {
+        throw new Error(`Tag at index ${index} has missing or invalid 'Key' property`);
+      }
+      if (!Object.prototype.hasOwnProperty.call(candidate, 'Value') || typeof candidate.Value !== 'string') {
+        throw new Error(`Tag at index ${index} has missing or invalid 'Value' property`);
+      }
+    });
+
+    return tags as SsmParameterStoreTag[];
+  } catch (error) {
+    throw new Error(`Failed to parse SSM_PARAMETER_STORE_TAGS: ${(error as Error).message}`);
+  }
+}

--- a/lambdas/libs/storage-providers/aws/ssm/runner-config-store.test.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/runner-config-store.test.ts
@@ -27,7 +27,7 @@ describe('aws_ssm runner config store', () => {
 
     await store.create(
       { runnerId: 'i-123', value: 'encoded-jit-config' },
-      { metadataTags: [{ key: 'InstanceId', value: 'i-123' }] },
+      { metadata: [{ key: 'InstanceId', value: 'i-123' }] },
     );
 
     expect(store.maxWritesPerSecond).toBe(40);

--- a/lambdas/libs/storage-providers/aws/ssm/runner-config-store.test.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/runner-config-store.test.ts
@@ -1,0 +1,88 @@
+import { putParameter } from '@aws-github-runner/aws-ssm-util';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createAwsSsmRunnerConfigStore } from './runner-config-store';
+
+vi.mock('@aws-github-runner/aws-ssm-util', () => ({
+  putParameter: vi.fn(),
+}));
+
+const putParameterMock = vi.mocked(putParameter);
+const cleanEnv = process.env;
+
+describe('aws_ssm runner config store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...cleanEnv };
+    delete process.env.SSM_PARAMETER_STORE_TAGS;
+    process.env.SSM_TOKEN_PATH = '/runner/tokens';
+  });
+
+  it('creates a secure parameter at the legacy path with metadata tags before configured tags', async () => {
+    process.env.SSM_PARAMETER_STORE_TAGS = JSON.stringify([
+      { Key: 'Environment', Value: 'test' },
+      { Key: 'Team', Value: 'actions' },
+    ]);
+    const store = createAwsSsmRunnerConfigStore();
+
+    await store.create(
+      { runnerId: 'i-123', value: 'encoded-jit-config' },
+      { metadataTags: [{ key: 'InstanceId', value: 'i-123' }] },
+    );
+
+    expect(store.maxWritesPerSecond).toBe(40);
+    expect(putParameterMock).toHaveBeenCalledWith('/runner/tokens/i-123', 'encoded-jit-config', true, {
+      tags: [
+        { Key: 'InstanceId', Value: 'i-123' },
+        { Key: 'Environment', Value: 'test' },
+        { Key: 'Team', Value: 'actions' },
+      ],
+    });
+  });
+
+  it('uses an empty tag list when no tags are configured', async () => {
+    const store = createAwsSsmRunnerConfigStore();
+
+    await store.create({ runnerId: 'runner-1', value: 'registration-config' });
+
+    expect(putParameterMock).toHaveBeenCalledWith('/runner/tokens/runner-1', 'registration-config', true, {
+      tags: [],
+    });
+  });
+
+  it.each([undefined, '', '   '])('rejects missing or blank SSM_TOKEN_PATH %j before writing', (tokenPath) => {
+    setTokenPath(tokenPath);
+
+    expect(() => createAwsSsmRunnerConfigStore()).toThrow('Environment variable SSM_TOKEN_PATH is not set');
+    expect(putParameterMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['{}', 'Tags must be an array'],
+    ['[null]', 'Tag at index 0 must be an object'],
+    [JSON.stringify([{ Key: '', Value: 'test' }]), "Tag at index 0 has missing or invalid 'Key' property"],
+    [JSON.stringify([{ Key: 'Environment' }]), "Tag at index 0 has missing or invalid 'Value' property"],
+  ])('rejects invalid legacy SSM parameter tags', (tags, reason) => {
+    process.env.SSM_PARAMETER_STORE_TAGS = tags;
+
+    expect(() => createAwsSsmRunnerConfigStore()).toThrow(`Failed to parse SSM_PARAMETER_STORE_TAGS: ${reason}`);
+    expect(putParameterMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a blank legacy tag value as no configured tags', async () => {
+    process.env.SSM_PARAMETER_STORE_TAGS = '   ';
+    const store = createAwsSsmRunnerConfigStore();
+
+    await store.create({ runnerId: 'runner-1', value: 'jit-config' });
+
+    expect(putParameterMock).toHaveBeenCalledWith('/runner/tokens/runner-1', 'jit-config', true, { tags: [] });
+  });
+});
+
+function setTokenPath(tokenPath: string | undefined): void {
+  if (tokenPath === undefined) {
+    delete process.env.SSM_TOKEN_PATH;
+  } else {
+    process.env.SSM_TOKEN_PATH = tokenPath;
+  }
+}

--- a/lambdas/libs/storage-providers/aws/ssm/runner-config-store.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/runner-config-store.ts
@@ -1,6 +1,6 @@
 import { putParameter } from '@aws-github-runner/aws-ssm-util';
 
-import type { RunnerConfigMetadataTag, RunnerConfigRecord, RunnerConfigStore } from '../../core';
+import type { RunnerConfigMetadata, RunnerConfigRecord, RunnerConfigStore } from '../../core';
 import type {} from './environment';
 import { loadSsmParameterStoreTagsFromEnvironment } from './parameter-store-tags';
 
@@ -26,10 +26,10 @@ class AwsSsmRunnerConfigStore implements RunnerConfigStore {
 
   constructor(private readonly config: AwsSsmRunnerConfigStoreConfig) {}
 
-  async create(record: RunnerConfigRecord, options: { metadataTags?: RunnerConfigMetadataTag[] } = {}): Promise<void> {
+  async create(record: RunnerConfigRecord, options: { metadata?: RunnerConfigMetadata[] } = {}): Promise<void> {
     await putParameter(`${this.config.tokenPath}/${record.runnerId}`, record.value, true, {
       tags: [
-        ...(options.metadataTags ?? []).map(({ key, value }) => ({ Key: key, Value: value })),
+        ...(options.metadata ?? []).map(({ key, value }) => ({ Key: key, Value: value })),
         ...this.config.parameterStoreTags,
       ],
     });

--- a/lambdas/libs/storage-providers/aws/ssm/runner-config-store.ts
+++ b/lambdas/libs/storage-providers/aws/ssm/runner-config-store.ts
@@ -1,0 +1,37 @@
+import { putParameter } from '@aws-github-runner/aws-ssm-util';
+
+import type { RunnerConfigMetadataTag, RunnerConfigRecord, RunnerConfigStore } from '../../core';
+import type {} from './environment';
+import { loadSsmParameterStoreTagsFromEnvironment } from './parameter-store-tags';
+
+interface AwsSsmRunnerConfigStoreConfig {
+  tokenPath: string;
+  parameterStoreTags: { Key: string; Value: string }[];
+}
+
+export function createAwsSsmRunnerConfigStore(): RunnerConfigStore {
+  const tokenPath = process.env.SSM_TOKEN_PATH;
+  if (!tokenPath || tokenPath.trim() === '') {
+    throw new Error('Environment variable SSM_TOKEN_PATH is not set');
+  }
+
+  return new AwsSsmRunnerConfigStore({
+    tokenPath,
+    parameterStoreTags: loadSsmParameterStoreTagsFromEnvironment(),
+  });
+}
+
+class AwsSsmRunnerConfigStore implements RunnerConfigStore {
+  readonly maxWritesPerSecond = 40;
+
+  constructor(private readonly config: AwsSsmRunnerConfigStoreConfig) {}
+
+  async create(record: RunnerConfigRecord, options: { metadataTags?: RunnerConfigMetadataTag[] } = {}): Promise<void> {
+    await putParameter(`${this.config.tokenPath}/${record.runnerId}`, record.value, true, {
+      tags: [
+        ...(options.metadataTags ?? []).map(({ key, value }) => ({ Key: key, Value: value })),
+        ...this.config.parameterStoreTags,
+      ],
+    });
+  }
+}

--- a/lambdas/libs/storage-providers/core/index.ts
+++ b/lambdas/libs/storage-providers/core/index.ts
@@ -1,4 +1,4 @@
-export interface RunnerConfigMetadataTag {
+export interface RunnerConfigMetadata {
   key: string;
   value: string;
 }
@@ -10,5 +10,5 @@ export interface RunnerConfigRecord {
 
 export interface RunnerConfigStore {
   readonly maxWritesPerSecond?: number;
-  create(record: RunnerConfigRecord, options?: { metadataTags?: RunnerConfigMetadataTag[] }): Promise<void>;
+  create(record: RunnerConfigRecord, options?: { metadata?: RunnerConfigMetadata[] }): Promise<void>;
 }

--- a/lambdas/libs/storage-providers/core/index.ts
+++ b/lambdas/libs/storage-providers/core/index.ts
@@ -1,0 +1,14 @@
+export interface RunnerConfigMetadataTag {
+  key: string;
+  value: string;
+}
+
+export interface RunnerConfigRecord {
+  runnerId: string;
+  value: string;
+}
+
+export interface RunnerConfigStore {
+  readonly maxWritesPerSecond?: number;
+  create(record: RunnerConfigRecord, options?: { metadataTags?: RunnerConfigMetadataTag[] }): Promise<void>;
+}

--- a/lambdas/libs/storage-providers/environment.d.ts
+++ b/lambdas/libs/storage-providers/environment.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      RUNNER_CONFIG_STORAGE_PROVIDER?: string;
+    }
+  }
+}

--- a/lambdas/libs/storage-providers/index.ts
+++ b/lambdas/libs/storage-providers/index.ts
@@ -1,2 +1,2 @@
-export type { RunnerConfigMetadataTag, RunnerConfigRecord, RunnerConfigStore } from './core';
-export { getRunnerConfigStore, resetRunnerConfigStore } from './runner-config';
+export type { RunnerConfigMetadata, RunnerConfigRecord, RunnerConfigStore } from './core';
+export { createRunnerConfigStore } from './runner-config';

--- a/lambdas/libs/storage-providers/index.ts
+++ b/lambdas/libs/storage-providers/index.ts
@@ -1,0 +1,2 @@
+export type { RunnerConfigMetadataTag, RunnerConfigRecord, RunnerConfigStore } from './core';
+export { getRunnerConfigStore, resetRunnerConfigStore } from './runner-config';

--- a/lambdas/libs/storage-providers/package.json
+++ b/lambdas/libs/storage-providers/package.json
@@ -16,7 +16,13 @@
     "all": "yarn format && yarn lint && yarn test"
   },
   "dependencies": {
-    "@aws-github-runner/aws-ssm-util": "*"
+    "@aws-github-runner/aws-powertools-util": "*",
+    "@aws-github-runner/aws-ssm-util": "*",
+    "@aws-sdk/client-ssm": "^3.1009.0"
+  },
+  "devDependencies": {
+    "aws-sdk-client-mock": "^4.1.0",
+    "aws-sdk-client-mock-jest": "^4.1.0"
   },
   "nx": {
     "includedScripts": [

--- a/lambdas/libs/storage-providers/package.json
+++ b/lambdas/libs/storage-providers/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@aws-github-runner/storage-providers",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "test": "NODE_ENV=test nx test",
+    "test:watch": "NODE_ENV=test nx test --watch",
+    "lint": "eslint .",
+    "format": "prettier --write \"**/*.ts\"",
+    "format-check": "prettier --check \"**/*.ts\"",
+    "all": "yarn format && yarn lint && yarn test"
+  },
+  "dependencies": {
+    "@aws-github-runner/aws-ssm-util": "*"
+  },
+  "nx": {
+    "includedScripts": [
+      "format",
+      "format-check",
+      "lint",
+      "all"
+    ]
+  }
+}

--- a/lambdas/libs/storage-providers/runner-config.test.ts
+++ b/lambdas/libs/storage-providers/runner-config.test.ts
@@ -1,84 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createAwsSsmRunnerConfigStore } from './aws/ssm/runner-config-store';
-import type { RunnerConfigStore } from './core';
-import { getRunnerConfigStore, resetRunnerConfigStore } from './runner-config';
+import { createRunnerConfigStore } from './runner-config';
 
 vi.mock('./aws/ssm/runner-config-store', () => ({
   createAwsSsmRunnerConfigStore: vi.fn(),
 }));
 
-const createAwsSsmRunnerConfigStoreMock = vi.mocked(createAwsSsmRunnerConfigStore);
-const cleanEnv = process.env;
+describe('runner config store factory', () => {
+  it('creates the SSM implementation while the provider seam is being introduced', () => {
+    const store = { create: vi.fn() };
+    vi.mocked(createAwsSsmRunnerConfigStore).mockReturnValue(store);
 
-describe('runner config store selection', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    process.env = { ...cleanEnv };
-    delete process.env.RUNNER_CONFIG_STORAGE_PROVIDER;
-    resetRunnerConfigStore();
-  });
-
-  it.each([undefined, '', '   '])('uses aws_ssm for default selector input %j', (provider) => {
-    setProvider(provider);
-    const store = stubStore();
-
-    expect(getRunnerConfigStore()).toBe(store);
-    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
-  });
-
-  it.each(['aws_ssm', ' AWS_SSM '])('uses aws_ssm for explicit selector input %j', (provider) => {
-    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = provider;
-    const store = stubStore();
-
-    expect(getRunnerConfigStore()).toBe(store);
-    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
-  });
-
-  it('rejects an unsupported provider on first use', () => {
-    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'not-registered';
-
-    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
-    expect(() => getRunnerConfigStore()).toThrow("Unsupported runner config storage provider 'not-registered'");
-    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
-  });
-
-  it('selects lazily and caches the created store', () => {
-    const store = stubStore();
-
-    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
-    const first = getRunnerConfigStore();
-    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'not-registered';
-    const second = getRunnerConfigStore();
-
-    expect(first).toBe(store);
-    expect(second).toBe(store);
-    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
-  });
-
-  it('selects again after the test reset', () => {
-    const firstStore = stubStore();
-    expect(getRunnerConfigStore()).toBe(firstStore);
-
-    const secondStore = { create: vi.fn() } satisfies RunnerConfigStore;
-    createAwsSsmRunnerConfigStoreMock.mockReturnValue(secondStore);
-    resetRunnerConfigStore();
-
-    expect(getRunnerConfigStore()).toBe(secondStore);
-    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledTimes(2);
+    expect(createRunnerConfigStore()).toBe(store);
+    expect(createAwsSsmRunnerConfigStore).toHaveBeenCalledOnce();
   });
 });
-
-function setProvider(provider: string | undefined): void {
-  if (provider === undefined) {
-    delete process.env.RUNNER_CONFIG_STORAGE_PROVIDER;
-  } else {
-    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = provider;
-  }
-}
-
-function stubStore(): RunnerConfigStore {
-  const store = { create: vi.fn() } satisfies RunnerConfigStore;
-  createAwsSsmRunnerConfigStoreMock.mockReturnValue(store);
-  return store;
-}

--- a/lambdas/libs/storage-providers/runner-config.test.ts
+++ b/lambdas/libs/storage-providers/runner-config.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createAwsSsmRunnerConfigStore } from './aws/ssm/runner-config-store';
+import type { RunnerConfigStore } from './core';
+import { getRunnerConfigStore, resetRunnerConfigStore } from './runner-config';
+
+vi.mock('./aws/ssm/runner-config-store', () => ({
+  createAwsSsmRunnerConfigStore: vi.fn(),
+}));
+
+const createAwsSsmRunnerConfigStoreMock = vi.mocked(createAwsSsmRunnerConfigStore);
+const cleanEnv = process.env;
+
+describe('runner config store selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...cleanEnv };
+    delete process.env.RUNNER_CONFIG_STORAGE_PROVIDER;
+    resetRunnerConfigStore();
+  });
+
+  it.each([undefined, '', '   '])('uses aws_ssm for default selector input %j', (provider) => {
+    setProvider(provider);
+    const store = stubStore();
+
+    expect(getRunnerConfigStore()).toBe(store);
+    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
+  });
+
+  it.each(['aws_ssm', ' AWS_SSM '])('uses aws_ssm for explicit selector input %j', (provider) => {
+    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = provider;
+    const store = stubStore();
+
+    expect(getRunnerConfigStore()).toBe(store);
+    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an unsupported provider on first use', () => {
+    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'not-registered';
+
+    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
+    expect(() => getRunnerConfigStore()).toThrow("Unsupported runner config storage provider 'not-registered'");
+    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
+  });
+
+  it('selects lazily and caches the created store', () => {
+    const store = stubStore();
+
+    expect(createAwsSsmRunnerConfigStoreMock).not.toHaveBeenCalled();
+    const first = getRunnerConfigStore();
+    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = 'not-registered';
+    const second = getRunnerConfigStore();
+
+    expect(first).toBe(store);
+    expect(second).toBe(store);
+    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledOnce();
+  });
+
+  it('selects again after the test reset', () => {
+    const firstStore = stubStore();
+    expect(getRunnerConfigStore()).toBe(firstStore);
+
+    const secondStore = { create: vi.fn() } satisfies RunnerConfigStore;
+    createAwsSsmRunnerConfigStoreMock.mockReturnValue(secondStore);
+    resetRunnerConfigStore();
+
+    expect(getRunnerConfigStore()).toBe(secondStore);
+    expect(createAwsSsmRunnerConfigStoreMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function setProvider(provider: string | undefined): void {
+  if (provider === undefined) {
+    delete process.env.RUNNER_CONFIG_STORAGE_PROVIDER;
+  } else {
+    process.env.RUNNER_CONFIG_STORAGE_PROVIDER = provider;
+  }
+}
+
+function stubStore(): RunnerConfigStore {
+  const store = { create: vi.fn() } satisfies RunnerConfigStore;
+  createAwsSsmRunnerConfigStoreMock.mockReturnValue(store);
+  return store;
+}

--- a/lambdas/libs/storage-providers/runner-config.ts
+++ b/lambdas/libs/storage-providers/runner-config.ts
@@ -2,45 +2,6 @@ import { createAwsSsmRunnerConfigStore } from './aws/ssm/runner-config-store';
 import type { RunnerConfigStore } from './core';
 import type {} from './environment';
 
-type RunnerConfigStoreFactory = () => RunnerConfigStore;
-
-const providerFactories = {
-  aws_ssm: createAwsSsmRunnerConfigStore,
-} as const satisfies Record<string, RunnerConfigStoreFactory>;
-
-type RunnerConfigStorageProvider = keyof typeof providerFactories;
-
-const defaultProvider = 'aws_ssm' satisfies RunnerConfigStorageProvider;
-
-let runnerConfigStore: RunnerConfigStore | undefined;
-
-export function getRunnerConfigStore(): RunnerConfigStore {
-  runnerConfigStore ??= providerFactories[resolveProvider(process.env.RUNNER_CONFIG_STORAGE_PROVIDER)]();
-  return runnerConfigStore;
-}
-
-// Test-only reset for cases that need to exercise first-use environment selection.
-export function resetRunnerConfigStore(): void {
-  runnerConfigStore = undefined;
-}
-
-function resolveProvider(provider: unknown): RunnerConfigStorageProvider {
-  if (provider === undefined) {
-    return defaultProvider;
-  }
-
-  if (typeof provider !== 'string') {
-    throw new Error(`Unsupported runner config storage provider '${String(provider)}'`);
-  }
-
-  const normalizedProvider = provider.trim().toLowerCase();
-  if (normalizedProvider === '') {
-    return defaultProvider;
-  }
-
-  if (!Object.prototype.hasOwnProperty.call(providerFactories, normalizedProvider)) {
-    throw new Error(`Unsupported runner config storage provider '${String(provider)}'`);
-  }
-
-  return normalizedProvider as RunnerConfigStorageProvider;
+export function createRunnerConfigStore(): RunnerConfigStore {
+  return createAwsSsmRunnerConfigStore();
 }

--- a/lambdas/libs/storage-providers/runner-config.ts
+++ b/lambdas/libs/storage-providers/runner-config.ts
@@ -1,0 +1,46 @@
+import { createAwsSsmRunnerConfigStore } from './aws/ssm/runner-config-store';
+import type { RunnerConfigStore } from './core';
+import type {} from './environment';
+
+type RunnerConfigStoreFactory = () => RunnerConfigStore;
+
+const providerFactories = {
+  aws_ssm: createAwsSsmRunnerConfigStore,
+} as const satisfies Record<string, RunnerConfigStoreFactory>;
+
+type RunnerConfigStorageProvider = keyof typeof providerFactories;
+
+const defaultProvider = 'aws_ssm' satisfies RunnerConfigStorageProvider;
+
+let runnerConfigStore: RunnerConfigStore | undefined;
+
+export function getRunnerConfigStore(): RunnerConfigStore {
+  runnerConfigStore ??= providerFactories[resolveProvider(process.env.RUNNER_CONFIG_STORAGE_PROVIDER)]();
+  return runnerConfigStore;
+}
+
+// Test-only reset for cases that need to exercise first-use environment selection.
+export function resetRunnerConfigStore(): void {
+  runnerConfigStore = undefined;
+}
+
+function resolveProvider(provider: unknown): RunnerConfigStorageProvider {
+  if (provider === undefined) {
+    return defaultProvider;
+  }
+
+  if (typeof provider !== 'string') {
+    throw new Error(`Unsupported runner config storage provider '${String(provider)}'`);
+  }
+
+  const normalizedProvider = provider.trim().toLowerCase();
+  if (normalizedProvider === '') {
+    return defaultProvider;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(providerFactories, normalizedProvider)) {
+    throw new Error(`Unsupported runner config storage provider '${String(provider)}'`);
+  }
+
+  return normalizedProvider as RunnerConfigStorageProvider;
+}

--- a/lambdas/libs/storage-providers/tsconfig.json
+++ b/lambdas/libs/storage-providers/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.test.ts", "vitest.config.ts"]
+}

--- a/lambdas/libs/storage-providers/vitest.config.ts
+++ b/lambdas/libs/storage-providers/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'path';
+
+import { mergeConfig } from 'vitest/config';
+import defaultConfig from '../../vitest.base.config';
+
+export default mergeConfig(defaultConfig, {
+  test: {
+    setupFiles: [resolve(__dirname, '../../aws-vitest-setup.ts')],
+    coverage: {
+      include: ['index.ts', 'runner-config.ts', 'core/**/*.ts', 'aws/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.d.ts'],
+    },
+  },
+});

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -154,6 +154,7 @@ __metadata:
     "@aws-github-runner/aws-powertools-util": "npm:*"
     "@aws-github-runner/aws-ssm-util": "npm:*"
     "@aws-github-runner/compute-providers": "npm:*"
+    "@aws-github-runner/storage-providers": "npm:*"
     "@aws-lambda-powertools/parameters": "npm:^2.31.0"
     "@aws-sdk/client-ec2": "npm:^3.1009.0"
     "@aws-sdk/client-sqs": "npm:^3.1009.0"
@@ -196,6 +197,14 @@ __metadata:
     aws-sdk-client-mock-jest: "npm:^4.1.0"
     aws-sdk-client-mock-vitest: "npm:^7.0.1"
     axios: "npm:^1.18.1"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/storage-providers@npm:*, @aws-github-runner/storage-providers@workspace:libs/storage-providers":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/storage-providers@workspace:libs/storage-providers"
+  dependencies:
+    "@aws-github-runner/aws-ssm-util": "npm:*"
   languageName: unknown
   linkType: soft
 

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -137,6 +137,7 @@ __metadata:
   dependencies:
     "@aws-github-runner/aws-powertools-util": "npm:*"
     "@aws-github-runner/aws-ssm-util": "npm:*"
+    "@aws-github-runner/storage-providers": "npm:*"
     "@aws-sdk/client-ec2": "npm:^3.1009.0"
     "@octokit/rest": "npm:22.0.1"
     aws-sdk-client-mock: "npm:^4.1.0"
@@ -204,7 +205,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-github-runner/storage-providers@workspace:libs/storage-providers"
   dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
     "@aws-github-runner/aws-ssm-util": "npm:*"
+    "@aws-sdk/client-ssm": "npm:^3.1009.0"
+    aws-sdk-client-mock: "npm:^4.1.0"
+    aws-sdk-client-mock-jest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Introduces the provider-neutral `RunnerConfigStore` contract and moves the existing SSM implementation behind it. Scale-up and runner creation now write registration-token or JIT configuration through the store's `create` operation, while SSM-specific parameter paths, tags, encryption behavior, and environment parsing stay in the AWS adapter.

The adapter preserves the existing stored values and metadata, exposes its maximum write throughput so callers can pace batches without hard-coding SSM limits, and accepts provider-neutral runner metadata that is translated into SSM tags. This establishes the storage boundary without adding another backend or changing Terraform resource addresses.

## Test Plan

- Added/updated runner-config store and control-plane tests.
- `git diff --check` passed.
- Runtime Yarn tests could not be run locally because the repository's pinned Yarn launcher is unavailable in this environment; CI should provide the full test result.

## Related Issues

- Related storage-backend work: #5266
