### PR TITLE
fix(lambda): uppercase LOG_LEVEL in the shared lambda module

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -3,7 +3,7 @@ locals {
 
   lambda_environment_variables = {
     ENVIRONMENT                              = var.lambda.prefix
-    LOG_LEVEL                                = var.lambda.log_level
+    LOG_LEVEL                                = upper(var.lambda.log_level)
     PREFIX                                   = var.lambda.prefix
     POWERTOOLS_LOGGER_LOG_EVENT              = var.lambda.log_level == "debug" ? "true" : "false"
     POWERTOOLS_SERVICE_NAME                  = var.lambda.name


### PR DESCRIPTION
## Description

#5238 wrapped every `LOG_LEVEL` assignment with `upper()` so Powertools v2 stops silently discarding the value, but it missed `modules/lambda/main.tf`. That module builds the environment for four functions:

- `modules/runners/job-retry`
- `modules/termination-watcher/deregister-retry`
- `modules/termination-watcher/notification`
- `modules/termination-watcher/termination`

`var.lambda.log_level` is validated against lowercase names only (`debug`, `info`, `warn`, `error`), so the value reaching those four functions can never match Powertools' uppercase `LogLevelThreshold` keys — every level silently resolves to `INFO`. Asking for `debug` produces no debug output, and asking for `warn` or `error` produces *more* output than requested.

`POWERTOOLS_LOGGER_LOG_EVENT` still compares the raw lowercase variable, which remains correct, so it is left untouched.

## Test Plan

Reproduced against the `@aws-lambda-powertools/logger` version this repository already depends on:

| `LOG_LEVEL` | effective level |
| --- | --- |
| `debug` | `INFO` |
| `DEBUG` | `DEBUG` |
| `warn` | `INFO` |
| `WARN` | `WARN` |

Confirmed on a live deployment before this change: the functions created through `modules/lambda` had `LOG_LEVEL=info`, while every function fixed by #5238 had `LOG_LEVEL=INFO`.

Checks run locally:

- `terraform fmt -recursive -check=true -write=false`
- `terraform validate` on `modules/lambda`, `modules/runners/job-retry`, `modules/termination-watcher`, `modules/termination-watcher/notification` and `modules/termination-watcher/termination`
- Confirmed no lowercase `LOG_LEVEL` assignment remains anywhere under `modules/`

Applying this to a running deployment is an in-place Lambda environment update — no resource replacement.

## Related Issues

Follow-up to #5238.
