### PR TITLE
refactor(compute-providers): share EC2 runner operations

### DIFF
--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import * as nock from 'nock';
 
 import { createRunners } from '@aws-github-runner/compute-providers/aws/ec2/control-plane/runner-config';
-import { listEC2Runners } from '@aws-github-runner/compute-providers/aws/ec2/control-plane/runners';
+import { listEC2Runners } from '@aws-github-runner/compute-providers/aws/ec2/runners';
 import * as ghAuth from '../github/auth';
 import { getGitHubEnterpriseApiUrl } from '../scale-runners/github-runner';
 import { adjust } from './pool';
@@ -26,7 +26,7 @@ vi.mock('@octokit/rest', () => ({
   }),
 }));
 
-vi.mock('@aws-github-runner/compute-providers/aws/ec2/control-plane/runners', async () => ({
+vi.mock('@aws-github-runner/compute-providers/aws/ec2/runners', async () => ({
   listEC2Runners: vi.fn(),
   // Include any other functions from the module that might be used
   bootTimeExceeded: vi.fn(),
@@ -212,7 +212,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
 
@@ -230,7 +230,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
 
@@ -242,7 +242,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
 
@@ -332,7 +332,7 @@ describe('Test simple pool.', () => {
         3,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });
@@ -354,7 +354,7 @@ describe('Test simple pool.', () => {
         3,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });
@@ -411,7 +411,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });
@@ -449,7 +449,7 @@ describe('Test simple pool.', () => {
         2,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
 
@@ -464,7 +464,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
 
@@ -478,7 +478,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });
@@ -503,7 +503,7 @@ describe('Test simple pool.', () => {
         2,
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });
@@ -567,7 +567,7 @@ describe('Test simple pool.', () => {
         expect.any(Number),
         expect.anything(),
         expect.anything(),
-        'pool-lambda',
+        'pool',
       );
     });
   });

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -212,7 +212,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
 
@@ -230,7 +230,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
 
@@ -242,7 +242,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
 
@@ -332,7 +332,7 @@ describe('Test simple pool.', () => {
         3,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });
@@ -354,7 +354,7 @@ describe('Test simple pool.', () => {
         3,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });
@@ -411,7 +411,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });
@@ -449,7 +449,7 @@ describe('Test simple pool.', () => {
         2,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
 
@@ -464,7 +464,7 @@ describe('Test simple pool.', () => {
         1,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
 
@@ -478,7 +478,7 @@ describe('Test simple pool.', () => {
         8,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });
@@ -503,7 +503,7 @@ describe('Test simple pool.', () => {
         2,
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });
@@ -567,7 +567,7 @@ describe('Test simple pool.', () => {
         expect.any(Number),
         expect.anything(),
         expect.anything(),
-        'pool',
+        'pool-lambda',
       );
     });
   });

--- a/lambdas/functions/control-plane/src/scale-runners/types.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/types.ts
@@ -3,7 +3,7 @@ export type {
   CreateRunnerResult,
   CreateScaleUpRunnersInput,
   CurrentRunnersInput,
-  LambdaRunnerSource,
+  RunnerSource,
   RunnerLabelResolution,
   RunnerInfo,
   RunnerType,

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/dynamic-labels.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/dynamic-labels.ts
@@ -32,7 +32,7 @@ import {
 } from '@aws-sdk/client-ec2';
 import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 
-import { Ec2OverrideConfig } from './runners.d';
+import { Ec2OverrideConfig } from '../runners.d';
 
 const EC2_OVERRIDE_LIST_VALUE_SEPARATOR = ';';
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.test.ts
@@ -1,9 +1,9 @@
 import type { RunnerInfo } from '../../../../core';
-import { bootTimeExceeded } from './runners';
+import { bootTimeExceeded } from '../runners';
 import { calculateEc2PoolSize } from './pool';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('./runners', () => ({
+vi.mock('../runners', () => ({
   bootTimeExceeded: vi.fn(),
 }));
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.ts
@@ -46,7 +46,7 @@ async function createEc2PoolRunners(
     numberOfRunners,
     githubInstallationClient,
     createStartRunnerConfig,
-    'pool',
+    'pool-lambda',
   );
   return instances;
 }

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/pool.ts
@@ -8,7 +8,7 @@ import type {
   RunnerStatus,
 } from '../../../../core';
 import { createRunners, loadEc2ProviderConfig } from './runner-config';
-import { bootTimeExceeded, listEC2Runners } from './runners';
+import { bootTimeExceeded, listEC2Runners } from '../runners';
 
 const logger = createChildLogger('pool');
 
@@ -46,7 +46,7 @@ async function createEc2PoolRunners(
     numberOfRunners,
     githubInstallationClient,
     createStartRunnerConfig,
-    'pool-lambda',
+    'pool',
   );
   return instances;
 }

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-config.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runner-config.ts
@@ -4,15 +4,15 @@ import type {
   CreateRunnerResult,
   CreateStartRunnerConfig,
   GitHubRunnerMetadata,
-  LambdaRunnerSource,
+  RunnerSource,
   StartRunnerConfigOptions,
 } from '../../../../core';
 import { Octokit } from '@octokit/rest';
 import type { Tag } from '@aws-sdk/client-ec2';
 import yn from 'yn';
 
-import { createRunner, tag, terminateRunner } from './runners';
-import type { RunnerInputParameters } from './runners.d';
+import { createRunner, tag, terminateRunner } from '../runners';
+import type { RunnerInputParameters } from '../runners.d';
 
 const logger = createChildLogger('ec2-runners');
 const RUNNER_LABELS_TAG_KEY = 'ghr:runner_labels';
@@ -66,7 +66,7 @@ export async function createRunners(
   numberOfRunners: number,
   ghClient: Octokit,
   createStartRunnerConfig: CreateStartRunnerConfig,
-  source: LambdaRunnerSource = 'scale-up-lambda',
+  source: RunnerSource,
 ): Promise<CreateRunnerResult> {
   let result: CreateRunnerResult;
   try {

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-down.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-down.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RunnerInfo, RunnerType } from '../../../../core';
 import { createEc2ScaleDownProvider } from './scale-down';
-import { listEC2Runners, tag, terminateRunner, untag } from './runners';
+import { listEC2Runners, tag, terminateRunner, untag } from '../runners';
 
-vi.mock('./runners', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./runners')>();
+vi.mock('../runners', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../runners')>();
   return {
     ...actual,
     listEC2Runners: vi.fn(),

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-down.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-down.ts
@@ -1,5 +1,5 @@
 import type { RunnerInfo, ScaleDownComputeProvider } from '../../../../core';
-import { bootTimeExceeded, listEC2Runners, tag, terminateRunner, untag } from './runners';
+import { bootTimeExceeded, listEC2Runners, tag, terminateRunner, untag } from '../runners';
 
 async function listEc2ScaleDownRunners(environment: string, orphan?: boolean): Promise<RunnerInfo[]> {
   return await listEC2Runners({ environment, orphan });

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -78,7 +78,7 @@ function expectedRunnerParams(
     tracingEnabled: false,
     onDemandFailoverOnError: [],
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'TargetCapacityLimitExceededException'],
-    source: 'lambda',
+    source: 'scale-up-lambda',
     useDedicatedHost: false,
     ec2OverrideConfig: undefined,
     ...overrides,

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.test.ts
@@ -7,11 +7,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { parseEc2OverrideConfig } from './dynamic-labels';
 import { EC2_TAG_VALUE_MAX_LENGTH, RUNNER_LABELS_TAG_MAX_COUNT } from './runner-config';
-import { createRunner, listEC2Runners, tag, terminateRunner } from './runners';
-import type { RunnerInputParameters } from './runners.d';
+import { createRunner, listEC2Runners, tag, terminateRunner } from '../runners';
+import type { RunnerInputParameters } from '../runners.d';
 import { createEc2ScaleUpProvider } from './scale-up';
 
-vi.mock('./runners', () => ({
+vi.mock('../runners', () => ({
   createRunner: vi.fn(),
   listEC2Runners: vi.fn(),
   tag: vi.fn(),
@@ -78,7 +78,7 @@ function expectedRunnerParams(
     tracingEnabled: false,
     onDemandFailoverOnError: [],
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded', 'TargetCapacityLimitExceededException'],
-    source: 'scale-up-lambda',
+    source: 'lambda',
     useDedicatedHost: false,
     ec2OverrideConfig: undefined,
     ...overrides,

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.ts
@@ -9,8 +9,8 @@ import type {
 } from '../../../../core';
 import yn from 'yn';
 
-import { listEC2Runners } from './runners';
-import type { Ec2OverrideConfig } from './runners.d';
+import { listEC2Runners } from '../runners';
+import type { Ec2OverrideConfig } from '../runners.d';
 import {
   getDefaultBlockDeviceNameFromLaunchTemplate,
   parseEc2OverrideConfig,
@@ -77,7 +77,7 @@ async function createEc2ScaleUpRunners(
     numberOfRunners,
     githubInstallationClient,
     createStartRunnerConfig,
-    'scale-up-lambda',
+    'lambda',
   );
 }
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/scale-up.ts
@@ -77,7 +77,7 @@ async function createEc2ScaleUpRunners(
     numberOfRunners,
     githubInstallationClient,
     createStartRunnerConfig,
-    'lambda',
+    'scale-up-lambda',
   );
 }
 

--- a/lambdas/libs/compute-providers/aws/ec2/src/runners.d.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/runners.d.ts
@@ -7,7 +7,7 @@ import {
   Placement,
   FleetBlockDeviceMappingRequest,
 } from '@aws-sdk/client-ec2';
-import type { LambdaRunnerSource, ListRunnerFilters, RunnerType } from '../../../../core';
+import type { ListRunnerFilters, RunnerSource, RunnerType } from '../../../core';
 
 export interface Ec2ListRunnerFilters extends ListRunnerFilters {
   statuses?: string[];
@@ -42,7 +42,7 @@ export interface RunnerInputParameters {
   };
   ec2OverrideConfig?: Ec2OverrideConfig;
   numberOfRunners: number;
-  source: LambdaRunnerSource;
+  source: RunnerSource;
   amiIdSsmParameterName?: string;
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];

--- a/lambdas/libs/compute-providers/aws/ec2/src/runners.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/runners.test.ts
@@ -21,7 +21,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest/vitest';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LambdaRunnerSource, RunnerInfo, RunnerType } from '../../../../core';
+import type { RunnerInfo, RunnerSource, RunnerType } from '../../../core';
 import { createRunner, listEC2Runners, tag, terminateRunner, untag } from './runners';
 import type { Ec2OverrideConfig, RunnerInputParameters } from './runners.d';
 
@@ -48,7 +48,7 @@ const mockRunningInstances: DescribeInstancesResult = {
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
             { Key: 'ghr:runner_name_prefix', Value: RUNNER_NAME_PREFIX },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: 'CoderToCat' },
           ],
@@ -67,7 +67,7 @@ const mockRunningInstancesJit: DescribeInstancesResult = {
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
             { Key: 'ghr:runner_name_prefix', Value: RUNNER_NAME_PREFIX },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: 'CoderToCat' },
             { Key: 'ghr:github_runner_id', Value: '9876543210' },
@@ -322,7 +322,7 @@ describe('create runner', () => {
     capacityType: 'spot',
     type: 'Org',
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
 
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
@@ -330,7 +330,7 @@ describe('create runner', () => {
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
 
   beforeEach(() => {
@@ -371,13 +371,13 @@ describe('create runner', () => {
     });
   });
 
-  it('calls create fleet of multiple instances with pool-lambda source when specified', async () => {
+  it('calls create fleet of multiple instances with pool source when specified', async () => {
     const instances = [{ InstanceIds: ['i-1234', 'i-5678', 'i-9012'] }];
 
     mockEC2Client.on(CreateFleetCommand).resolves({ Instances: instances });
 
     await createRunner({
-      ...createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }),
+      ...createRunnerConfig({ ...defaultRunnerConfig, source: 'pool' }),
       numberOfRunners: 3,
     });
 
@@ -385,7 +385,7 @@ describe('create runner', () => {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
         totalTargetCapacity: 3,
-        source: 'pool-lambda',
+        source: 'pool',
       }),
     });
   });
@@ -515,24 +515,24 @@ describe('create runner', () => {
     });
   });
 
-  it('calls create fleet with source set to scale-up-lambda when source is specified', async () => {
-    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'scale-up-lambda' }));
+  it('calls create fleet with source set to lambda when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'lambda' }));
 
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
-        source: 'scale-up-lambda',
+        source: 'lambda',
       }),
     });
   });
 
-  it('calls create fleet with source set to pool-lambda when source is specified', async () => {
-    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }));
+  it('calls create fleet with source set to pool when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'pool' }));
 
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
-        source: 'pool-lambda',
+        source: 'pool',
       }),
     });
   });
@@ -753,14 +753,14 @@ describe('create runner with errors', () => {
     capacityType: 'spot',
     type: 'Repo',
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -999,14 +999,14 @@ describe('create runner with errors fail over to OnDemand', () => {
     type: 'Repo',
     onDemandFailoverOnError: ['InsufficientInstanceCapacity'],
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'scale-up-lambda',
+    source: 'lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1170,7 +1170,7 @@ interface RunnerConfig {
   tracingEnabled?: boolean;
   onDemandFailoverOnError?: string[];
   scaleErrors: string[];
-  source: LambdaRunnerSource;
+  source: RunnerSource;
   useDedicatedHost?: boolean;
   ec2OverrideConfig?: Ec2OverrideConfig;
 }
@@ -1209,7 +1209,7 @@ interface ExpectedFleetRequestValues {
   totalTargetCapacity: number;
   imageId?: string;
   tracingEnabled?: boolean;
-  source: LambdaRunnerSource;
+  source: RunnerSource;
 }
 
 function expectedCreateFleetRequest(expectedValues: ExpectedFleetRequestValues): CreateFleetCommandInput {
@@ -1318,6 +1318,7 @@ describe('create runner with useDedicatedHost', () => {
   const dedicatedHostRunnerConfig: RunnerConfig = {
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     capacityType: 'on-demand',
+    source: 'lambda',
     type: 'Org',
     scaleErrors: [],
     useDedicatedHost: true,
@@ -1393,7 +1394,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1402,7 +1403,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1411,7 +1412,7 @@ describe('create runner with useDedicatedHost', () => {
     });
   });
 
-  it('creates multiple instances via RunInstances', async () => {
+  it('creates multiple instances via RunInstances and preserves the caller source', async () => {
     mockEC2Client.on(RunInstancesCommand).resolves({
       Instances: [{ InstanceId: 'i-dedicated-1' }, { InstanceId: 'i-dedicated-2' }],
     });
@@ -1419,6 +1420,7 @@ describe('create runner with useDedicatedHost', () => {
     const result = await createRunner({
       ...createRunnerConfig(dedicatedHostRunnerConfig),
       numberOfRunners: 2,
+      source: 'lambda',
     });
 
     expect(result).toEqual({
@@ -1440,7 +1442,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'pool-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1449,7 +1451,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'pool-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1574,7 +1576,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1583,7 +1585,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
+            { Key: 'ghr:created_by', Value: 'lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],

--- a/lambdas/libs/compute-providers/aws/ec2/src/runners.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/runners.test.ts
@@ -48,7 +48,7 @@ const mockRunningInstances: DescribeInstancesResult = {
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
             { Key: 'ghr:runner_name_prefix', Value: RUNNER_NAME_PREFIX },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: 'CoderToCat' },
           ],
@@ -67,7 +67,7 @@ const mockRunningInstancesJit: DescribeInstancesResult = {
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
             { Key: 'ghr:runner_name_prefix', Value: RUNNER_NAME_PREFIX },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: 'CoderToCat' },
             { Key: 'ghr:github_runner_id', Value: '9876543210' },
@@ -322,7 +322,7 @@ describe('create runner', () => {
     capacityType: 'spot',
     type: 'Org',
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
 
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
@@ -330,7 +330,7 @@ describe('create runner', () => {
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
 
   beforeEach(() => {
@@ -377,7 +377,7 @@ describe('create runner', () => {
     mockEC2Client.on(CreateFleetCommand).resolves({ Instances: instances });
 
     await createRunner({
-      ...createRunnerConfig({ ...defaultRunnerConfig, source: 'pool' }),
+      ...createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }),
       numberOfRunners: 3,
     });
 
@@ -385,7 +385,7 @@ describe('create runner', () => {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
         totalTargetCapacity: 3,
-        source: 'pool',
+        source: 'pool-lambda',
       }),
     });
   });
@@ -515,24 +515,24 @@ describe('create runner', () => {
     });
   });
 
-  it('calls create fleet with source set to lambda when source is specified', async () => {
-    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'lambda' }));
+  it('calls create fleet with source set to scale-up-lambda when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'scale-up-lambda' }));
 
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
-        source: 'lambda',
+        source: 'scale-up-lambda',
       }),
     });
   });
 
-  it('calls create fleet with source set to pool when source is specified', async () => {
-    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'pool' }));
+  it('calls create fleet with source set to pool-lambda when source is specified', async () => {
+    await createRunner(createRunnerConfig({ ...defaultRunnerConfig, source: 'pool-lambda' }));
 
     expect(mockEC2Client).toHaveReceivedCommandWith(CreateFleetCommand, {
       ...expectedCreateFleetRequest({
         ...defaultExpectedFleetRequestValues,
-        source: 'pool',
+        source: 'pool-lambda',
       }),
     });
   });
@@ -753,14 +753,14 @@ describe('create runner with errors', () => {
     capacityType: 'spot',
     type: 'Repo',
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -999,14 +999,14 @@ describe('create runner with errors fail over to OnDemand', () => {
     type: 'Repo',
     onDemandFailoverOnError: ['InsufficientInstanceCapacity'],
     scaleErrors: ['UnfulfillableCapacity', 'MaxSpotInstanceCountExceeded'],
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
   const defaultExpectedFleetRequestValues: ExpectedFleetRequestValues = {
     type: 'Repo',
     capacityType: 'spot',
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     totalTargetCapacity: 1,
-    source: 'lambda',
+    source: 'scale-up-lambda',
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1318,7 +1318,7 @@ describe('create runner with useDedicatedHost', () => {
   const dedicatedHostRunnerConfig: RunnerConfig = {
     allocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
     capacityType: 'on-demand',
-    source: 'lambda',
+    source: 'scale-up-lambda',
     type: 'Org',
     scaleErrors: [],
     useDedicatedHost: true,
@@ -1394,7 +1394,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1403,7 +1403,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1420,7 +1420,7 @@ describe('create runner with useDedicatedHost', () => {
     const result = await createRunner({
       ...createRunnerConfig(dedicatedHostRunnerConfig),
       numberOfRunners: 2,
-      source: 'lambda',
+      source: 'scale-up-lambda',
     });
 
     expect(result).toEqual({
@@ -1442,7 +1442,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1451,7 +1451,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1576,7 +1576,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],
@@ -1585,7 +1585,7 @@ describe('create runner with useDedicatedHost', () => {
           ResourceType: 'volume',
           Tags: [
             { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: 'lambda' },
+            { Key: 'ghr:created_by', Value: 'scale-up-lambda' },
             { Key: 'ghr:Type', Value: 'Org' },
             { Key: 'ghr:Owner', Value: REPO_NAME },
           ],

--- a/lambdas/libs/compute-providers/aws/ec2/src/runners.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/runners.ts
@@ -22,7 +22,7 @@ import { getTracedAWSV3Client, tracer } from '@aws-github-runner/aws-powertools-
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import moment from 'moment';
 
-import type { CreateRunnerResult, RunnerInfo } from '../../../../core';
+import type { CreateRunnerResult, RunnerInfo } from '../../../core';
 import type { Ec2ListRunnerFilters, Ec2OverrideConfig, RunnerInputParameters } from './runners.d';
 
 const logger = createChildLogger('runners');
@@ -584,7 +584,7 @@ async function createInstancesWithRunInstances(
 ): Promise<CreateRunnerResult> {
   const tags = [
     { Key: 'ghr:Application', Value: 'github-action-runner' },
-    { Key: 'ghr:created_by', Value: runnerParameters.numberOfRunners === 1 ? 'scale-up-lambda' : 'pool-lambda' },
+    { Key: 'ghr:created_by', Value: runnerParameters.source },
     { Key: 'ghr:Type', Value: runnerParameters.runnerType },
     { Key: 'ghr:Owner', Value: runnerParameters.runnerOwner },
   ];

--- a/lambdas/libs/compute-providers/core/index.ts
+++ b/lambdas/libs/compute-providers/core/index.ts
@@ -6,7 +6,7 @@ export interface ComputeProvider {
   type: ComputeProviderType;
 }
 
-export type LambdaRunnerSource = 'scale-up-lambda' | 'pool-lambda';
+export type RunnerSource = 'lambda' | 'pool';
 export type RunnerType = 'Org' | 'Repo';
 
 export interface CreateGitHubRunnerConfig {

--- a/lambdas/libs/compute-providers/core/index.ts
+++ b/lambdas/libs/compute-providers/core/index.ts
@@ -6,7 +6,7 @@ export interface ComputeProvider {
   type: ComputeProviderType;
 }
 
-export type RunnerSource = 'lambda' | 'pool';
+export type RunnerSource = 'scale-up-lambda' | 'pool-lambda';
 export type RunnerType = 'Org' | 'Repo';
 
 export interface CreateGitHubRunnerConfig {

--- a/lambdas/libs/compute-providers/package.json
+++ b/lambdas/libs/compute-providers/package.json
@@ -10,7 +10,7 @@
     "./control-plane": "./control-plane.ts",
     "./aws/ec2/webhook": "./aws/ec2/webhook.ts",
     "./aws/ec2/control-plane": "./aws/ec2/control-plane.ts",
-    "./aws/ec2/control-plane/runners": "./aws/ec2/src/control-plane/runners.ts",
+    "./aws/ec2/runners": "./aws/ec2/src/runners.ts",
     "./aws/ec2/control-plane/runner-config": "./aws/ec2/src/control-plane/runner-config.ts"
   },
   "type": "module",


### PR DESCRIPTION
## Description

Moves the shared EC2 runner implementation and types out of the control-plane directory and exposes them through the EC2 provider package boundary so multiple orchestration entry points can use the same runner operations.

Requires callers to provide a `RunnerSource`, preserving the existing `scale-up-lambda` and `pool-lambda` values. Both EC2 launch paths now use that caller-provided source for the `ghr:created_by` tag.

PR #5301 is the follow-up and will be stacked on this PR.

## Test Plan

- Ran ESLint for the compute-provider and control-plane projects.
- Ran the Lambda Vitest suite: 50 test files and 819 tests passed.
- Ran `git diff --check` against `refactor-ec2-provider-isolation`.

## Related Issues

None.
