### PR TITLE
feat(multi-runner): consume resolved experimental config

### DIFF
--- a/modules/multi-runner/runner-binaries.tf
+++ b/modules/multi-runner/runner-binaries.tf
@@ -20,7 +20,9 @@ module "runner_binaries" {
   source   = "../runner-binaries-syncer"
   for_each = local.resolved_runner_binary_targets_by_key
   prefix   = "${var.prefix}-${each.value.os_type}-${each.value.architecture}"
-  tags     = local.tags
+  tags = merge(local.resolved_config.tags, {
+    "ghr:environment" = var.prefix
+  })
 
   # force mandatory lower case for s3 bucketname
   distribution_bucket_name = lower("${var.prefix}-${each.value.os_type}-${each.value.architecture}-dist-${random_string.random.result}")
@@ -28,35 +30,44 @@ module "runner_binaries" {
   runner_os           = each.value.os_type
   runner_architecture = each.value.architecture
 
-  lambda_s3_bucket                 = var.lambda_s3_bucket
-  syncer_lambda_s3_key             = var.syncer_lambda_s3_key
-  syncer_lambda_s3_object_version  = var.syncer_lambda_s3_object_version
-  lambda_runtime                   = var.lambda_runtime
-  lambda_architecture              = var.lambda_architecture
-  lambda_zip                       = var.runner_binaries_syncer_lambda_zip
-  lambda_memory_size               = var.runner_binaries_syncer_memory_size
-  lambda_timeout                   = var.runner_binaries_syncer_lambda_timeout
-  lambda_tags                      = var.lambda_tags
-  tracing_config                   = var.tracing_config
-  logging_retention_in_days        = var.logging_retention_in_days
-  logging_kms_key_id               = var.logging_kms_key_id
-  log_class                        = var.log_class
-  state_event_rule_binaries_syncer = var.state_event_rule_binaries_syncer
+  lambda_s3_bucket                 = try(local.resolved_config.lambda.artifact.s3.bucket, null)
+  syncer_lambda_s3_key             = try(local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.artifact.s3.key, null)
+  syncer_lambda_s3_object_version  = try(local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.artifact.s3.object_version, null)
+  lambda_runtime                   = local.resolved_config.lambda.runtime
+  lambda_architecture              = local.resolved_config.lambda.architecture
+  lambda_zip                       = local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.artifact.zip
+  lambda_memory_size               = local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.lambda.memory_size
+  lambda_timeout                   = local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.lambda.timeout
+  lambda_tags                      = local.resolved_config.lambda.tags
+  tracing_config                   = local.resolved_config.observability.tracing
+  logging_retention_in_days        = local.resolved_config.observability.logs.retention_in_days
+  logging_kms_key_id               = local.resolved_config.observability.logs.kms_key_id
+  log_class                        = local.resolved_config.observability.logs.class
+  lambda_schedule_expression       = local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.schedule.expression
+  state_event_rule_binaries_syncer = local.resolved_config.compute_provider.aws.ec2.runner_binaries.syncer.schedule.state
 
-  server_side_encryption_configuration = var.runner_binaries_s3_sse_configuration
-  s3_tags                              = var.runner_binaries_s3_tags
-  s3_versioning                        = var.runner_binaries_s3_versioning
+  server_side_encryption_configuration = try(local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.encryption.enabled, false) ? {
+    rule = {
+      bucket_key_enabled = local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.encryption.bucket_key_enabled
+      apply_server_side_encryption_by_default = {
+        sse_algorithm     = local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.encryption.sse_algorithm
+        kms_master_key_id = local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.encryption.kms_master_key_id
+      }
+    }
+  } : null
+  s3_tags       = local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.tags
+  s3_versioning = local.resolved_config.compute_provider.aws.ec2.runner_binaries.s3.versioning
 
-  role_path                 = var.role_path
-  role_permissions_boundary = var.role_permissions_boundary
+  role_path                 = local.resolved_config.roles.path
+  role_permissions_boundary = local.resolved_config.roles.permissions_boundary
 
-  log_level = var.log_level
+  log_level = local.resolved_config.observability.logs.level
 
-  lambda_subnet_ids         = var.lambda_subnet_ids
-  lambda_security_group_ids = var.lambda_security_group_ids
+  lambda_subnet_ids         = local.resolved_config.lambda.subnet_ids
+  lambda_security_group_ids = local.resolved_config.lambda.security_group_ids
   aws_partition             = var.aws_partition
 
-  lambda_principals = var.lambda_principals
+  lambda_principals = local.resolved_config.lambda.principals
 }
 locals {
   runner_binaries_by_os_and_arch_map = {

--- a/modules/multi-runner/runner-binaries.tf
+++ b/modules/multi-runner/runner-binaries.tf
@@ -1,6 +1,24 @@
+locals {
+  # Derive binary targets from the resolved runner lanes before the binary
+  # module is instantiated, so the effective configuration can consume the
+  # binary outputs without depending on its own inputs.
+  resolved_runner_binary_targets = distinct([
+    for config in local.resolved_config.multi_runner_config : {
+      os_type      = config.runner.os
+      architecture = config.runner.architecture
+    }
+    if try(config.compute_provider.aws.ec2.binaries_syncer.enabled, false)
+  ])
+
+  resolved_runner_binary_targets_by_key = {
+    for target in local.resolved_runner_binary_targets :
+    "${target.os_type}_${target.architecture}" => target
+  }
+}
+
 module "runner_binaries" {
   source   = "../runner-binaries-syncer"
-  for_each = local.unique_os_and_arch
+  for_each = local.resolved_runner_binary_targets_by_key
   prefix   = "${var.prefix}-${each.value.os_type}-${each.value.architecture}"
   tags     = local.tags
 

--- a/modules/multi-runner/tests/config-effective.tftest.hcl
+++ b/modules/multi-runner/tests/config-effective.tftest.hcl
@@ -208,7 +208,8 @@ run "v2_effective_config_contains_derived_values" {
       && local.effective_config.multi_runner_config["lane"].orchestration_provider.webhook.lambda.artifact.zip == "global-webhook.zip"
       && local.effective_config.multi_runner_config["lane"].orchestration_provider.webhook.queue.kms_key_id == "kms-global-queue"
       && local.effective_config.multi_runner_config["lane"].ssm.kms_key_id == "kms-global-ssm"
+      && toset(keys(local.resolved_runner_binary_targets_by_key)) == toset(["linux_x64"])
     )
-    error_message = "The effective v2 configuration must contain global values and derived labels."
+    error_message = "The effective v2 configuration must contain global values, derived labels, and the resolved runner-binary target map."
   }
 }

--- a/modules/multi-runner/tests/config-effective.tftest.hcl
+++ b/modules/multi-runner/tests/config-effective.tftest.hcl
@@ -164,6 +164,13 @@ run "v2_effective_config_contains_derived_values" {
         ec2 = {
           runner_binaries = {
             enabled = true
+            syncer = {
+              artifact = {
+                s3 = {
+                  key = "runner-binaries-syncer.zip"
+                }
+              }
+            }
           }
         }
       }

--- a/modules/multi-runner/tests/config-translation.tftest.hcl
+++ b/modules/multi-runner/tests/config-translation.tftest.hcl
@@ -414,6 +414,16 @@ run "v2_entry_without_matcher_config_is_authoritative" {
   variables {
     experimental_features = ["multi-runner-v2"]
 
+    global_config_compute_provider = {
+      aws = {
+        ec2 = {
+          runner_binaries = {
+            enabled = false
+          }
+        }
+      }
+    }
+
     multi_runner_config = {
       no_matcher = {
         runner = {


### PR DESCRIPTION
## Description

- Derive runner-binary targets from the resolved multi-runner configuration.
- Break the binary-discovery configuration cycle by keeping discovery inputs independent from generated resources.
- Add effective-config coverage for the resolved binary artifact and preserve the v1-to-v2 translation boundary.

## Test Plan

- `terraform validate` in `modules/multi-runner`
- `terraform test` in `modules/multi-runner`
- `git diff --check` and rebase `range-diff` verification

## Related Issues

Depends on #5284.
