### PR TITLE
fix(perf): Avoid server-side tag filtering in listEC2Runners DescribeInstances call

### DIFF
--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runners.test.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runners.test.ts
@@ -139,67 +139,75 @@ describe('list instances', () => {
     expect(mockEC2Client).toHaveReceivedCommand(DescribeInstancesCommand);
   });
 
-  it('filters instances on repo name', async () => {
+  it('sends only the instance-state-name filter to EC2 (tags are filtered client-side)', async () => {
     mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
     await listEC2Runners({
       runnerType: 'Repo',
       runnerOwner: REPO_NAME,
-      environment: undefined,
+      environment: ENVIRONMENT,
+      orphan: true,
     });
     expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:ghr:Type', Values: ['Repo'] },
-        { Name: 'tag:ghr:Owner', Values: [REPO_NAME] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
+      Filters: [{ Name: 'instance-state-name', Values: ['running', 'pending'] }],
     });
   });
 
-  it('filters instances on org name', async () => {
-    mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
-    await listEC2Runners({
+  it('filters instances on repo name (client-side)', async () => {
+    const instances = buildInstancesResult([
+      { 'ghr:Application': 'github-action-runner', 'ghr:Type': 'Repo', 'ghr:Owner': REPO_NAME },
+      { 'ghr:Application': 'github-action-runner', 'ghr:Type': 'Org', 'ghr:Owner': ORG_NAME },
+    ]);
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+    const resp = await listEC2Runners({
+      runnerType: 'Repo',
+      runnerOwner: REPO_NAME,
+      environment: undefined,
+    });
+    expect(resp.length).toBe(1);
+    expect(resp[0].owner).toBe(REPO_NAME);
+  });
+
+  it('filters instances on org name (client-side)', async () => {
+    const instances = buildInstancesResult([
+      { 'ghr:Application': 'github-action-runner', 'ghr:Type': 'Org', 'ghr:Owner': ORG_NAME },
+      { 'ghr:Application': 'github-action-runner', 'ghr:Type': 'Repo', 'ghr:Owner': REPO_NAME },
+    ]);
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+    const resp = await listEC2Runners({
       runnerType: 'Org',
       runnerOwner: ORG_NAME,
       environment: undefined,
     });
-    expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:ghr:Type', Values: ['Org'] },
-        { Name: 'tag:ghr:Owner', Values: [ORG_NAME] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
-    });
+    expect(resp.length).toBe(1);
+    expect(resp[0].owner).toBe(ORG_NAME);
   });
 
-  it('filters instances on environment', async () => {
-    mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
-    await listEC2Runners({ environment: ENVIRONMENT });
-    expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:ghr:environment', Values: [ENVIRONMENT] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
-    });
+  it('filters instances on environment (client-side)', async () => {
+    const instances = buildInstancesResult([
+      { 'ghr:Application': 'github-action-runner', 'ghr:environment': ENVIRONMENT },
+      { 'ghr:Application': 'github-action-runner', 'ghr:environment': 'some-other-environment' },
+    ]);
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+    const resp = await listEC2Runners({ environment: ENVIRONMENT });
+    expect(resp.length).toBe(1);
   });
 
-  it('filters instances on environment and orphan', async () => {
-    mockRunningInstances.Reservations![0].Instances![0].Tags!.push({
-      Key: 'ghr:orphan',
-      Value: 'true',
-    });
-    mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
-    await listEC2Runners({ environment: ENVIRONMENT, orphan: true });
-    expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:ghr:environment', Values: [ENVIRONMENT] },
-        { Name: 'tag:ghr:orphan', Values: ['true'] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
-    });
+  it('filters instances on environment and orphan (client-side)', async () => {
+    const instances = buildInstancesResult([
+      { 'ghr:Application': 'github-action-runner', 'ghr:environment': ENVIRONMENT, 'ghr:orphan': 'true' },
+      { 'ghr:Application': 'github-action-runner', 'ghr:environment': ENVIRONMENT },
+      { 'ghr:Application': 'github-action-runner', 'ghr:environment': 'some-other-environment', 'ghr:orphan': 'true' },
+    ]);
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+    const resp = await listEC2Runners({ environment: ENVIRONMENT, orphan: true });
+    expect(resp.length).toBe(1);
+  });
+
+  it('excludes instances missing the Application tag (client-side)', async () => {
+    const instances = buildInstancesResult([{ 'ghr:Type': 'Org', 'ghr:Owner': ORG_NAME }]);
+    mockEC2Client.on(DescribeInstancesCommand).resolves(instances);
+    const resp = await listEC2Runners();
+    expect(resp.length).toBe(0);
   });
 
   it('No instances, undefined reservations list.', async () => {
@@ -211,7 +219,7 @@ describe('list instances', () => {
     expect(resp.length).toBe(0);
   });
 
-  it('Instances with no tags.', async () => {
+  it('Instances with no tags are excluded (no Application tag match).', async () => {
     const noInstances: DescribeInstancesResult = {
       Reservations: [
         {
@@ -227,17 +235,14 @@ describe('list instances', () => {
     };
     mockEC2Client.on(DescribeInstancesCommand).resolves(noInstances);
     const resp = await listEC2Runners();
-    expect(resp.length).toBe(1);
+    expect(resp.length).toBe(0);
   });
 
   it('Filter instances for state running.', async () => {
     mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
     await listEC2Runners({ statuses: ['running'] });
     expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running'] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
+      Filters: [{ Name: 'instance-state-name', Values: ['running'] }],
     });
   });
 
@@ -245,13 +250,24 @@ describe('list instances', () => {
     mockEC2Client.on(DescribeInstancesCommand).resolves(mockRunningInstances);
     await listEC2Runners({ statuses: undefined });
     expect(mockEC2Client).toHaveReceivedCommandWith(DescribeInstancesCommand, {
-      Filters: [
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:ghr:Application', Values: ['github-action-runner'] },
-      ],
+      Filters: [{ Name: 'instance-state-name', Values: ['running', 'pending'] }],
     });
   });
 });
+
+function buildInstancesResult(tagSets: Record<string, string>[]): DescribeInstancesResult {
+  return {
+    Reservations: [
+      {
+        Instances: tagSets.map((tags, index) => ({
+          LaunchTime: new Date('2020-10-10T14:48:00.000+09:00'),
+          InstanceId: `i-${index}`,
+          Tags: Object.entries(tags).map(([Key, Value]) => ({ Key, Value })),
+        })),
+      },
+    ],
+  };
+}
 
 describe('terminate runner', () => {
   beforeEach(() => {

--- a/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runners.ts
+++ b/lambdas/libs/compute-providers/aws/ec2/src/control-plane/runners.ts
@@ -6,6 +6,7 @@ import {
   DeleteTagsCommand,
   DescribeInstancesCommand,
   DescribeInstancesResult,
+  type Instance,
   RunInstancesCommand,
   type RunInstancesCommandInput,
   RunInstancesCommandOutput,
@@ -35,40 +36,30 @@ interface Ec2Filter {
 type FleetError = NonNullable<CreateFleetResult['Errors']>[number];
 
 export async function listEC2Runners(filters: Ec2ListRunnerFilters | undefined = undefined): Promise<RunnerInfo[]> {
-  const ec2Filters = constructFilters(filters);
-  const runners: RunnerInfo[] = [];
-  for (const filter of ec2Filters) {
-    runners.push(...(await getRunners(filter)));
-  }
-  return runners;
+  const ec2Statuses = filters?.statuses ? filters.statuses : ['running', 'pending'];
+  const stateFilter: Ec2Filter[] = [{ Name: 'instance-state-name', Values: ec2Statuses }];
+  const tagFilters = constructTagFilters(filters);
+  return await getRunners(stateFilter, tagFilters);
 }
 
-function constructFilters(filters?: Ec2ListRunnerFilters): Ec2Filter[][] {
-  const ec2Statuses = filters?.statuses ? filters.statuses : ['running', 'pending'];
-  const ec2Filters: Ec2Filter[][] = [];
-  const ec2FiltersBase = [{ Name: 'instance-state-name', Values: ec2Statuses }];
+function constructTagFilters(filters?: Ec2ListRunnerFilters): Ec2Filter[] {
+  const tagFilters: Ec2Filter[] = [{ Name: 'tag:ghr:Application', Values: ['github-action-runner'] }];
   if (filters) {
     if (filters.environment !== undefined) {
-      ec2FiltersBase.push({ Name: 'tag:ghr:environment', Values: [filters.environment] });
+      tagFilters.push({ Name: 'tag:ghr:environment', Values: [filters.environment] });
     }
     if (filters.runnerType && filters.runnerOwner) {
-      ec2FiltersBase.push({ Name: `tag:ghr:Type`, Values: [filters.runnerType] });
-      ec2FiltersBase.push({ Name: `tag:ghr:Owner`, Values: [filters.runnerOwner] });
+      tagFilters.push({ Name: `tag:ghr:Type`, Values: [filters.runnerType] });
+      tagFilters.push({ Name: `tag:ghr:Owner`, Values: [filters.runnerOwner] });
     }
     if (filters.orphan) {
-      ec2FiltersBase.push({ Name: 'tag:ghr:orphan', Values: ['true'] });
+      tagFilters.push({ Name: 'tag:ghr:orphan', Values: ['true'] });
     }
   }
-
-  for (const key of ['tag:ghr:Application']) {
-    const filter = [...ec2FiltersBase];
-    filter.push({ Name: key, Values: ['github-action-runner'] });
-    ec2Filters.push(filter);
-  }
-  return ec2Filters;
+  return tagFilters;
 }
 
-async function getRunners(ec2Filters: Ec2Filter[]): Promise<RunnerInfo[]> {
+async function getRunners(ec2Filters: Ec2Filter[], tagFilters: Ec2Filter[]): Promise<RunnerInfo[]> {
   const ec2 = getTracedAWSV3Client(new EC2Client({ region: process.env.AWS_REGION }));
   const runners: RunnerInfo[] = [];
   let nextToken;
@@ -79,9 +70,30 @@ async function getRunners(ec2Filters: Ec2Filter[]): Promise<RunnerInfo[]> {
     );
     hasNext = instances.NextToken ? true : false;
     nextToken = instances.NextToken;
-    runners.push(...getRunnerInfo(instances));
+    runners.push(...getRunnerInfo(filterInstancesByTags(instances, tagFilters)));
   }
   return runners;
+}
+
+function matchesTagFilters(instance: Instance, tagFilters: Ec2Filter[]): boolean {
+  return tagFilters.every((filter) => {
+    const tagKey = filter.Name.replace(/^tag:/, '');
+    const tagValue = instance.Tags?.find((t) => t.Key === tagKey)?.Value;
+    return tagValue !== undefined && filter.Values.includes(tagValue);
+  });
+}
+
+function filterInstancesByTags(result: DescribeInstancesResult, tagFilters: Ec2Filter[]): DescribeInstancesResult {
+  if (!result.Reservations) {
+    return result;
+  }
+  return {
+    ...result,
+    Reservations: result.Reservations.map((reservation) => ({
+      ...reservation,
+      Instances: reservation.Instances?.filter((instance) => matchesTagFilters(instance, tagFilters)),
+    })),
+  };
 }
 
 function getRunnerInfo(runningInstances: DescribeInstancesResult) {


### PR DESCRIPTION
## Description

The Scale-Up Lambda's runner-lookup call (`listEC2Runners` in `lambdas/libs/compute-providers/aws/ec2/src/control-plane/runners.ts`) dominated total invocation latency. X-Ray traces showed total invocation duration consistently ~35s, while the actual provisioning logic (credential lookups, `CreateFleet`) was sub-2s — `DescribeInstances` alone accounted for ~93% of the invocation (~24–33s), reproducing consistently across 10+ sampled traces over a 24-hour window.

Root-cause investigation ruled out the usual suspects:
- Not pagination — result sets are in the hundreds, well under AWS's ~1,000-per-page default.
- Not Lambda networking (VPC/ENI) — the same delay reproduced identically calling the same API locally, outside the Lambda's VPC, via both boto3 and the AWS CLI.
- Not match count — a query with fewer filters but fewer matches still ran 5x faster.
- Each additional `tag:ghr:*` filter (`environment`, `Type`, `Owner`, `Application`, optionally `orphan`) pays the same tag-index lookup cost server-side; the current implementation stacks up to four.
- Tried two AWS APIs purpose-built for tag lookups (`DescribeTags`, Resource Groups Tagging API) — both performed the same or worse. This confirmed the fix isn't "use a different tag-lookup API," it's "avoid server-side tag filtering in this call entirely."

This PR changes `listEC2Runners` to fetch by `instance-state-name` only (a fast, native attribute) and filter by tag in application code afterward, instead of asking EC2 to filter by tags server-side:

```typescript
// Before: EC2 filters by instance-state-name AND up to 4 tag:ghr:* filters
const ec2Filters = constructFilters(filters);
const instances = await ec2.send(new DescribeInstancesCommand({ Filters: ec2Filters }));

// After: EC2 filters by instance-state-name only; tags matched client-side
const stateFilter = [{ Name: 'instance-state-name', Values: ec2Statuses }];
const tagFilters = constructTagFilters(filters);
const instances = await ec2.send(new DescribeInstancesCommand({ Filters: stateFilter }));
const matched = filterInstancesByTags(instances, tagFilters);
```

Since `Instance.Tags` is already returned on every instance in the `DescribeInstances` response, no extra API calls are needed — the tag data is just filtered in-process instead of server-side. This is an internal implementation change only: `listEC2Runners`'s signature and the `Ec2ListRunnerFilters` input shape are unchanged, so no changes were needed in any of its callers (`pool.ts`, `scale-up.ts`, `scale-down.ts`).

Measured locally with real data: state-only fetch took 6.4s for ~950 instances, with client-side tag filtering afterward costing under 2ms — a ~5x improvement over the ~24–33s baseline.

## Test Plan

- `runners.test.ts` updated: filter-assertion tests now confirm only `instance-state-name` is sent to `DescribeInstancesCommand`, and new tests verify correct client-side inclusion/exclusion for `environment`, `Type`+`Owner`, `orphan`, and `Application` tag combinations (including instances missing the `Application` tag being correctly excluded).
- `vitest run` on `runners.test.ts`: 71/71 passing.
- Full `compute-providers` package test suite: 10 files / 272 tests passing (no ripple effects in `pool.ts`, `scale-up.ts`, `scale-down.ts` or their tests).
- `functions/control-plane/src/pool/pool.test.ts`: 20/20 passing.
- `tsc --noEmit` and `eslint` clean on both changed files.
- Confirmed no `docs/`/`README.md` content describes this internal filtering behavior, so no doc updates needed.

## Related Issues
https://github.com/github-aws-runners/terraform-aws-github-runner/issues/5327