### PR TITLE
fix(control-plane): clarify partial runner creation test name

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -947,7 +947,7 @@ describe('scaleUp with GHES', () => {
       expect(rejectedMessages).toEqual(['message-0']);
     });
 
-    it('does not retry non-retryable partial runner creation failures', async () => {
+    it('non-retryable partial runner creation failures are not retried', async () => {
       mockCreateRunner.mockImplementation(async () => createRunnerResult(['i-12345'], 0, 2));
 
       const rejectedMessages = await scaleUpModule.scaleUp(createTestMessages(3));


### PR DESCRIPTION
## Description

Clarifies the partial runner creation test name so it explicitly states that non-retryable failures are not retried, while keeping the terminology provider-neutral.

This addresses the same review suggestion raised in the stacked PR discussions for [#5308](https://github.com/github-aws-runners/terraform-aws-github-runner/pull/5308#discussion_r3916493806) and [#5301](https://github.com/github-aws-runners/terraform-aws-github-runner/pull/5301#discussion_r3916539369).

## Test Plan

- Ran the focused control-plane scale-up suite: 113 tests passed.
- Ran Prettier for the changed file.
- Ran `git diff --check`.
- Repository pre-commit hooks passed.

## Related Issues

Related to #5338
