### PR TITLE
refactor(control-plane): remove EC2 assumptions

### DIFF
--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -276,14 +276,14 @@ describe('Test scale down lambda wrapper.', () => {
 describe('Adjust pool.', () => {
   it('Receive message to adjust pool.', async () => {
     vi.mocked(adjust).mockResolvedValue();
-    await expect(adjustPool({ poolSize: 2, type: 'ec2' }, context)).resolves.not.toThrow();
+    await expect(adjustPool({ poolSize: 2 }, context)).resolves.not.toThrow();
   });
 
   it('Handle error for adjusting pool.', async () => {
     const error = new Error('Handle error for adjusting pool.');
     vi.mocked(adjust).mockRejectedValue(error);
     const logSpy = vi.spyOn(logger, 'error');
-    await adjustPool({ poolSize: 0, type: 'ec2' }, context);
+    await adjustPool({ poolSize: 0 }, context);
     expect(logSpy).toHaveBeenCalledWith(`Handle error for adjusting pool. ${error.message}`, { error });
   });
 });

--- a/lambdas/functions/control-plane/src/local-pool.ts
+++ b/lambdas/functions/control-plane/src/local-pool.ts
@@ -1,7 +1,7 @@
 import { adjust } from './pool/pool';
 
 export function run(): void {
-  adjust({ poolSize: 1, type: 'ec2' })
+  adjust({ poolSize: 1 })
     .then()
     .catch((e) => {
       console.log(e);

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.test.ts
@@ -2,6 +2,7 @@ import type { Octokit } from '@octokit/rest';
 import { RequestError } from '@octokit/request-error';
 import moment from 'moment';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
 
 import { controlPlaneProviderRegistry } from '../control-plane-providers';
 import * as ghAuth from '../github/auth';
@@ -33,13 +34,12 @@ const mockOctokit = {
 };
 
 const mockComputeProvider = {
-  type: 'ec2',
   list: vi.fn(),
   bootTimeExceeded: vi.fn(),
   markOrphan: vi.fn(),
   unmarkOrphan: vi.fn(),
   terminate: vi.fn(),
-} satisfies ScaleDownComputeProvider;
+} satisfies Omit<ScaleDownComputeProvider, 'type'>;
 
 const mockedResolveCapability = vi.spyOn(controlPlaneProviderRegistry, 'capability');
 const mockedAppAuth = vi.mocked(ghAuth.createGithubAppAuth);
@@ -177,7 +177,7 @@ describe('Scale down runners', () => {
     process.env.ENVIRONMENT = ENVIRONMENT;
     process.env.MINIMUM_RUNNING_TIME_IN_MINUTES = MINIMUM_TIME_RUNNING_IN_MINUTES.toString();
     process.env.RUNNER_BOOT_TIME_IN_MINUTES = MINIMUM_BOOT_TIME.toString();
-    process.env.COMPUTE_PROVIDER_TYPE = mockComputeProvider.type;
+    process.env.COMPUTE_PROVIDER_TYPE = defaultComputeProvider;
 
     vi.clearAllMocks();
     githubCache.clients.clear();

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -16,6 +16,7 @@ import type {
   CreateScaleUpRunnersInput,
   ScaleUpComputeProvider,
 } from './types';
+import { defaultComputeProvider } from '@aws-github-runner/compute-providers/provider-types';
 import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Octokit } from '@octokit/rest';
@@ -57,12 +58,11 @@ const mockSSMClient = mockClient(SSMClient);
 const mockSSMgetParameter = vi.mocked(getParameter);
 const mockPublishRetryMessage = vi.mocked(publishRetryMessage);
 const testProviderState = { provider: 'test' };
-const mockComputeProvider: ScaleUpComputeProvider = {
-  type: 'ec2',
+const mockComputeProvider = {
   resolveLabelsForRunners: vi.fn(),
   getCurrentRunners: vi.fn(),
   createRunners: vi.fn(),
-};
+} satisfies Omit<ScaleUpComputeProvider, 'type'>;
 const mockResolveLabelsForRunners = vi.mocked(mockComputeProvider.resolveLabelsForRunners);
 const mockGetCurrentRunners = vi.mocked(mockComputeProvider.getCurrentRunners);
 const mockCreateRunners = vi.mocked(mockComputeProvider.createRunners);
@@ -928,7 +928,7 @@ describe('scaleUp with GHES', () => {
       expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
     });
 
-    it('Should handle partial EC2 instance creation failures', async () => {
+    it('handles partial runner creation failures', async () => {
       mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
 
       const messages = createTestMessages(3);
@@ -938,7 +938,7 @@ describe('scaleUp with GHES', () => {
       expect(rejectedMessages).toEqual(['message-0', 'message-1']);
     });
 
-    it('Should reject only retryable partial EC2 instance creation failures', async () => {
+    it('rejects only retryable partial runner creation failures', async () => {
       mockCreateRunner.mockResolvedValue(createRunnerResult(['i-12345'], 1, 1));
 
       const messages = createTestMessages(3);
@@ -947,7 +947,7 @@ describe('scaleUp with GHES', () => {
       expect(rejectedMessages).toEqual(['message-0']);
     });
 
-    it('does not retry partial EC2 instance creation failures that are not retryable', async () => {
+    it('does not retry non-retryable partial runner creation failures', async () => {
       mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 0, 2));
 
       const rejectedMessages = await scaleUpModule.scaleUp(createTestMessages(3));
@@ -1379,7 +1379,7 @@ describe('scaleUp with public GH', () => {
       expect(rejectedMessages).toHaveLength(3); // All 3 messages should be rejected
     });
 
-    it('Should handle partial EC2 instance creation failures', async () => {
+    it('handles partial runner creation failures', async () => {
       mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
 
       const messages = createTestMessages(3);
@@ -1857,7 +1857,7 @@ describe('scaleUp with Github Data Residency', () => {
       expect(rejectedMessages).toHaveLength(4); // 5 requested - 1 created = 4 rejected
     });
 
-    it('Should handle partial EC2 instance creation failures', async () => {
+    it('handles partial runner creation failures', async () => {
       mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 2)); // Only creates 1 instead of requested 3
 
       const messages = createTestMessages(3);
@@ -2148,12 +2148,12 @@ describe('Retry mechanism tests', () => {
 });
 
 describe('compute provider selection', () => {
-  it('defaults scale-up to EC2 when no compute provider is configured', async () => {
+  it('uses the default compute provider when none is configured', async () => {
     delete process.env.COMPUTE_PROVIDER_TYPE;
 
     await scaleUpModule.scaleUp(TEST_DATA);
 
-    expect(mockedResolveCapability).toHaveBeenCalledWith('ec2', 'scaleUp');
+    expect(mockedResolveCapability).toHaveBeenCalledWith(defaultComputeProvider, 'scaleUp');
   });
 
   it('rejects unsupported scale-up provider types', async () => {


### PR DESCRIPTION
## Description

Depends on #5307.

Removes EC2-specific assumptions from generic control-plane tests and the local pool invocation. Scale-up and scale-down test doubles now model provider capability factories without owning a provider type, partial creation tests use provider-neutral runner terminology, and pool events rely on the optional provider type's default behavior.

The scale-up provider-selection test remains as integration coverage, but asserts the public `defaultComputeProvider` contract instead of the concrete EC2 value. The provider-type unit tests remain responsible for the concrete default mapping.

## Test Plan

- Ran the affected scale-up, scale-down, and Lambda wrapper suites: 253 tests passed.
- Ran the complete Lambda Vitest suite: 819 tests passed.
- Ran the control-plane TypeScript type-check.
- Ran ESLint and Prettier checks for all changed files.
- Ran `git diff --check`.
- Verified the four scoped files contain no EC2 references.

## Related Issues

None.
