### PR TITLE
fix(lambda): create log groups before functions

### DIFF
--- a/modules/ami-housekeeper/main.tf
+++ b/modules/ami-housekeeper/main.tf
@@ -1,6 +1,7 @@
 locals {
-  lambda_zip = var.lambda_zip == null ? "${path.module}/../../lambdas/functions/ami-housekeeper/ami-housekeeper.zip" : var.lambda_zip
-  role_path  = var.role_path == null ? "/${var.prefix}/" : var.role_path
+  lambda_name = "${var.prefix}-ami-housekeeper"
+  lambda_zip  = var.lambda_zip == null ? "${path.module}/../../lambdas/functions/ami-housekeeper/ami-housekeeper.zip" : var.lambda_zip
+  role_path   = var.role_path == null ? "/${var.prefix}/" : var.role_path
 }
 
 resource "aws_lambda_function" "ami_housekeeper" {
@@ -9,13 +10,14 @@ resource "aws_lambda_function" "ami_housekeeper" {
   s3_object_version = var.lambda_s3_object_version != null ? var.lambda_s3_object_version : null
   filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.prefix}-ami-housekeeper"
+  function_name     = local.lambda_name
   role              = aws_iam_role.ami_housekeeper.arn
   handler           = "index.handler"
   runtime           = var.lambda_runtime
   timeout           = var.lambda_timeout
   memory_size       = var.lambda_memory_size
   architectures     = [var.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.ami_housekeeper]
 
   environment {
     variables = {
@@ -48,7 +50,7 @@ resource "aws_lambda_function" "ami_housekeeper" {
 }
 
 resource "aws_cloudwatch_log_group" "ami_housekeeper" {
-  name              = "/aws/lambda/${aws_lambda_function.ami_housekeeper.function_name}"
+  name              = "/aws/lambda/${local.lambda_name}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = var.logging_kms_key_id
   log_group_class   = var.log_class

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -1,5 +1,6 @@
 locals {
-  role_path = var.lambda.role_path == null ? "/${var.lambda.prefix}/" : var.lambda.role_path
+  lambda_name = "${var.lambda.prefix}-${var.lambda.name}"
+  role_path   = var.lambda.role_path == null ? "/${var.lambda.prefix}/" : var.lambda.role_path
 
   lambda_environment_variables = {
     ENVIRONMENT                              = var.lambda.prefix
@@ -22,13 +23,14 @@ resource "aws_lambda_function" "main" {
   s3_object_version = var.lambda.s3_object_version != null ? var.lambda.s3_object_version : null
   filename          = var.lambda.s3_bucket == null ? var.lambda.zip : null
   source_code_hash  = var.lambda.s3_bucket == null ? filebase64sha256(var.lambda.zip) : null
-  function_name     = "${var.lambda.prefix}-${var.lambda.name}"
+  function_name     = local.lambda_name
   role              = aws_iam_role.main.arn
   handler           = var.lambda.handler
   runtime           = var.lambda.runtime
   timeout           = var.lambda.timeout
   memory_size       = var.lambda.memory_size
   architectures     = [var.lambda.architecture]
+  depends_on        = [aws_cloudwatch_log_group.main]
 
   environment {
     variables = local.environment_variable
@@ -53,7 +55,7 @@ resource "aws_lambda_function" "main" {
 }
 
 resource "aws_cloudwatch_log_group" "main" {
-  name              = "/aws/lambda/${aws_lambda_function.main.function_name}"
+  name              = "/aws/lambda/${local.lambda_name}"
   retention_in_days = var.lambda.logging_retention_in_days
   kms_key_id        = var.lambda.logging_kms_key_id
   log_group_class   = var.lambda.log_class

--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -1,6 +1,7 @@
 locals {
-  lambda_zip = var.lambda_zip == null ? "${path.module}/../../lambdas/functions/gh-agent-syncer/runner-binaries-syncer.zip" : var.lambda_zip
-  role_path  = var.role_path == null ? "/${var.prefix}/" : var.role_path
+  lambda_name = "${var.prefix}-syncer"
+  lambda_zip  = var.lambda_zip == null ? "${path.module}/../../lambdas/functions/gh-agent-syncer/runner-binaries-syncer.zip" : var.lambda_zip
+  role_path   = var.role_path == null ? "/${var.prefix}/" : var.role_path
   gh_binary_os_label = {
     windows = "win",
     linux   = "linux"
@@ -14,13 +15,14 @@ resource "aws_lambda_function" "syncer" {
   s3_object_version = var.syncer_lambda_s3_object_version != null ? var.syncer_lambda_s3_object_version : null
   filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.prefix}-syncer"
+  function_name     = local.lambda_name
   role              = aws_iam_role.syncer_lambda.arn
   handler           = "index.handler"
   runtime           = var.lambda_runtime
   timeout           = var.lambda_timeout
   memory_size       = var.lambda_memory_size
   architectures     = [var.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.syncer]
 
   environment {
     variables = {
@@ -68,7 +70,7 @@ resource "aws_iam_role_policy" "lambda_kms" {
 }
 
 resource "aws_cloudwatch_log_group" "syncer" {
-  name              = "/aws/lambda/${aws_lambda_function.syncer.function_name}"
+  name              = "/aws/lambda/${local.lambda_name}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = var.logging_kms_key_id
   log_group_class   = var.log_class

--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -1,4 +1,5 @@
 locals {
+  lambda_name = "${var.config.prefix}-pool"
   pool_name_prefix = (
     length("${var.config.prefix}-pool") <= 38
     ? "${var.config.prefix}-pool"
@@ -13,7 +14,7 @@ resource "aws_lambda_function" "pool" {
   s3_object_version              = var.config.lambda.s3_object_version != null ? var.config.lambda.s3_object_version : null
   filename                       = var.config.lambda.s3_bucket == null ? var.config.lambda.zip : null
   source_code_hash               = var.config.lambda.s3_bucket == null ? filebase64sha256(var.config.lambda.zip) : null
-  function_name                  = "${var.config.prefix}-pool"
+  function_name                  = local.lambda_name
   role                           = aws_iam_role.pool.arn
   handler                        = "index.adjustPool"
   architectures                  = [var.config.lambda.architecture]
@@ -21,6 +22,7 @@ resource "aws_lambda_function" "pool" {
   timeout                        = var.config.lambda.timeout
   reserved_concurrent_executions = var.config.lambda.reserved_concurrent_executions
   memory_size                    = var.config.lambda.memory_size
+  depends_on                     = [aws_cloudwatch_log_group.pool]
   tags                           = merge(var.config.tags, var.config.lambda_tags)
 
   environment {
@@ -82,7 +84,7 @@ resource "aws_lambda_function" "pool" {
 }
 
 resource "aws_cloudwatch_log_group" "pool" {
-  name              = "/aws/lambda/${aws_lambda_function.pool.function_name}"
+  name              = "/aws/lambda/${local.lambda_name}"
   retention_in_days = var.config.lambda.logging_retention_in_days
   kms_key_id        = var.config.lambda.logging_kms_key_id
   log_group_class   = var.config.lambda.log_class

--- a/modules/runners/scale-down.tf
+++ b/modules/runners/scale-down.tf
@@ -1,4 +1,5 @@
 locals {
+  scale_down_lambda_name = "${var.prefix}-scale-down"
   # Windows Runners can take their sweet time to do anything
   # For an AWS vended AMI with an x86 Mac instance or an Apple silicon Mac instance,
   # the launch time can range from approximately 6 minutes to 20 minutes. 
@@ -14,7 +15,7 @@ resource "aws_lambda_function" "scale_down" {
   s3_object_version = var.runners_lambda_s3_object_version != null ? var.runners_lambda_s3_object_version : null
   filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.prefix}-scale-down"
+  function_name     = local.scale_down_lambda_name
   role              = aws_iam_role.scale_down.arn
   handler           = "index.scaleDownHandler"
   runtime           = var.lambda_runtime
@@ -22,6 +23,7 @@ resource "aws_lambda_function" "scale_down" {
   tags              = merge(local.tags, var.lambda_tags)
   memory_size       = var.lambda_scale_down_memory_size
   architectures     = [var.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.scale_down]
 
   environment {
     variables = {
@@ -64,7 +66,7 @@ resource "aws_lambda_function" "scale_down" {
 }
 
 resource "aws_cloudwatch_log_group" "scale_down" {
-  name              = "/aws/lambda/${aws_lambda_function.scale_down.function_name}"
+  name              = "/aws/lambda/${local.scale_down_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = var.logging_kms_key_id
   log_group_class   = var.log_class

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -8,13 +8,17 @@ locals {
   } : {}
 }
 
+locals {
+  scale_up_lambda_name = "${var.prefix}-scale-up"
+}
+
 resource "aws_lambda_function" "scale_up" {
   s3_bucket                      = var.lambda_s3_bucket != null ? var.lambda_s3_bucket : null
   s3_key                         = var.runners_lambda_s3_key != null ? var.runners_lambda_s3_key : null
   s3_object_version              = var.runners_lambda_s3_object_version != null ? var.runners_lambda_s3_object_version : null
   filename                       = var.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash               = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name                  = "${var.prefix}-scale-up"
+  function_name                  = local.scale_up_lambda_name
   role                           = aws_iam_role.scale_up.arn
   handler                        = "index.scaleUpHandler"
   runtime                        = var.lambda_runtime
@@ -23,6 +27,7 @@ resource "aws_lambda_function" "scale_up" {
   memory_size                    = var.lambda_scale_up_memory_size
   tags                           = merge(local.tags, var.lambda_tags)
   architectures                  = [var.lambda_architecture]
+  depends_on                     = [aws_cloudwatch_log_group.scale_up]
   environment {
     variables = {
       AMI_ID_SSM_PARAMETER_NAME                 = local.ami_id_ssm_parameter_name
@@ -86,7 +91,7 @@ resource "aws_lambda_function" "scale_up" {
 }
 
 resource "aws_cloudwatch_log_group" "scale_up" {
-  name              = "/aws/lambda/${aws_lambda_function.scale_up.function_name}"
+  name              = "/aws/lambda/${local.scale_up_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = var.logging_kms_key_id
   log_group_class   = var.log_class

--- a/modules/runners/ssm-housekeeper.tf
+++ b/modules/runners/ssm-housekeeper.tf
@@ -1,4 +1,5 @@
 locals {
+  ssm_housekeeper_lambda_name = "${var.prefix}-ssm-housekeeper"
   ssm_housekeeper = {
     schedule_expression = var.ssm_housekeeper.schedule_expression
     state               = var.ssm_housekeeper.state
@@ -18,7 +19,7 @@ resource "aws_lambda_function" "ssm_housekeeper" {
   s3_object_version = var.runners_lambda_s3_object_version != null ? var.runners_lambda_s3_object_version : null
   filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.prefix}-ssm-housekeeper"
+  function_name     = local.ssm_housekeeper_lambda_name
   role              = aws_iam_role.ssm_housekeeper.arn
   handler           = "index.ssmHousekeeper"
   runtime           = var.lambda_runtime
@@ -26,6 +27,7 @@ resource "aws_lambda_function" "ssm_housekeeper" {
   tags              = merge(local.tags, var.lambda_tags)
   memory_size       = local.ssm_housekeeper.lambda_memory_size
   architectures     = [var.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.ssm_housekeeper]
 
   environment {
     variables = {
@@ -56,7 +58,7 @@ resource "aws_lambda_function" "ssm_housekeeper" {
 }
 
 resource "aws_cloudwatch_log_group" "ssm_housekeeper" {
-  name              = "/aws/lambda/${aws_lambda_function.ssm_housekeeper.function_name}"
+  name              = "/aws/lambda/${local.ssm_housekeeper_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = var.logging_kms_key_id
   log_group_class   = var.log_class

--- a/modules/webhook/direct/webhook.tf
+++ b/modules/webhook/direct/webhook.tf
@@ -1,5 +1,6 @@
 locals {
-  lambda_zip = var.config.lambda_zip == null ? "${path.module}/../../../lambdas/functions/webhook/webhook.zip" : var.config.lambda_zip
+  lambda_name = "${var.config.prefix}-webhook"
+  lambda_zip  = var.config.lambda_zip == null ? "${path.module}/../../../lambdas/functions/webhook/webhook.zip" : var.config.lambda_zip
 }
 
 resource "aws_lambda_function" "webhook" {
@@ -8,13 +9,14 @@ resource "aws_lambda_function" "webhook" {
   s3_object_version = var.config.lambda_s3_object_version != null ? var.config.lambda_s3_object_version : null
   filename          = var.config.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.config.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.config.prefix}-webhook"
+  function_name     = local.lambda_name
   role              = aws_iam_role.webhook_lambda.arn
   handler           = "index.directWebhook"
   runtime           = var.config.lambda_runtime
   memory_size       = var.config.lambda_memory_size
   timeout           = var.config.lambda_timeout
   architectures     = [var.config.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.webhook]
 
   environment {
     variables = {
@@ -56,7 +58,7 @@ resource "aws_lambda_function" "webhook" {
 }
 
 resource "aws_cloudwatch_log_group" "webhook" {
-  name              = "/aws/lambda/${aws_lambda_function.webhook.function_name}"
+  name              = "/aws/lambda/${local.lambda_name}"
   retention_in_days = var.config.logging_retention_in_days
   kms_key_id        = var.config.logging_kms_key_id
   log_group_class   = var.config.log_class

--- a/modules/webhook/eventbridge/dispatcher.tf
+++ b/modules/webhook/eventbridge/dispatcher.tf
@@ -1,3 +1,7 @@
+locals {
+  dispatcher_lambda_name = "${var.config.prefix}-dispatch-to-runner"
+}
+
 resource "aws_cloudwatch_event_rule" "workflow_job" {
   name           = "${var.config.prefix}-workflow_job"
   description    = "Workflow job event rule for job queued."
@@ -26,13 +30,14 @@ resource "aws_lambda_function" "dispatcher" {
   s3_object_version = var.config.lambda_s3_object_version != null ? var.config.lambda_s3_object_version : null
   filename          = var.config.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.config.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.config.prefix}-dispatch-to-runner"
+  function_name     = local.dispatcher_lambda_name
   role              = aws_iam_role.dispatcher_lambda.arn
   handler           = "index.dispatchToRunners"
   runtime           = var.config.lambda_runtime
   memory_size       = var.config.lambda_memory_size
   timeout           = var.config.lambda_timeout
   architectures     = [var.config.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.dispatcher]
 
   environment {
     variables = {
@@ -71,7 +76,7 @@ resource "aws_lambda_function" "dispatcher" {
 }
 
 resource "aws_cloudwatch_log_group" "dispatcher" {
-  name              = "/aws/lambda/${aws_lambda_function.dispatcher.function_name}"
+  name              = "/aws/lambda/${local.dispatcher_lambda_name}"
   retention_in_days = var.config.logging_retention_in_days
   kms_key_id        = var.config.logging_kms_key_id
   log_group_class   = var.config.log_class

--- a/modules/webhook/eventbridge/webhook.tf
+++ b/modules/webhook/eventbridge/webhook.tf
@@ -1,3 +1,7 @@
+locals {
+  webhook_lambda_name = "${var.config.prefix}-webhook"
+}
+
 resource "null_resource" "github_app_parameters" {
   triggers = {
     github_app_webhook_secret_name = var.config.github_app_parameters.webhook_secret.name
@@ -10,13 +14,14 @@ resource "aws_lambda_function" "webhook" {
   s3_object_version = var.config.lambda_s3_object_version != null ? var.config.lambda_s3_object_version : null
   filename          = var.config.lambda_s3_bucket == null ? local.lambda_zip : null
   source_code_hash  = var.config.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
-  function_name     = "${var.config.prefix}-webhook"
+  function_name     = local.webhook_lambda_name
   role              = aws_iam_role.webhook_lambda.arn
   handler           = "index.eventBridgeWebhook"
   runtime           = var.config.lambda_runtime
   memory_size       = var.config.lambda_memory_size
   timeout           = var.config.lambda_timeout
   architectures     = [var.config.lambda_architecture]
+  depends_on        = [aws_cloudwatch_log_group.webhook]
 
   environment {
     variables = {
@@ -59,7 +64,7 @@ resource "aws_lambda_function" "webhook" {
 }
 
 resource "aws_cloudwatch_log_group" "webhook" {
-  name              = "/aws/lambda/${aws_lambda_function.webhook.function_name}"
+  name              = "/aws/lambda/${local.webhook_lambda_name}"
   retention_in_days = var.config.logging_retention_in_days
   kms_key_id        = var.config.logging_kms_key_id
   log_group_class   = var.config.log_class


### PR DESCRIPTION
## Description

- Define a shared name for each Terraform-managed Lambda and its CloudWatch log group.
- Make each Lambda explicitly depend on its own log group.
- Prevent AWS from auto-creating a Lambda log group before Terraform creates the managed resource.
- Standardize this dependency pattern across all affected Lambda modules while preserving existing names, retention, encryption, and tags.

## Test Plan

- `terraform fmt -recursive -check=true -write=false`
- `terraform validate`
- `tflint` for the root module and all affected modules
- `terraform -chdir=modules/runners test -test-directory=tests` (1 passed, 0 failed)
- Generated the Terraform plan graph and verified every affected Lambda depends on its CloudWatch log group.

## Related Issues

Fixes #5323
