### PR TITLE
chore(dependabot): group CodeQL action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
         patterns:
           - "actions/*"
           - "github/"
+          - "github/codeql-action/*"
 
   - package-ecosystem: "npm"
     directory: "/lambdas"


### PR DESCRIPTION
## Description

- group `github/codeql-action/*` updates in the existing GitHub Actions Dependabot group
- keep CodeQL `init` and `analyze` actions on the same release in a single Dependabot pull request

## Test Plan

- parsed `.github/dependabot.yml` with Ruby's YAML parser
- ran `git diff --check`
- passed the configured pre-commit hooks

## Related Issues

- Follow-up to #5289 and #5290
